### PR TITLE
add #include <array> in files which use std::array

### DIFF
--- a/cartographer/io/points_batch.h
+++ b/cartographer/io/points_batch.h
@@ -17,6 +17,7 @@
 #ifndef CARTOGRAPHER_IO_POINTS_BATCH_H_
 #define CARTOGRAPHER_IO_POINTS_BATCH_H_
 
+#include <array>
 #include <cstdint>
 #include <vector>
 

--- a/cartographer/mapping_3d/hybrid_grid.h
+++ b/cartographer/mapping_3d/hybrid_grid.h
@@ -17,6 +17,7 @@
 #ifndef CARTOGRAPHER_MAPPING_3D_HYBRID_GRID_H_
 #define CARTOGRAPHER_MAPPING_3D_HYBRID_GRID_H_
 
+#include <array>
 #include <cmath>
 #include <limits>
 #include <utility>

--- a/cartographer/sensor/collator_test.cc
+++ b/cartographer/sensor/collator_test.cc
@@ -16,6 +16,7 @@
 
 #include "cartographer/sensor/collator.h"
 
+#include <array>
 #include <memory>
 
 #include "cartographer/common/lua_parameter_dictionary_test_helpers.h"


### PR DESCRIPTION
This pull request adds some missing `#include <array>` in files which directly use `std::array`. Without these includes, this fails to compile with clang on macOS, for example:

```
[  1%] Building CXX object CMakeFiles/cartographer.dir/cartographer/io/coloring_points_processor.cc.o
In file included from /Users/william/ros2_ws/src/vendor/cartographer/cartographer/io/coloring_points_processor.cc:17:
/Users/william/ros2_ws/src/vendor/cartographer/cartographer/io/coloring_points_processor.h:49:15: error: implicit instantiation of undefined template 'std::__1::array<unsigned char, 3>'
  const Color color_;
              ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__tuple:116:92: note: template is declared here
template <class _Tp, size_t _Size> struct __attribute__ ((__type_visibility__("default"))) array;
                                                                                           ^
```