### PR TITLE
Sphinx build fix

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(OUTPUT_DIR "${CMAKE_BINARY_DIR}/docs/html")
+set(OUTPUT_DIR "${PROJECT_BINARY_DIR}/docs/html")
 
 add_custom_target(build_doc ALL
     ${SPHINX_EXECUTABLE} -b html


### PR DESCRIPTION
This was missed in #203, where uses of absolute CMAKE_BINARY_DIR were changed to PROJECT_BINARY_DIR.