### PR TITLE
fix #36: add EIGEN_MAKE_ALIGNED_NEW in many classes

### DIFF
--- a/cartographer/kalman_filter/gaussian_distribution.h
+++ b/cartographer/kalman_filter/gaussian_distribution.h
@@ -38,6 +38,8 @@ class GaussianDistribution {
  private:
   Eigen::Matrix<T, N, 1> mean_;
   Eigen::Matrix<T, N, N> covariance_;
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 template <typename T, int N>

--- a/cartographer/kalman_filter/pose_tracker.h
+++ b/cartographer/kalman_filter/pose_tracker.h
@@ -87,6 +87,8 @@ class ImuTracker {
   Eigen::Quaterniond orientation_;
   Eigen::Vector3d gravity_direction_;
   Eigen::Vector3d imu_angular_velocity_;
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 // A Kalman filter for a 3D state of position and orientation.

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -45,6 +45,7 @@ class SparsePoseGraph {
     struct Pose {
       transform::Rigid2d zbar_ij;
       Eigen::Matrix<double, 3, 3> sqrt_Lambda_ij;
+      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     // Submap index.
@@ -66,6 +67,7 @@ class SparsePoseGraph {
     struct Pose {
       transform::Rigid3d zbar_ij;
       Eigen::Matrix<double, 6, 6> sqrt_Lambda_ij;
+      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     // Submap index.

--- a/cartographer/mapping/submaps.h
+++ b/cartographer/mapping/submaps.h
@@ -89,6 +89,7 @@ struct Submap {
   // change anymore. Otherwise, this is nullptr and the next call to
   // InsertLaserFan() will change the submap.
   const mapping_2d::ProbabilityGrid* finished_probability_grid = nullptr;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 // A container of Submaps.

--- a/cartographer/mapping_2d/map_limits.h
+++ b/cartographer/mapping_2d/map_limits.h
@@ -127,6 +127,8 @@ class MapLimits {
   double resolution_;
   Eigen::Vector2d max_;
   CellLimits cell_limits_;
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 }  // namespace mapping_2d

--- a/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher.h
+++ b/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher.h
@@ -90,6 +90,8 @@ class PrecomputationGrid {
 
   // Probabilites mapped to 0 to 255.
   std::vector<uint8> cells_;
+ public:
+   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 class PrecomputationGridStack;

--- a/cartographer/mapping_2d/xy_index.h
+++ b/cartographer/mapping_2d/xy_index.h
@@ -94,6 +94,8 @@ class XYIndexRangeIterator
   Eigen::Array2i min_xy_index_;
   Eigen::Array2i max_xy_index_;
   Eigen::Array2i xy_index_;
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 }  // namespace mapping_2d

--- a/cartographer/mapping_3d/acceleration_cost_function.h
+++ b/cartographer/mapping_3d/acceleration_cost_function.h
@@ -74,6 +74,8 @@ class AccelerationCostFunction {
   const Eigen::Vector3d delta_velocity_imu_frame_;
   const double first_delta_time_seconds_;
   const double second_delta_time_seconds_;
+ public:
+   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 }  // namespace mapping_3d

--- a/cartographer/mapping_3d/hybrid_grid.h
+++ b/cartographer/mapping_3d/hybrid_grid.h
@@ -459,6 +459,8 @@ class HybridGridBase : public Grid<ValueType> {
 
   // Position of the center of the octree.
   const Eigen::Vector3f origin_;
+ public:
+   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 // A grid containing probability values stored using 15 bits, and an update

--- a/cartographer/mapping_3d/imu_integration.h
+++ b/cartographer/mapping_3d/imu_integration.h
@@ -33,12 +33,14 @@ struct ImuData {
   common::Time time;
   Eigen::Vector3d linear_acceleration;
   Eigen::Vector3d angular_velocity;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 template <typename T>
 struct IntegrateImuResult {
   Eigen::Matrix<T, 3, 1> delta_velocity;
   Eigen::Quaternion<T> delta_rotation;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 // Returns velocity delta in map frame.

--- a/cartographer/mapping_3d/rotation_cost_function.h
+++ b/cartographer/mapping_3d/rotation_cost_function.h
@@ -52,6 +52,8 @@ class RotationCostFunction {
  private:
   const double scaling_factor_;
   const Eigen::Quaterniond delta_rotation_imu_frame_;
+ public:
+   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 }  // namespace mapping_3d

--- a/cartographer/mapping_3d/scan_matching/rotational_scan_matcher.h
+++ b/cartographer/mapping_3d/scan_matching/rotational_scan_matcher.h
@@ -45,6 +45,8 @@ class RotationalScanMatcher {
   float MatchHistogram(const Eigen::VectorXf& scan_histogram) const;
 
   Eigen::VectorXf histogram_;
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 }  // namespace scan_matching

--- a/cartographer/sensor/compressed_point_cloud.h
+++ b/cartographer/sensor/compressed_point_cloud.h
@@ -89,6 +89,8 @@ class CompressedPointCloud::ConstIterator
   Eigen::Vector3f current_point_;
   Eigen::Vector3i current_block_coordinates_;
   std::vector<int32>::const_iterator input_;
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 }  // namespace sensor

--- a/cartographer/sensor/laser.h
+++ b/cartographer/sensor/laser.h
@@ -33,6 +33,7 @@ struct LaserFan {
   Eigen::Vector2f origin;
   PointCloud2D point_cloud;
   PointCloud2D missing_echo_point_cloud;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 LaserFan ToLaserFan(const proto::LaserScan& proto, float min_range,
                     float max_range, float missing_echo_ray_length);
@@ -52,6 +53,7 @@ struct LaserFan3D {
 
   // Reflectivity value of returns.
   std::vector<uint8> reflectivities;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 // Like LaserFan3D but with compressed point clouds. The point order changes
@@ -63,6 +65,7 @@ struct CompressedLaserFan3D {
 
   // Reflectivity value of returns.
   std::vector<uint8> reflectivities;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 LaserFan3D Decompress(const CompressedLaserFan3D& compressed_laser_fan);

--- a/cartographer/transform/rigid_transform.h
+++ b/cartographer/transform/rigid_transform.h
@@ -94,6 +94,8 @@ class Rigid2 {
  private:
   Vector translation_;
   Rotation2D rotation_;
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 template <typename FloatType>
@@ -194,6 +196,8 @@ class Rigid3 {
  private:
   Vector translation_;
   Quaternion rotation_;
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 template <typename FloatType>


### PR DESCRIPTION
fix #36 add EIGEN_MAKE_ALIGNED_NEW in all places found by `find ./ -name "*.h*" | xargs grep --color "^[^(]*Eigen::[^(&={]*$"`

Probably not exhaustive

Builds and passes all tests.

Will likely have CLA approved by 2016-10-07