### PR TITLE
Remove the 'also_match_to_new_submaps' option.

### DIFF
--- a/cartographer/mapping/proto/sparse_pose_graph_options.proto
+++ b/cartographer/mapping/proto/sparse_pose_graph_options.proto
@@ -24,9 +24,6 @@ message SparsePoseGraphOptions {
   // is built.
   optional int32 optimize_every_n_scans = 1;
 
-  // If true, constraints between old scans and new submaps will be computed.
-  optional bool also_match_to_new_submaps = 2;
-
   // Options for the constraint builder.
   optional mapping.sparse_pose_graph.proto.ConstraintBuilderOptions
       constraint_builder_options = 3;

--- a/cartographer/mapping/sparse_pose_graph.cc
+++ b/cartographer/mapping/sparse_pose_graph.cc
@@ -45,8 +45,6 @@ proto::SparsePoseGraphOptions CreateSparsePoseGraphOptions(
   proto::SparsePoseGraphOptions options;
   options.set_optimize_every_n_scans(
       parameter_dictionary->GetInt("optimize_every_n_scans"));
-  options.set_also_match_to_new_submaps(
-      parameter_dictionary->GetBool("also_match_to_new_submaps"));
   *options.mutable_constraint_builder_options() =
       sparse_pose_graph::CreateConstraintBuilderOptions(
           parameter_dictionary->GetDictionary("constraint_builder").get());

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -226,11 +226,9 @@ void SparsePoseGraph::ComputeConstraintsForScan(
     const int finished_submap_index = GetSubmapIndex(finished_submap);
     SubmapState& finished_submap_state = submap_states_[finished_submap_index];
     CHECK(!finished_submap_state.finished);
-    if (options_.also_match_to_new_submaps()) {
-      // We have a new completed submap, so we look into adding constraints for
-      // old scans.
-      ComputeConstraintsForOldScans(finished_submap);
-    }
+    // We have a new completed submap, so we look into adding constraints for
+    // old scans.
+    ComputeConstraintsForOldScans(finished_submap);
     finished_submap_state.finished = true;
   }
   constraint_builder_.NotifyEndOfScan(scan_index);

--- a/cartographer/mapping_2d/sparse_pose_graph_test.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph_test.cc
@@ -68,7 +68,6 @@ class SparsePoseGraphTest : public ::testing::Test {
       auto parameter_dictionary = common::MakeDictionary(R"text(
           return {
             optimize_every_n_scans = 1000,
-            also_match_to_new_submaps = true,
             constraint_builder = {
               sampling_ratio = 1.,
               max_constraint_distance = 6.,

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -234,11 +234,9 @@ void SparsePoseGraph::ComputeConstraintsForScan(
     const int finished_submap_index = GetSubmapIndex(finished_submap);
     SubmapState& finished_submap_state = submap_states_[finished_submap_index];
     CHECK(!finished_submap_state.finished);
-    if (options_.also_match_to_new_submaps()) {
-      // We have a new completed submap, so we look into adding constraints for
-      // old scans.
-      ComputeConstraintsForOldScans(finished_submap);
-    }
+    // We have a new completed submap, so we look into adding constraints for
+    // old scans.
+    ComputeConstraintsForOldScans(finished_submap);
     finished_submap_state.finished = true;
   }
   constraint_builder_.NotifyEndOfScan(scan_index);

--- a/configuration_files/sparse_pose_graph.lua
+++ b/configuration_files/sparse_pose_graph.lua
@@ -14,7 +14,6 @@
 
 SPARSE_POSE_GRAPH = {
   optimize_every_n_scans = 90,
-  also_match_to_new_submaps = true,
   constraint_builder = {
     sampling_ratio = 0.3,
     max_constraint_distance = 15.,


### PR DESCRIPTION
Instead, using a different constraint_builder.sampling_ratio is preferred.