### PR TITLE
Supports system-wide installed GMock

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -218,8 +218,8 @@ macro(_common_test_stuff)
 
   # Make sure that gmock always includes the correct gtest/gtest.h.
   target_include_directories("${NAME}" SYSTEM PRIVATE
-    "${GMOCK_SRC_DIR}/gtest/include")
-  target_link_libraries("${NAME}" gmock_main)
+    "${GMOCK_INCLUDE_DIRS}")
+  target_link_libraries("${NAME}" ${GMOCK_LIBRARIES})
 endmacro()
 
 function(google_catkin_test NAME)
@@ -351,7 +351,6 @@ macro(google_initialize_cartographer_project)
 endmacro()
 
 macro(google_enable_testing)
-  set(GMOCK_SRC_DIR "/usr/src/gmock" CACHE STRING "Path to google-mock sources.")
-  add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
   enable_testing()
+  find_package(GMock REQUIRED)
 endmacro()

--- a/cmake/modules/FindGMock.cmake
+++ b/cmake/modules/FindGMock.cmake
@@ -1,0 +1,69 @@
+# Copyright 2016 The Cartographer Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+find_path(GMOCK_INCLUDE_DIRS gmock/gmock.h
+  HINTS
+    ENV GMOCK_DIR
+  PATH_SUFFIXES include
+  PATHS
+    /usr
+)
+
+# Find system-wide installed gmock.
+find_library(GMOCK_LIBRARIES
+  NAMES gmock_main
+  HINTS
+    ENV GMOCK_DIR
+  PATH_SUFFIXES lib
+  PATHS
+    /usr
+)
+
+if(NOT GMOCK_LIBRARIES)
+  # If no system-wide gmock found, then find src version.
+  # Ubuntu might have this.
+  find_path(GMOCK_SRC_DIR gmock/CMakeLists.txt
+    HINTS
+      ENV GMOCK_DIR
+    PATH_SUFFIXES src
+    PATHS
+      /usr
+  )
+  if(GMOCK_SRC_DIR)
+    # If src version found, build it.
+    add_subdirectory(${GMOCK_SRC_DIR}/gmock "${CMAKE_CURRENT_BINARY_DIR}/gmock")
+    set(GMOCK_LIBRARIES gmock_main)
+  endif()
+endif()
+
+# Find gtest header.
+# It is contained in gmock src dir in Ubuntu environment.
+find_path(GTEST_INCLUDE_DIRS gtest/gtest.h
+  HINTS
+    ENV GTEST_DIR
+  PATH_SUFFIXES include
+  PATHS
+    /usr ${GMOCK_SRC_DIR}/gmock/gtest
+)
+list(APPEND GMOCK_INCLUDE_DIRS ${GTEST_INCLUDE_DIRS})
+
+# System-wide installed gmock library might require pthreads.
+find_package(Threads REQUIRED)
+list(APPEND GMOCK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GMock DEFAULT_MSG GMOCK_LIBRARIES
+                                  GMOCK_INCLUDE_DIRS GTEST_INCLUDE_DIRS
+                                  GTEST_INCLUDE_DIRS)
+

--- a/cmake/modules/FindGMock.cmake
+++ b/cmake/modules/FindGMock.cmake
@@ -64,6 +64,5 @@ list(APPEND GMOCK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GMock DEFAULT_MSG GMOCK_LIBRARIES
-                                  GMOCK_INCLUDE_DIRS GTEST_INCLUDE_DIRS
-                                  GTEST_INCLUDE_DIRS)
+                                  GMOCK_INCLUDE_DIRS GTEST_INCLUDE_DIRS)
 


### PR DESCRIPTION
This commit fixes #73.
Tested using docker ubuntu:trusty and native Fedora 24 with gmock 1.8.

This is far from elegant because old gmock environments lack it.
Do you have any elegant way?