### PR TITLE
make constraint() in sparase pose graph public

### DIFF
--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -99,10 +99,10 @@ class SparsePoseGraph {
   // Serializes the constraints and trajectories.
   proto::SparsePoseGraph ToProto();
 
- protected:
   // Returns the collection of constraints.
   virtual std::vector<Constraint> constraints() = 0;
 
+ protected:
   // Returns the mapping from Submaps* to trajectory IDs.
   virtual const std::unordered_map<const Submaps*, int>& trajectory_ids() = 0;
 };

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -89,8 +89,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   std::vector<mapping::TrajectoryNode> GetTrajectoryNodes() override
       EXCLUDES(mutex_);
 
- protected:
   std::vector<Constraint> constraints() override EXCLUDES(mutex_);
+ protected:
   const std::unordered_map<const mapping::Submaps*, int>& trajectory_ids()
       override EXCLUDES(mutex_);
 

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -89,7 +89,7 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   std::vector<mapping::TrajectoryNode> GetTrajectoryNodes() override
       EXCLUDES(mutex_);
   std::vector<Constraint> constraints() override EXCLUDES(mutex_);
- 
+
  protected:
   const std::unordered_map<const mapping::Submaps*, int>& trajectory_ids()
       override EXCLUDES(mutex_);

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -88,8 +88,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
       EXCLUDES(mutex_) override;
   std::vector<mapping::TrajectoryNode> GetTrajectoryNodes() override
       EXCLUDES(mutex_);
-
   std::vector<Constraint> constraints() override EXCLUDES(mutex_);
+ 
  protected:
   const std::unordered_map<const mapping::Submaps*, int>& trajectory_ids()
       override EXCLUDES(mutex_);

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -91,8 +91,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   std::vector<mapping::TrajectoryNode> GetTrajectoryNodes() override
       EXCLUDES(mutex_);
 
- protected:
   std::vector<Constraint> constraints() override EXCLUDES(mutex_);
+ protected:
   const std::unordered_map<const mapping::Submaps*, int>& trajectory_ids()
       override EXCLUDES(mutex_);
 

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -90,8 +90,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
       EXCLUDES(mutex_) override;
   std::vector<mapping::TrajectoryNode> GetTrajectoryNodes() override
       EXCLUDES(mutex_);
-
   std::vector<Constraint> constraints() override EXCLUDES(mutex_);
+
  protected:
   const std::unordered_map<const mapping::Submaps*, int>& trajectory_ids()
       override EXCLUDES(mutex_);


### PR DESCRIPTION
It is necessary for trajectory and constraint visualization.