### PR TITLE
Optimize only once per submap in 2D.

### DIFF
--- a/configuration_files/sparse_pose_graph.lua
+++ b/configuration_files/sparse_pose_graph.lua
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 SPARSE_POSE_GRAPH = {
-  optimize_every_n_scans = 45,
+  optimize_every_n_scans = 90,
   also_match_to_new_submaps = true,
   constraint_builder = {
     sampling_ratio = 0.3,


### PR DESCRIPTION
The setting was unintentionally set to optimize twice per submap which
harms parallelism.