### PR TITLE
Add missing include

### DIFF
--- a/cartographer/io/points_batch.h
+++ b/cartographer/io/points_batch.h
@@ -18,6 +18,7 @@
 #define CARTOGRAPHER_IO_POINTS_BATCH_H_
 
 #include <cstdint>
+#include <vector>
 
 #include "Eigen/Core"
 #include "cartographer/common/time.h"


### PR DESCRIPTION
Including <vector> on cartographer/io/points_batch.h is mandatory.
This issue happened on g++ 6.2.1 with glibcxx 3.4.22.