### PR TITLE
Add Ceres sparse linear algebra library dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ google_initialize_cartographer_project()
 google_enable_testing()
 
 find_package(Boost REQUIRED COMPONENTS iostreams)
-find_package(Ceres REQUIRED)
+find_package(Ceres REQUIRED COMPONENTS SparseLinearAlgebraLibrary)
 find_package(Eigen3 REQUIRED)
 find_package(LuaGoogle REQUIRED)
 find_package(Protobuf REQUIRED)


### PR DESCRIPTION
Ceres can be built without linking against a sparse linear algebra library
such as SuiteSparse or Eigen-sparse. This can happen if the user does not
have all the dependencies, which normally get installed when following
the Cartographer installation guide. In this case, Cartographer will
work, but without loop closures, because Ceres is not working fast enough
(the loop closure optimization without a sparse linear algebra library
is a few orders of magnitude slower). Another bad side effect of this is
that Cartographer will hang when finalizing the trajectory or on exit,
because all loop closing optimizations will be waiting in a queue which
can take hours to process.

When Ceres is regularly built against a sparse linear algebra library, as it
is supposed to be, it declares a component named SparseLinearAlgebraLibrary.
Because normal functioning of Cartographer seemingly depends on this being
present, it is introduced here in Cartographer as a required Ceres component
dependency.

(original issue at googlecartographer/cartographer_ros#247)