### PR TITLE
Determine the trajectory that is blocking progress.

### DIFF
--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -108,6 +108,10 @@ void MapBuilder::FinishTrajectory(const int trajectory_id) {
   sensor_collator_.FinishTrajectory(trajectory_id);
 }
 
+int MapBuilder::GetBlockingTrajectoryId() const {
+  return sensor_collator_.GetBlockingTrajectoryId();
+}
+
 int MapBuilder::GetTrajectoryId(const Submaps* const trajectory) const {
   const auto trajectory_id = trajectory_ids_.find(trajectory);
   CHECK(trajectory_id != trajectory_ids_.end());

--- a/cartographer/mapping/map_builder.h
+++ b/cartographer/mapping/map_builder.h
@@ -67,6 +67,11 @@ class MapBuilder {
   // i.e. no further sensor data is expected.
   void FinishTrajectory(int trajectory_id);
 
+  // Must only be called if at least one unfinished trajectory exists. Returns
+  // the ID of the trajectory that needs more data before the MapBuilder is
+  // unblocked.
+  int GetBlockingTrajectoryId() const;
+
   // Returns the trajectory ID for 'trajectory'.
   int GetTrajectoryId(const mapping::Submaps* trajectory) const;
 

--- a/cartographer/sensor/collator.cc
+++ b/cartographer/sensor/collator.cc
@@ -46,5 +46,9 @@ void Collator::AddSensorData(const int trajectory_id, const string& sensor_id,
 
 void Collator::Flush() { queue_.Flush(); }
 
+int Collator::GetBlockingTrajectoryId() const {
+  return queue_.GetBlocker().trajectory_id;
+}
+
 }  // namespace sensor
 }  // namespace cartographer

--- a/cartographer/sensor/collator.h
+++ b/cartographer/sensor/collator.h
@@ -57,6 +57,11 @@ class Collator {
   // AddSensorData may not be called after Flush.
   void Flush();
 
+  // Must only be called if at least one unfinished trajectory exists. Returns
+  // the ID of the trajectory that needs more data before the Collator is
+  // unblocked.
+  int GetBlockingTrajectoryId() const;
+
  private:
   // Queue keys are a pair of trajectory ID and sensor identifier.
   OrderedMultiQueue queue_;

--- a/cartographer/sensor/ordered_multi_queue.h
+++ b/cartographer/sensor/ordered_multi_queue.h
@@ -69,6 +69,11 @@ class OrderedMultiQueue {
   // queues.
   void Flush();
 
+  // Must only be called if at least one unfinished queue exists. Returns the
+  // key of a queue that needs more data before the OrderedMultiQueue can
+  // dispatch data.
+  QueueKey GetBlocker() const;
+
  private:
   struct Queue {
     common::BlockingQueue<std::unique_ptr<Data>> queue;
@@ -77,8 +82,7 @@ class OrderedMultiQueue {
   };
 
   void Dispatch();
-  void CannotMakeProgress();
-  string EmptyQueuesDebugString();
+  void CannotMakeProgress(const QueueKey& queue_key);
   common::Time GetCommonStartTime(int trajectory_id);
 
   // Used to verify that values are dispatched in sorted order.
@@ -86,6 +90,7 @@ class OrderedMultiQueue {
 
   std::map<int, common::Time> common_start_time_per_trajectory_;
   std::map<QueueKey, Queue> queues_;
+  QueueKey blocker_;
 };
 
 }  // namespace sensor


### PR DESCRIPTION
When processing offline data determining which trajectory needs more
data before processing can continue is surprisingly tricky. We thus
expose this information at the map builder to avoid duplicating this
logic.