### PR TITLE
fix #34: add Eigen::aligned_allocator to many necceary places

### DIFF
--- a/cartographer/kalman_filter/unscented_kalman_filter.h
+++ b/cartographer/kalman_filter/unscented_kalman_filter.h
@@ -25,7 +25,6 @@
 #include "Eigen/Cholesky"
 #include "Eigen/Core"
 #include "Eigen/Eigenvalues"
-#include "Eigen/StdVector"
 #include "cartographer/kalman_filter/gaussian_distribution.h"
 #include "glog/logging.h"
 

--- a/cartographer/kalman_filter/unscented_kalman_filter.h
+++ b/cartographer/kalman_filter/unscented_kalman_filter.h
@@ -25,6 +25,7 @@
 #include "Eigen/Cholesky"
 #include "Eigen/Core"
 #include "Eigen/Eigenvalues"
+#include "Eigen/StdVector"
 #include "cartographer/kalman_filter/gaussian_distribution.h"
 #include "glog/logging.h"
 
@@ -158,7 +159,7 @@ class UnscentedKalmanFilter {
     W.reserve(2 * N + 1);
     W.emplace_back(StateType::Zero());
 
-    std::vector<Eigen::Matrix<FloatType, K, 1>> Z;
+    std::vector<Eigen::Matrix<FloatType, K, 1>, Eigen::aligned_allocator<Eigen::Matrix<FloatType, K, 1>>> Z;
     Z.reserve(2 * N + 1);
     Z.emplace_back(h(mu));
 

--- a/cartographer/mapping_2d/ray_casting.cc
+++ b/cartographer/mapping_2d/ray_casting.cc
@@ -15,7 +15,6 @@
  */
 
 #include "cartographer/mapping_2d/ray_casting.h"
-#include "Eigen/StdVector"
 
 namespace cartographer {
 namespace mapping_2d {

--- a/cartographer/mapping_2d/ray_casting.cc
+++ b/cartographer/mapping_2d/ray_casting.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/mapping_2d/ray_casting.h"
+#include "Eigen/StdVector"
 
 namespace cartographer {
 namespace mapping_2d {
@@ -160,7 +161,7 @@ void CastRays(const sensor::LaserFan& laser_fan, const MapLimits& limits,
                                                          laser_fan.origin.y());
 
   // Compute and add the end points.
-  std::vector<Eigen::Array2i> ends;
+  std::vector<Eigen::Array2i, Eigen::aligned_allocator<Eigen::Array2i>> ends;
   ends.reserve(laser_fan.point_cloud.size());
   for (const Eigen::Vector2f& laser_return : laser_fan.point_cloud) {
     ends.push_back(superscaled_limits.GetXYIndexOfCellContainingPoint(

--- a/cartographer/mapping_2d/scan_matching/correlative_scan_matcher.h
+++ b/cartographer/mapping_2d/scan_matching/correlative_scan_matcher.h
@@ -20,7 +20,6 @@
 #include <vector>
 
 #include "Eigen/Core"
-#include "Eigen/StdVector"
 #include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer/mapping_2d/map_limits.h"
 #include "cartographer/mapping_2d/xy_index.h"

--- a/cartographer/mapping_2d/scan_matching/correlative_scan_matcher.h
+++ b/cartographer/mapping_2d/scan_matching/correlative_scan_matcher.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "Eigen/Core"
+#include "Eigen/StdVector"
 #include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer/mapping_2d/map_limits.h"
 #include "cartographer/mapping_2d/xy_index.h"
@@ -29,7 +30,7 @@ namespace cartographer {
 namespace mapping_2d {
 namespace scan_matching {
 
-typedef std::vector<Eigen::Array2i> DiscreteScan;
+typedef std::vector<Eigen::Array2i, Eigen::aligned_allocator<Eigen::Array2i>> DiscreteScan;
 
 // Describes the search space.
 struct SearchParameters {

--- a/cartographer/mapping_3d/kalman_local_trajectory_builder_test.cc
+++ b/cartographer/mapping_3d/kalman_local_trajectory_builder_test.cc
@@ -20,6 +20,7 @@
 #include <random>
 
 #include "Eigen/Core"
+#include "Eigen/StdVector"
 #include "cartographer/common/lua_parameter_dictionary_test_helpers.h"
 #include "cartographer/common/time.h"
 #include "cartographer/mapping_3d/hybrid_grid.h"
@@ -267,7 +268,7 @@ class KalmanLocalTrajectoryBuilderTest : public ::testing::Test {
   }
 
   std::unique_ptr<KalmanLocalTrajectoryBuilder> local_trajectory_builder_;
-  std::vector<Eigen::Vector3f> bubbles_;
+  std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> bubbles_;
 };
 
 TEST_F(KalmanLocalTrajectoryBuilderTest,

--- a/cartographer/mapping_3d/kalman_local_trajectory_builder_test.cc
+++ b/cartographer/mapping_3d/kalman_local_trajectory_builder_test.cc
@@ -20,7 +20,6 @@
 #include <random>
 
 #include "Eigen/Core"
-#include "Eigen/StdVector"
 #include "cartographer/common/lua_parameter_dictionary_test_helpers.h"
 #include "cartographer/common/time.h"
 #include "cartographer/mapping_3d/hybrid_grid.h"

--- a/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher.cc
+++ b/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher.cc
@@ -22,7 +22,6 @@
 #include <limits>
 
 #include "Eigen/Geometry"
-#include "Eigen/StdVector"
 #include "cartographer/common/make_unique.h"
 #include "cartographer/common/math.h"
 #include "cartographer/mapping_3d/scan_matching/precomputation_grid.h"

--- a/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher.cc
+++ b/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher.cc
@@ -22,6 +22,7 @@
 #include <limits>
 
 #include "Eigen/Geometry"
+#include "Eigen/StdVector"
 #include "cartographer/common/make_unique.h"
 #include "cartographer/common/math.h"
 #include "cartographer/mapping_3d/scan_matching/precomputation_grid.h"
@@ -143,9 +144,9 @@ bool FastCorrelativeScanMatcher::Match(
 DiscreteScan FastCorrelativeScanMatcher::DiscretizeScan(
     const sensor::PointCloud& point_cloud,
     const transform::Rigid3f& pose) const {
-  std::vector<std::vector<Eigen::Array3i>> cell_indices_per_depth;
+  std::vector<std::vector<Eigen::Array3i, Eigen::aligned_allocator<Eigen::Array3i>>> cell_indices_per_depth;
   const PrecomputationGrid& original_grid = precomputation_grid_stack_->Get(0);
-  std::vector<Eigen::Array3i> full_resolution_cell_indices;
+  std::vector<Eigen::Array3i, Eigen::aligned_allocator<Eigen::Array3i>> full_resolution_cell_indices;
   for (const Eigen::Vector3f& point :
        sensor::TransformPointCloud(point_cloud, pose)) {
     full_resolution_cell_indices.push_back(original_grid.GetCellIndex(point));

--- a/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher.h
+++ b/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher.h
@@ -24,7 +24,6 @@
 #include <vector>
 
 #include "Eigen/Core"
-#include "Eigen/StdVector"
 #include "cartographer/common/port.h"
 #include "cartographer/mapping/trajectory_node.h"
 #include "cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher.h"

--- a/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher.h
+++ b/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "Eigen/Core"
+#include "Eigen/StdVector"
 #include "cartographer/common/port.h"
 #include "cartographer/mapping/trajectory_node.h"
 #include "cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher.h"
@@ -45,7 +46,7 @@ class PrecomputationGridStack;
 struct DiscreteScan {
   transform::Rigid3f pose;
   // Contains a vector of discretized scans for each 'depth'.
-  std::vector<std::vector<Eigen::Array3i>> cell_indices_per_depth;
+  std::vector<std::vector<Eigen::Array3i, Eigen::aligned_allocator<Eigen::Array3i>>> cell_indices_per_depth;
 };
 
 struct Candidate {

--- a/cartographer/mapping_3d/submaps.h
+++ b/cartographer/mapping_3d/submaps.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "Eigen/Geometry"
+#include "Eigen/StdVector"
 #include "cartographer/mapping/sparse_pose_graph.h"
 #include "cartographer/mapping/submaps.h"
 #include "cartographer/mapping_2d/laser_fan_inserter.h"
@@ -118,7 +119,7 @@ class Submaps : public mapping::Submaps {
   // The first three entries of this is are a cell_index and the last is the
   // corresponding probability value. We batch them together like this to only
   // have one vector and have better cache locality.
-  std::vector<Eigen::Array4i> voxel_indices_and_probabilities_;
+  std::vector<Eigen::Array4i, Eigen::aligned_allocator<Eigen::Array4i>> voxel_indices_and_probabilities_;
 };
 
 }  // namespace mapping_3d

--- a/cartographer/mapping_3d/submaps.h
+++ b/cartographer/mapping_3d/submaps.h
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include "Eigen/Geometry"
-#include "Eigen/StdVector"
 #include "cartographer/mapping/sparse_pose_graph.h"
 #include "cartographer/mapping/submaps.h"
 #include "cartographer/mapping_2d/laser_fan_inserter.h"

--- a/cartographer/sensor/point_cloud.h
+++ b/cartographer/sensor/point_cloud.h
@@ -20,7 +20,6 @@
 #include <vector>
 
 #include "Eigen/Core"
-#include "Eigen/StdVector"
 #include "Eigen/Geometry"
 #include "cartographer/sensor/proto/sensor.pb.h"
 #include "cartographer/transform/rigid_transform.h"

--- a/cartographer/sensor/point_cloud.h
+++ b/cartographer/sensor/point_cloud.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "Eigen/Core"
+#include "Eigen/StdVector"
 #include "Eigen/Geometry"
 #include "cartographer/sensor/proto/sensor.pb.h"
 #include "cartographer/transform/rigid_transform.h"
@@ -28,8 +29,9 @@
 namespace cartographer {
 namespace sensor {
 
-typedef std::vector<Eigen::Vector3f> PointCloud;
-typedef std::vector<Eigen::Vector2f> PointCloud2D;
+
+typedef std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> PointCloud;
+typedef std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f>> PointCloud2D;
 
 // Transforms 'point_cloud' according to 'transform'.
 PointCloud TransformPointCloud(const PointCloud& point_cloud,


### PR DESCRIPTION
Fixes #34 

Only handles those found by found by `grep -r "std::\w*<Eigen"`

builds and passes tests.