### PR TITLE
Prepare CMake files for testing support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,8 @@ set(CARTOGRAPHER_VERSION ${CARTOGRAPHER_MAJOR_VERSION}.${CARTOGRAPHER_MINOR_VERS
 set(CARTOGRAPHER_SOVERSION ${CARTOGRAPHER_MAJOR_VERSION}.${CARTOGRAPHER_MINOR_VERSION})
 
 include("${CMAKE_SOURCE_DIR}/cmake/functions.cmake")
-google_initialize_cartographer_project(True)
+google_initialize_cartographer_project()
+google_enable_testing()
 
 find_package(Boost REQUIRED COMPONENTS system iostreams)
 find_package(Ceres REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CARTOGRAPHER_VERSION ${CARTOGRAPHER_MAJOR_VERSION}.${CARTOGRAPHER_MINOR_VERS
 set(CARTOGRAPHER_SOVERSION ${CARTOGRAPHER_MAJOR_VERSION}.${CARTOGRAPHER_MINOR_VERSION})
 
 include("${CMAKE_SOURCE_DIR}/cmake/functions.cmake")
-google_initialize_cartographer_project()
+google_initialize_cartographer_project(True)
 
 find_package(Boost REQUIRED COMPONENTS system iostreams)
 find_package(Ceres REQUIRED)
@@ -35,8 +35,6 @@ find_package(Sphinx)
 if(SPHINX_FOUND)
   add_subdirectory("docs")
 endif()
-
-enable_testing()
 
 SET(ALL_LIBRARIES "" CACHE INTERNAL "ALL_LIBRARIES")
 

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -325,7 +325,7 @@ function(google_proto_library NAME)
   target_link_libraries("${NAME}" ${PROTOBUF_LIBRARY} pthread)
 endfunction()
 
-macro(google_initialize_cartographer_project ENABLE_TESTING)
+macro(google_initialize_cartographer_project)
   SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
   set(GOOG_CXX_FLAGS "-pthread -std=c++11 ${GOOG_CXX_FLAGS}")
 
@@ -354,9 +354,10 @@ macro(google_initialize_cartographer_project ENABLE_TESTING)
 
   message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
-  if (${ENABLE_TESTING})
-    set(GMOCK_SRC_DIR "/usr/src/gmock" CACHE STRING "Path to google-mock sources.")
-    add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
-    enable_testing()
-  endif()
+endmacro()
+
+macro(google_enable_testing)
+  set(GMOCK_SRC_DIR "/usr/src/gmock" CACHE STRING "Path to google-mock sources.")
+  add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
+  enable_testing()
 endmacro()

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -218,20 +218,39 @@ function(google_add_flag VAR_NAME FLAG)
   endif()
 endfunction()
 
-function(google_test NAME)
-  _parse_arguments("${ARGN}")
-
+macro(_common_test_stuff)
   add_executable(${NAME}
     ${ARG_SRCS} ${ARG_HDRS}
   )
-
   _common_compile_stuff("PRIVATE")
 
   # Make sure that gmock always includes the correct gtest/gtest.h.
   target_include_directories("${NAME}" SYSTEM PRIVATE
     "${GMOCK_SRC_DIR}/gtest/include")
   target_link_libraries("${NAME}" gmock_main)
+endmacro()
 
+function(google_catkin_test NAME)
+  if(NOT "${CATKIN_ENABLE_TESTING}")
+    return()
+  endif()
+
+  _parse_arguments("${ARGN}")
+  _common_test_stuff()
+
+  # Copied from the catkin sources. Tracked in ros/catkin:#830.
+  add_dependencies(tests ${NAME})
+  get_target_property(_target_path ${NAME} RUNTIME_OUTPUT_DIRECTORY)
+  set(cmd "${_target_path}/${NAME} --gtest_output=xml:${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}/gtest-${NAME}.xml")
+  catkin_run_tests_target("gtest" ${NAME} "gtest-${NAME}.xml"
+    COMMAND ${cmd}
+    DEPENDENCIES ${NAME}
+    WORKING_DIRECTORY ${ARG_WORKING_DIRECTORY})
+endfunction()
+
+function(google_test NAME)
+  _parse_arguments("${ARGN}")
+  _common_test_stuff()
   add_test(${NAME} ${NAME})
 endfunction()
 
@@ -306,7 +325,7 @@ function(google_proto_library NAME)
   target_link_libraries("${NAME}" ${PROTOBUF_LIBRARY} pthread)
 endfunction()
 
-macro(google_initialize_cartographer_project)
+macro(google_initialize_cartographer_project ENABLE_TESTING)
   SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
   set(GOOG_CXX_FLAGS "-pthread -std=c++11 ${GOOG_CXX_FLAGS}")
 
@@ -335,6 +354,9 @@ macro(google_initialize_cartographer_project)
 
   message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
-  set(GMOCK_SRC_DIR "/usr/src/gmock" CACHE STRING "Path to google-mock sources.")
-  add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
+  if (${ENABLE_TESTING})
+    set(GMOCK_SRC_DIR "/usr/src/gmock" CACHE STRING "Path to google-mock sources.")
+    add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
+    enable_testing()
+  endif()
 endmacro()


### PR DESCRIPTION
- Only build gmock if we really require testing.
- Adds a wrapper for generating catkin aware tests. This works around
  ros/catkin:830.