### PR TITLE
Remove covariance computation from branch-and-bound.

### DIFF
--- a/cartographer/mapping_2d/scan_matching/CMakeLists.txt
+++ b/cartographer/mapping_2d/scan_matching/CMakeLists.txt
@@ -58,7 +58,6 @@ google_library(mapping_2d_scan_matching_fast_correlative_scan_matcher
   DEPENDS
     common_math
     common_port
-    kalman_filter_pose_tracker
     mapping_2d_probability_grid
     mapping_2d_scan_matching_correlative_scan_matcher
     mapping_2d_scan_matching_proto_fast_correlative_scan_matcher_options
@@ -74,7 +73,6 @@ google_library(mapping_2d_scan_matching_fast_global_localizer
   HDRS
     fast_global_localizer.h
   DEPENDS
-    kalman_filter_pose_tracker
     mapping_2d_scan_matching_fast_correlative_scan_matcher
     sensor_voxel_filter
 )

--- a/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher.h
+++ b/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher.h
@@ -30,7 +30,6 @@
 
 #include "Eigen/Core"
 #include "cartographer/common/port.h"
-#include "cartographer/kalman_filter/pose_tracker.h"
 #include "cartographer/mapping_2d/probability_grid.h"
 #include "cartographer/mapping_2d/scan_matching/correlative_scan_matcher.h"
 #include "cartographer/mapping_2d/scan_matching/proto/fast_correlative_scan_matcher_options.pb.h"
@@ -109,20 +108,18 @@ class FastCorrelativeScanMatcher {
 
   // Aligns 'point_cloud' within the 'probability_grid' given an
   // 'initial_pose_estimate'. If a score above 'min_score' (excluding equality)
-  // is possible, true is returned, and 'score', 'pose_estimate' and
-  // 'covariance' are updated with the result.
+  // is possible, true is returned, and 'score' and 'pose_estimate' are updated
+  // with the result.
   bool Match(const transform::Rigid2d& initial_pose_estimate,
              const sensor::PointCloud2D& point_cloud, float min_score,
-             float* score, transform::Rigid2d* pose_estimate,
-             kalman_filter::Pose2DCovariance* covariance) const;
+             float* score, transform::Rigid2d* pose_estimate) const;
 
   // Aligns 'point_cloud' within the full 'probability_grid', i.e., not
   // restricted to the configured search window. If a score above 'min_score'
-  // (excluding equality) is possible, true is returned, and 'score',
-  // 'pose_estimate' and 'covariance' are updated with the result.
+  // (excluding equality) is possible, true is returned, and 'score' and
+  // 'pose_estimate' are updated with the result.
   bool MatchFullSubmap(const sensor::PointCloud2D& point_cloud, float min_score,
-                       float* score, transform::Rigid2d* pose_estimate,
-                       kalman_filter::Pose2DCovariance* covariance) const;
+                       float* score, transform::Rigid2d* pose_estimate) const;
 
  private:
   // The actual implementation of the scan matcher, called by Match() and
@@ -132,8 +129,7 @@ class FastCorrelativeScanMatcher {
       SearchParameters search_parameters,
       const transform::Rigid2d& initial_pose_estimate,
       const sensor::PointCloud2D& point_cloud, float min_score, float* score,
-      transform::Rigid2d* pose_estimate,
-      kalman_filter::Pose2DCovariance* covariance) const;
+      transform::Rigid2d* pose_estimate) const;
   std::vector<Candidate> ComputeLowestResolutionCandidates(
       const std::vector<DiscreteScan>& discrete_scans,
       const SearchParameters& search_parameters) const;
@@ -146,9 +142,7 @@ class FastCorrelativeScanMatcher {
   Candidate BranchAndBound(const std::vector<DiscreteScan>& discrete_scans,
                            const SearchParameters& search_parameters,
                            const std::vector<Candidate>& candidates,
-                           int candidate_depth, float min_score,
-                           Eigen::Matrix3d* K, Eigen::Vector3d* u,
-                           double* s) const;
+                           int candidate_depth, float min_score) const;
 
   const proto::FastCorrelativeScanMatcherOptions options_;
   MapLimits limits_;

--- a/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher_test.cc
+++ b/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher_test.cc
@@ -111,7 +111,6 @@ CreateFastCorrelativeScanMatcherTestOptions(const int branch_and_bound_depth) {
       return {
          linear_search_window = 3.,
          angular_search_window = 1.,
-         covariance_scale = 1.,
          branch_and_bound_depth = )text" +
                              std::to_string(branch_and_bound_depth) + "}");
   return CreateFastCorrelativeScanMatcherOptions(parameter_dictionary.get());
@@ -159,11 +158,10 @@ TEST(FastCorrelativeScanMatcherTest, CorrectPose) {
     FastCorrelativeScanMatcher fast_correlative_scan_matcher(probability_grid,
                                                              options);
     transform::Rigid2d pose_estimate;
-    kalman_filter::Pose2DCovariance unused_covariance;
     float score;
     EXPECT_TRUE(fast_correlative_scan_matcher.Match(
         transform::Rigid2d::Identity(), point_cloud, kMinScore, &score,
-        &pose_estimate, &unused_covariance));
+        &pose_estimate));
     EXPECT_LT(kMinScore, score);
     EXPECT_THAT(expected_pose,
                 transform::IsNearly(pose_estimate.cast<float>(), 0.03f))
