### PR TITLE
Fix divison by zero.

### DIFF
--- a/cartographer/mapping_2d/local_trajectory_builder.cc
+++ b/cartographer/mapping_2d/local_trajectory_builder.cc
@@ -201,7 +201,8 @@ LocalTrajectoryBuilder::AddHorizontalRangeData(
   }
 
   // Improve the velocity estimate.
-  if (last_scan_match_time_ > common::Time::min()) {
+  if (last_scan_match_time_ > common::Time::min() &&
+      time > last_scan_match_time_) {
     const double delta_t = common::ToSeconds(time - last_scan_match_time_);
     velocity_estimate_ += (pose_estimate_.translation().head<2>() -
                            model_prediction.translation().head<2>()) /


### PR DESCRIPTION
If mapping_2d::LocalTrajectoryBuilder::AddHorizontalRangeData is called
twice in a row with the same `time`, the `velocity_estimate_` becomes
`inf` which led to `inf`s in the optimization problem, which led to
failures inside Ceres.

Fixes #233.