### PR TITLE
Comply to CMake's CMP0037.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ foreach(ABS_FIL ${ALL_TESTS})
   file(RELATIVE_PATH REL_FIL ${PROJECT_SOURCE_DIR} ${ABS_FIL})
   get_filename_component(DIR ${REL_FIL} DIRECTORY)
   get_filename_component(FIL_WE ${REL_FIL} NAME_WE)
+  # Replace slashes as required for CMP0037.
   string(REPLACE "/" "." TEST_TARGET_NAME "${DIR}/${FIL_WE}")
   google_test("${TEST_TARGET_NAME}" ${ABS_FIL})
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,8 @@ foreach(ABS_FIL ${ALL_TESTS})
   file(RELATIVE_PATH REL_FIL ${PROJECT_SOURCE_DIR} ${ABS_FIL})
   get_filename_component(DIR ${REL_FIL} DIRECTORY)
   get_filename_component(FIL_WE ${REL_FIL} NAME_WE)
-  google_test("${DIR}/${FIL_WE}" ${ABS_FIL})
+  string(REPLACE "/" "." TEST_TARGET_NAME "${DIR}/${FIL_WE}")
+  google_test("${TEST_TARGET_NAME}" ${ABS_FIL})
 endforeach()
 
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC


### PR DESCRIPTION
Test target names are generated from the directory and
source filename. Now "/"s are replaced by "."s which are
allowed by CMP0037.