### PR TITLE
Compute the common start time per trajectory.

### DIFF
--- a/cartographer/sensor/ordered_multi_queue.h
+++ b/cartographer/sensor/ordered_multi_queue.h
@@ -79,11 +79,12 @@ class OrderedMultiQueue {
   void Dispatch();
   void CannotMakeProgress();
   string EmptyQueuesDebugString();
+  common::Time GetCommonStartTime(int trajectory_id);
 
   // Used to verify that values are dispatched in sorted order.
   common::Time last_dispatched_time_ = common::Time::min();
-  common::Time common_start_time_ = common::Time::min();
 
+  std::map<int, common::Time> common_start_time_per_trajectory_;
   std::map<QueueKey, Queue> queues_;
 };
 

--- a/cartographer/sensor/ordered_multi_queue_test.cc
+++ b/cartographer/sensor/ordered_multi_queue_test.cc
@@ -94,6 +94,23 @@ TEST_F(OrderedMultiQueueTest, MarkQueueAsFinished) {
   }
 }
 
+TEST_F(OrderedMultiQueueTest, CommonStartTimePerTrajectory) {
+  queue_.Add(kFirst, MakeImu(0));
+  queue_.Add(kFirst, MakeImu(1));
+  queue_.Add(kFirst, MakeImu(2));
+  queue_.Add(kFirst, MakeImu(3));
+  queue_.Add(kSecond, MakeImu(2));
+  EXPECT_TRUE(values_.empty());
+  queue_.Add(kThird, MakeImu(4));
+  EXPECT_EQ(values_.size(), 2);
+  queue_.MarkQueueAsFinished(kFirst);
+  EXPECT_EQ(values_.size(), 2);
+  queue_.MarkQueueAsFinished(kSecond);
+  EXPECT_EQ(values_.size(), 4);
+  queue_.MarkQueueAsFinished(kThird);
+  EXPECT_EQ(values_.size(), 4);
+}
+
 }  // namespace
 }  // namespace sensor
 }  // namespace cartographer


### PR DESCRIPTION
In the multi-trajectory case, other trajectories should not influence which
data gets dropped. This is especially the case if all trajectories are
added before any of their data. In this case, data before the start of the
last trajectory was dropped.