### PR TITLE
math.h NormalizeAngleDifference infinite loop

### DIFF
--- a/cartographer/common/math.h
+++ b/cartographer/common/math.h
@@ -71,7 +71,7 @@ T NormalizeAngleDifference(T difference) {
   // Copy the sign of the value in radians to the value of pi.
   T signed_pi = std::copysign(M_PI,difference);
   // Set the value of difference to the appropriate signed value between pi and -pi.
-  difference = std::fmod(difference + signed_pi,(2 * M_PI)) - signedPI;
+  difference = std::fmod(difference + signed_pi,(2 * M_PI)) - signed_pi;
   return difference;
 }
 

--- a/cartographer/common/math.h
+++ b/cartographer/common/math.h
@@ -68,12 +68,10 @@ constexpr double RadToDeg(double rad) { return 180. * rad / M_PI; }
 // Bring the 'difference' between two angles into [-pi; pi].
 template <typename T>
 T NormalizeAngleDifference(T difference) {
-  while (difference > M_PI) {
-    difference -= T(2. * M_PI);
-  }
-  while (difference < -M_PI) {
-    difference += T(2. * M_PI);
-  }
+  // Copy the sign of the value in radians to the value of pi.
+  T signed_pi = std::copysign(M_PI,difference);
+  // Set the value of difference to the appropriate signed value between pi and -pi.
+  difference = std::fmod(difference + signed_pi,(2 * M_PI)) - signedPI;
   return difference;
 }
 


### PR DESCRIPTION
Consider the case of:
```C++
NormalizeAngleDifference(std::numeric_limits<double>::max());
```

The previous version of this function will be stuck in an infinite loop because: 

```c++
std::numeric_limits<double>::max() == std::numeric_limits<double>::max() - M_PI
```

In addition to eliminating the infinite loop, the updated version is frequently noticeably faster when the the value is well outside the -pi to pi range.

This file change is based on the following stackoverflow post of my own creation:
http://stackoverflow.com/a/11126083/99379

Also, please consider switching to this function name as it may be more clear:
```C++
template<typename T>
inline T NormalizeRadiansPiToMinusPi(T rad);
```