### PR TITLE
Make all 'PointProcessor's registerable with the PipelineBuilder.

### DIFF
--- a/cartographer/io/CMakeLists.txt
+++ b/cartographer/io/CMakeLists.txt
@@ -10,6 +10,8 @@ google_library(io_min_max_range_filtering_points_processor
   HDRS
     min_max_range_filtering_points_processor.h
   DEPENDS
+    common_lua_parameter_dictionary
+    common_make_unique
     io_points_batch
     io_points_processor
 )
@@ -21,6 +23,19 @@ google_library(io_null_points_processor
     io_points_processor
 )
 
+google_library(io_pcd_writing_points_processor
+  USES_GLOG
+  SRCS
+    pcd_writing_points_processor.cc
+  HDRS
+    pcd_writing_points_processor.h
+  DEPENDS
+    common_lua_parameter_dictionary
+    common_make_unique
+    io_points_batch
+    io_points_processor
+)
+
 google_library(io_ply_writing_points_processor
   USES_GLOG
   SRCS
@@ -28,6 +43,9 @@ google_library(io_ply_writing_points_processor
   HDRS
     ply_writing_points_processor.h
   DEPENDS
+    common_lua_parameter_dictionary
+    common_make_unique
+    io_points_batch
     io_points_processor
 )
 
@@ -56,8 +74,13 @@ google_library(io_points_processor_pipeline_builder
   DEPENDS
     common_lua_parameter_dictionary
     common_make_unique
+    io_min_max_range_filtering_points_processor
     io_null_points_processor
+    io_pcd_writing_points_processor
+    io_ply_writing_points_processor
     io_points_processor
+    io_xray_points_processor
+    io_xyz_writing_points_processor
 )
 
 google_library(io_xray_points_processor
@@ -87,17 +110,4 @@ google_library(io_xyz_writing_points_processor
     common_lua_parameter_dictionary
     common_make_unique
     io_points_processor
-)
-
-google_library(io_pcd_points_processor
-  USES_EIGEN
-  SRCS
-    pcd_writing_points_processor.cc
-  HDRS
-    pcd_writing_points_processor.h
-  DEPENDS
-    common_math
-    io_points_processor
-    mapping_3d_hybrid_grid
-    transform_rigid_transform
 )

--- a/cartographer/io/min_max_range_filtering_points_processor.cc
+++ b/cartographer/io/min_max_range_filtering_points_processor.cc
@@ -16,10 +16,21 @@
 
 #include "cartographer/io/min_max_range_filtering_points_processor.h"
 
+#include "cartographer/common/lua_parameter_dictionary.h"
+#include "cartographer/common/make_unique.h"
 #include "cartographer/io/points_batch.h"
 
 namespace cartographer {
 namespace io {
+
+std::unique_ptr<MinMaxRangeFiteringPointsProcessor>
+MinMaxRangeFiteringPointsProcessor::FromDictionary(
+    common::LuaParameterDictionary* const dictionary,
+    PointsProcessor* const next) {
+  return common::make_unique<MinMaxRangeFiteringPointsProcessor>(
+      dictionary->GetDouble("min_range"), dictionary->GetDouble("max_range"),
+      next);
+}
 
 MinMaxRangeFiteringPointsProcessor::MinMaxRangeFiteringPointsProcessor(
     const double min_range, const double max_range, PointsProcessor* next)

--- a/cartographer/io/min_max_range_filtering_points_processor.h
+++ b/cartographer/io/min_max_range_filtering_points_processor.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 
+#include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer/io/points_processor.h"
 
 namespace cartographer {
@@ -28,8 +29,13 @@ namespace io {
 // or closer than 'min_range'.
 class MinMaxRangeFiteringPointsProcessor : public PointsProcessor {
  public:
+  constexpr static const char* kConfigurationFileActionName =
+      "min_max_range_filter";
   MinMaxRangeFiteringPointsProcessor(double min_range, double max_range,
                                      PointsProcessor* next);
+  static std::unique_ptr<MinMaxRangeFiteringPointsProcessor> FromDictionary(
+      common::LuaParameterDictionary* dictionary, PointsProcessor* next);
+
   ~MinMaxRangeFiteringPointsProcessor() override {}
 
   MinMaxRangeFiteringPointsProcessor(

--- a/cartographer/io/pcd_writing_points_processor.h
+++ b/cartographer/io/pcd_writing_points_processor.h
@@ -16,6 +16,7 @@
 
 #include <fstream>
 
+#include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer/io/points_processor.h"
 
 namespace cartographer {
@@ -24,7 +25,12 @@ namespace io {
 // Streams a PCD file to disk. The header is written in 'Flush'.
 class PcdWritingPointsProcessor : public PointsProcessor {
  public:
+  constexpr static const char* kConfigurationFileActionName = "write_pcd";
   PcdWritingPointsProcessor(const string& filename, PointsProcessor* next);
+
+  static std::unique_ptr<PcdWritingPointsProcessor> FromDictionary(
+      common::LuaParameterDictionary* dictionary, PointsProcessor* next);
+
   ~PcdWritingPointsProcessor() override {}
 
   PcdWritingPointsProcessor(const PcdWritingPointsProcessor&) = delete;

--- a/cartographer/io/ply_writing_points_processor.h
+++ b/cartographer/io/ply_writing_points_processor.h
@@ -16,6 +16,7 @@
 
 #include <fstream>
 
+#include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer/io/points_processor.h"
 
 namespace cartographer {
@@ -24,8 +25,12 @@ namespace io {
 // Streams a PLY file to disk. The header is written in 'Flush'.
 class PlyWritingPointsProcessor : public PointsProcessor {
  public:
+  constexpr static const char* kConfigurationFileActionName = "write_ply";
   PlyWritingPointsProcessor(const string& filename, PointsProcessor* next);
   ~PlyWritingPointsProcessor() override {}
+
+  static std::unique_ptr<PlyWritingPointsProcessor> FromDictionary(
+      common::LuaParameterDictionary* dictionary, PointsProcessor* next);
 
   PlyWritingPointsProcessor(const PlyWritingPointsProcessor&) = delete;
   PlyWritingPointsProcessor& operator=(const PlyWritingPointsProcessor&) =

--- a/cartographer/io/points_processor_pipeline_builder.cc
+++ b/cartographer/io/points_processor_pipeline_builder.cc
@@ -17,12 +17,23 @@
 #include "cartographer/io/points_processor_pipeline_builder.h"
 
 #include "cartographer/common/make_unique.h"
+#include "cartographer/io/min_max_range_filtering_points_processor.h"
 #include "cartographer/io/null_points_processor.h"
+#include "cartographer/io/pcd_writing_points_processor.h"
+#include "cartographer/io/ply_writing_points_processor.h"
+#include "cartographer/io/xray_points_processor.h"
+#include "cartographer/io/xyz_writing_points_processor.h"
 
 namespace cartographer {
 namespace io {
 
-PointsProcessorPipelineBuilder::PointsProcessorPipelineBuilder() {}
+PointsProcessorPipelineBuilder::PointsProcessorPipelineBuilder() {
+  RegisterNonStatic<MinMaxRangeFiteringPointsProcessor>();
+  RegisterNonStatic<PcdWritingPointsProcessor>();
+  RegisterNonStatic<PlyWritingPointsProcessor>();
+  RegisterNonStatic<XRayPointsProcessor>();
+  RegisterNonStatic<XyzWriterPointsProcessor>();
+}
 
 PointsProcessorPipelineBuilder* PointsProcessorPipelineBuilder::instance() {
   static PointsProcessorPipelineBuilder instance;

--- a/cartographer/io/points_processor_pipeline_builder.h
+++ b/cartographer/io/points_processor_pipeline_builder.h
@@ -28,7 +28,8 @@ namespace cartographer {
 namespace io {
 
 // Singleton that knows how to build a points processor pipeline out of a Lua
-// configuration. You can register new classes with this instance that must
+// configuration. All the PointsProcessor shipping with Cartographer are already
+// registered with 'instance', but can register new classes with it that must
 // define its name and a way to build itself out of a LuaParameterDictionary.
 // See the various 'PointsProcessor's for examples.
 class PointsProcessorPipelineBuilder {
@@ -42,12 +43,7 @@ class PointsProcessorPipelineBuilder {
 
   template <typename PointsProcessorType>
   void Register() {
-    instance()->RegisterType(
-        PointsProcessorType::kConfigurationFileActionName,
-        [](common::LuaParameterDictionary* const dictionary,
-           PointsProcessor* const next) -> std::unique_ptr<PointsProcessor> {
-          return PointsProcessorType::FromDictionary(dictionary, next);
-        });
+    instance()->RegisterNonStatic<PointsProcessorType>();
   }
 
   std::vector<std::unique_ptr<PointsProcessor>> CreatePipeline(
@@ -56,6 +52,16 @@ class PointsProcessorPipelineBuilder {
  private:
   using FactoryFunction = std::function<std::unique_ptr<PointsProcessor>(
       common::LuaParameterDictionary*, PointsProcessor* next)>;
+
+  template <typename PointsProcessorType>
+  void RegisterNonStatic() {
+    RegisterType(
+        PointsProcessorType::kConfigurationFileActionName,
+        [](common::LuaParameterDictionary* const dictionary,
+           PointsProcessor* const next) -> std::unique_ptr<PointsProcessor> {
+          return PointsProcessorType::FromDictionary(dictionary, next);
+        });
+  }
 
   PointsProcessorPipelineBuilder();
 


### PR DESCRIPTION
Also the default instance has now knowledge of all of Cartographer's
'PointsProcessor's by default.