### PR TITLE
Minor sparse_pose_graph.proto improvements.

### DIFF
--- a/cartographer/mapping/proto/sparse_pose_graph.proto
+++ b/cartographer/mapping/proto/sparse_pose_graph.proto
@@ -45,7 +45,7 @@ message SparsePoseGraph {
     // into the submap frame.
     optional transform.proto.Rigid3d relative_pose = 3;
     // 6x6 square root inverse of the covariance matrix. This is stored in
-    // column-major order for ease of Eigen::Map.
+    // column-major order for ease of use with Eigen::Map.
     repeated double sqrt_Lambda = 4 [packed = true];  // NOLINT
     optional Tag tag = 5;
   }

--- a/cartographer/mapping/proto/sparse_pose_graph.proto
+++ b/cartographer/mapping/proto/sparse_pose_graph.proto
@@ -44,8 +44,9 @@ message SparsePoseGraph {
     // Pose of the scan relative to submap, i.e. taking data from the scan frame
     // into the submap frame.
     optional transform.proto.Rigid3d relative_pose = 3;
-    // 6x6 square root inverse of the covariance matrix.
-    repeated double sqrt_Lambda = 4;  // NOLINT
+    // 6x6 square root inverse of the covariance matrix. This is stored in
+    // column-major order for ease of Eigen::Map.
+    repeated double sqrt_Lambda = 4 [packed = true];  // NOLINT
     optional Tag tag = 5;
   }
 


### PR DESCRIPTION
From [the encoding spec:](https://developers.google.com/protocol-buffers/docs/encoding)

> Protocol buffer parsers must be able to parse repeated fields that were compiled as packed as if they were not packed, and vice versa. This permits adding [packed=true] to existing fields in a forward- and backward-compatible way.