@@ -211,10 +209,9 @@ TEST(FastCorrelativeScanMatcherTest, FullSubmapMatching) {
     FastCorrelativeScanMatcher fast_correlative_scan_matcher(probability_grid,
                                                              options);
     transform::Rigid2d pose_estimate;
-    kalman_filter::Pose2DCovariance unused_covariance;
     float score;
     EXPECT_TRUE(fast_correlative_scan_matcher.MatchFullSubmap(
-        point_cloud, kMinScore, &score, &pose_estimate, &unused_covariance));
+        point_cloud, kMinScore, &score, &pose_estimate));
     EXPECT_LT(kMinScore, score);
     EXPECT_THAT(expected_pose,
                 transform::IsNearly(pose_estimate.cast<float>(), 0.03f))

--- a/cartographer/mapping_2d/scan_matching/fast_global_localizer.cc
+++ b/cartographer/mapping_2d/scan_matching/fast_global_localizer.cc
@@ -16,7 +16,6 @@
 
 #include "cartographer/mapping_2d/scan_matching/fast_global_localizer.h"
 
-#include "cartographer/kalman_filter/pose_tracker.h"
 #include "glog/logging.h"
 
 namespace cartographer {
@@ -36,7 +35,6 @@ bool PerformGlobalLocalization(
   CHECK(best_score != nullptr) << "Need a non-null best_score!";
   *best_score = cutoff;
   transform::Rigid2d pose_estimate;
-  kalman_filter::Pose2DCovariance best_pose_estimate_covariance;
   const sensor::PointCloud2D filtered_point_cloud =
       voxel_filter.Filter(point_cloud);
   bool success = false;
@@ -47,13 +45,11 @@ bool PerformGlobalLocalization(
   for (auto& matcher : matchers) {
     float score = -1;
     transform::Rigid2d pose_estimate;
-    kalman_filter::Pose2DCovariance pose_estimate_covariance;
     if (matcher->MatchFullSubmap(filtered_point_cloud, *best_score, &score,
-                                 &pose_estimate, &pose_estimate_covariance)) {
+                                 &pose_estimate)) {
       CHECK_GT(score, *best_score) << "MatchFullSubmap lied!";
       *best_score = score;
       *best_pose_estimate = pose_estimate;
-      best_pose_estimate_covariance = pose_estimate_covariance;
       success = true;
     }
   }

--- a/cartographer/mapping_2d/scan_matching/proto/fast_correlative_scan_matcher_options.proto
+++ b/cartographer/mapping_2d/scan_matching/proto/fast_correlative_scan_matcher_options.proto
@@ -27,7 +27,4 @@ message FastCorrelativeScanMatcherOptions {
 
   // Number of precomputed grids to use.
   optional int32 branch_and_bound_depth = 2;
-
-  // Covariance estimate is multiplied by this scale.
-  optional double covariance_scale = 5;
 };

--- a/cartographer/mapping_2d/sparse_pose_graph_test.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph_test.cc
@@ -85,7 +85,6 @@ class SparsePoseGraphTest : public ::testing::Test {
                 linear_search_window = 3.,
                 angular_search_window = 0.1,
                 branch_and_bound_depth = 3,
-                covariance_scale = 1.,
               },
               ceres_scan_matcher = {
                 occupied_space_cost_functor_weight = 20.,

--- a/cartographer/mapping_3d/sparse_pose_graph/constraint_builder.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph/constraint_builder.cc
@@ -237,9 +237,7 @@ void ConstraintBuilder::ComputeConstraint(
 
   // Use the CSM estimate as both the initial and previous pose. This has the
   // effect that, in the absence of better information, we prefer the original
-  // CSM estimate. We also prefer to use the CSM covariance estimate for loop
-  // closure constraints since it is representative of a larger area (as opposed
-  // to the local Ceres estimate of covariance).
+  // CSM estimate.
   ceres::Solver::Summary unused_summary;
   kalman_filter::PoseCovariance covariance;
   ceres_scan_matcher_.Match(

--- a/configuration_files/sparse_pose_graph.lua
+++ b/configuration_files/sparse_pose_graph.lua
@@ -31,13 +31,12 @@ SPARSE_POSE_GRAPH = {
       linear_search_window = 7.,
       angular_search_window = math.rad(30.),
       branch_and_bound_depth = 7,
-      covariance_scale = 1e-6,
     },
     ceres_scan_matcher = {
       occupied_space_cost_functor_weight = 20.,
       previous_pose_translation_delta_cost_functor_weight = 10.,
       initial_pose_estimate_rotation_delta_cost_functor_weight = 1.,
-      covariance_scale = 1e-6,
+      covariance_scale = 1e-4,
       ceres_solver_options = {
         use_nonmonotonic_steps = true,
         max_num_iterations = 10,
@@ -67,7 +66,7 @@ SPARSE_POSE_GRAPH = {
     },
   },
   optimization_problem = {
-    huber_scale = 5e2,
+    huber_scale = 1e1,
     acceleration_scale = 7e4,
     rotation_scale = 3e6,
     consecutive_scan_translation_penalty_factor = 1e5,


### PR DESCRIPTION
These covariances were only used in 2D and are only an estimate.
Following 3D, we change 2D to use the (local) covariance computed
using Ceres.