### PR TITLE
Fix 3D SLAM loop closure issues.

### DIFF
--- a/cartographer/kalman_filter/pose_tracker.h
+++ b/cartographer/kalman_filter/pose_tracker.h
@@ -122,6 +122,10 @@ class PoseTracker {
 
   const mapping::OdometryStateTracker::OdometryStates& odometry_states() const;
 
+  Eigen::Quaterniond gravity_orientation() const {
+    return imu_tracker_.orientation();
+  }
+
  private:
   // Returns the distribution required to initialize the KalmanFilter.
   static Distribution KalmanFilterInit();

--- a/cartographer/mapping/imu_tracker.h
+++ b/cartographer/mapping/imu_tracker.h
@@ -41,7 +41,7 @@ class ImuTracker {
       const Eigen::Vector3d& imu_angular_velocity);
 
   // Query the current orientation estimate.
-  Eigen::Quaterniond orientation() { return orientation_; }
+  Eigen::Quaterniond orientation() const { return orientation_; }
 
  private:
   const double imu_gravity_time_constant_;

--- a/cartographer/mapping/submaps.h
+++ b/cartographer/mapping/submaps.h
@@ -52,19 +52,15 @@ inline uint8 ProbabilityToLogOddsInteger(const float probability) {
   return value;
 }
 
-// An individual submap, which has an initial position 'origin', keeps track of
-// how many range data were inserted into it, and sets the
+// An individual submap, which has a 'local_pose' in the local SLAM frame, keeps
+// track of how many range data were inserted into it, and sets the
 // 'finished_probability_grid' to be used for loop closing once the map no
 // longer changes.
 struct Submap {
-  Submap(const Eigen::Vector3f& origin) : origin(origin) {}
+  Submap(const transform::Rigid3d& local_pose) : local_pose(local_pose) {}
 
-  transform::Rigid3d local_pose() const {
-    return transform::Rigid3d::Translation(origin.cast<double>());
-  }
-
-  // Origin of this submap.
-  const Eigen::Vector3f origin;
+  // Local SLAM pose of this submap.
+  const transform::Rigid3d local_pose;
 
   // Number of RangeData inserted.
   int num_range_data = 0;

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -441,8 +441,7 @@ transform::Rigid3d SparsePoseGraph::GetLocalToGlobalTransform(
   return extrapolated_submap_transforms.back() *
          submap_states_.at(trajectory_id)
              .at(extrapolated_submap_transforms.size() - 1)
-             .submap->local_pose()
-             .inverse();
+             .submap->local_pose.inverse();
 }
 
 std::vector<std::vector<int>> SparsePoseGraph::GetConnectedTrajectories() {
@@ -476,14 +475,13 @@ std::vector<transform::Rigid3d> SparsePoseGraph::ExtrapolateSubmapTransforms(
     } else if (result.empty()) {
       result.push_back(transform::Rigid3d::Identity());
     } else {
-      // Extrapolate to the remaining submaps. Accessing local_pose() in Submaps
+      // Extrapolate to the remaining submaps. Accessing 'local_pose' in Submaps
       // is okay, since the member is const.
       result.push_back(result.back() *
                        submap_states_.at(trajectory_id)
                            .at(result.size() - 1)
-                           .submap->local_pose()
-                           .inverse() *
-                       state.submap->local_pose());
+                           .submap->local_pose.inverse() *
+                       state.submap->local_pose);
     }
   }
 

--- a/cartographer/mapping_2d/sparse_pose_graph/constraint_builder.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph/constraint_builder.cc
@@ -40,7 +40,7 @@ namespace mapping_2d {
 namespace sparse_pose_graph {
 
 transform::Rigid2d ComputeSubmapPose(const mapping::Submap& submap) {
-  return transform::Project2D(submap.local_pose());
+  return transform::Project2D(submap.local_pose);
 }
 
 ConstraintBuilder::ConstraintBuilder(

--- a/cartographer/mapping_2d/submaps.cc
+++ b/cartographer/mapping_2d/submaps.cc
@@ -102,7 +102,8 @@ proto::SubmapsOptions CreateSubmapsOptions(
 }
 
 Submap::Submap(const MapLimits& limits, const Eigen::Vector2f& origin)
-    : mapping::Submap(Eigen::Vector3f(origin.x(), origin.y(), 0.)),
+    : mapping::Submap(transform::Rigid3d::Translation(
+          Eigen::Vector3d(origin.x(), origin.y(), 0.))),
       probability_grid(limits) {}
 
 Submaps::Submaps(const proto::SubmapsOptions& options)
@@ -137,7 +138,7 @@ int Submaps::size() const { return submaps_.size(); }
 void Submaps::SubmapToProto(
     const int index, const transform::Rigid3d&,
     mapping::proto::SubmapQuery::Response* const response) const {
-  AddProbabilityGridToResponse(Get(index)->local_pose(),
+  AddProbabilityGridToResponse(Get(index)->local_pose,
                                Get(index)->probability_grid, response);
 }
 

--- a/cartographer/mapping_3d/kalman_local_trajectory_builder.cc
+++ b/cartographer/mapping_3d/kalman_local_trajectory_builder.cc
@@ -143,7 +143,7 @@ KalmanLocalTrajectoryBuilder::AddAccumulatedRangeData(
   const Submap* const matching_submap =
       submaps_->Get(submaps_->matching_index());
   transform::Rigid3d initial_ceres_pose =
-      matching_submap->local_pose().inverse() * pose_prediction;
+      matching_submap->local_pose.inverse() * pose_prediction;
   sensor::AdaptiveVoxelFilter adaptive_voxel_filter(
       options_.high_resolution_adaptive_voxel_filter_options());
   const sensor::PointCloud filtered_point_cloud_in_tracking =
@@ -171,7 +171,7 @@ KalmanLocalTrajectoryBuilder::AddAccumulatedRangeData(
                                &matching_submap->low_resolution_hybrid_grid}},
                              &pose_observation_in_submap, &summary);
   const transform::Rigid3d pose_observation =
-      matching_submap->local_pose() * pose_observation_in_submap;
+      matching_submap->local_pose * pose_observation_in_submap;
   pose_tracker_->AddPoseObservation(
       time, pose_observation,
       options_.kalman_local_trajectory_builder_options()
@@ -227,8 +227,10 @@ KalmanLocalTrajectoryBuilder::InsertIntoSubmap(
   for (int insertion_index : submaps_->insertion_indices()) {
     insertion_submaps.push_back(submaps_->Get(insertion_index));
   }
-  submaps_->InsertRangeData(sensor::TransformRangeData(
-      range_data_in_tracking, pose_observation.cast<float>()));
+  submaps_->InsertRangeData(
+      sensor::TransformRangeData(range_data_in_tracking,
+                                 pose_observation.cast<float>()),
+      pose_tracker_->gravity_orientation());
   return std::unique_ptr<InsertionResult>(new InsertionResult{
       time, range_data_in_tracking, pose_observation, covariance_estimate,
       matching_submap, insertion_submaps});

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -187,6 +187,18 @@ void SparsePoseGraph::ComputeConstraint(const mapping::NodeId& node_id,
   // Only globally match against submaps not in this trajectory.
   if (node_id.trajectory_id != submap_id.trajectory_id &&
       global_localization_samplers_[node_id.trajectory_id]->Pulse()) {
+    // In this situation, 'initial_relative_pose' is:
+    //
+    // submap <- global map 2 <- global map 1 <- tracking
+    //               (agreeing on gravity)
+    //
+    // Since they possibly came from two disconnected trajectories, the only
+    // guaranteed connection between the tracking and the submap frames is
+    // an agreement on the direction of gravity. Therefore, excluding yaw,
+    // 'initial_relative_pose.rotation()' is a good estimate of the relative
+    // orientation of the point cloud in the submap frame. Finding the correct
+    // yaw component will be handled by the matching procedure in the
+    // FastCorrelativeScanMatcher, and the given yaw is essentially ignored.
     constraint_builder_.MaybeAddGlobalConstraint(
         submap_id,
         submap_states_.at(submap_id.trajectory_id)

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -81,8 +81,8 @@ void SparsePoseGraph::GrowSubmapTransformsAsNeeded(
         submap_data.at(trajectory_id).at(first_submap_id.submap_index).pose;
     optimization_problem_.AddSubmap(
         trajectory_id, first_submap_pose *
-                           insertion_submaps[0]->local_pose().inverse() *
-                           insertion_submaps[1]->local_pose());
+                           insertion_submaps[0]->local_pose.inverse() *
+                           insertion_submaps[1]->local_pose);
   }
 }
 
@@ -164,6 +164,12 @@ void SparsePoseGraph::ComputeConstraint(const mapping::NodeId& node_id,
           .at(submap_id.submap_index)
           .pose.inverse();
 
+  const transform::Rigid3d initial_relative_pose =
+      inverse_submap_pose * optimization_problem_.node_data()
+                                .at(node_id.trajectory_id)
+                                .at(node_id.node_index)
+                                .point_cloud_pose;
+
   std::vector<mapping::TrajectoryNode> submap_nodes;
   for (const mapping::NodeId& submap_node_id :
        submap_states_.at(submap_id.trajectory_id)
@@ -190,7 +196,8 @@ void SparsePoseGraph::ComputeConstraint(const mapping::NodeId& node_id,
         &trajectory_nodes_.at(node_id.trajectory_id)
              .at(node_id.node_index)
              .constant_data->range_data_3d.returns,
-        submap_nodes, &trajectory_connectivity_);
+        submap_nodes, initial_relative_pose.rotation(),
+        &trajectory_connectivity_);
   } else {
     const bool scan_and_submap_trajectories_connected =
         reverse_connected_components_.count(node_id.trajectory_id) > 0 &&
@@ -199,11 +206,6 @@ void SparsePoseGraph::ComputeConstraint(const mapping::NodeId& node_id,
             reverse_connected_components_.at(submap_id.trajectory_id);
     if (node_id.trajectory_id == submap_id.trajectory_id ||
         scan_and_submap_trajectories_connected) {
-      const transform::Rigid3d initial_relative_pose =
-          inverse_submap_pose * optimization_problem_.node_data()
-                                    .at(node_id.trajectory_id)
-                                    .at(node_id.node_index)
-                                    .point_cloud_pose;
       constraint_builder_.MaybeAddConstraint(
           submap_id,
           submap_states_.at(submap_id.trajectory_id)
@@ -242,7 +244,7 @@ void SparsePoseGraph::ComputeConstraintsForScan(
           .at(matching_id.trajectory_id)
           .at(matching_id.submap_index)
           .pose *
-      matching_submap->local_pose().inverse() * pose;
+      matching_submap->local_pose.inverse() * pose;
   CHECK_EQ(scan_index, scan_index_to_node_id_.size());
   const mapping::NodeId node_id{
       matching_id.trajectory_id,
@@ -266,7 +268,7 @@ void SparsePoseGraph::ComputeConstraintsForScan(
         .node_ids.emplace(node_id);
     // Unchanged covariance as (submap <- map) is a translation.
     const transform::Rigid3d constraint_transform =
-        submap->local_pose().inverse() * pose;
+        submap->local_pose.inverse() * pose;
     constraints_.push_back(
         Constraint{submap_id,
                    node_id,
@@ -447,8 +449,7 @@ transform::Rigid3d SparsePoseGraph::GetLocalToGlobalTransform(
   return extrapolated_submap_transforms.back() *
          submap_states_.at(trajectory_id)
              .at(extrapolated_submap_transforms.size() - 1)
-             .submap->local_pose()
-             .inverse();
+             .submap->local_pose.inverse();
 }
 
 std::vector<std::vector<int>> SparsePoseGraph::GetConnectedTrajectories() {
@@ -482,14 +483,13 @@ std::vector<transform::Rigid3d> SparsePoseGraph::ExtrapolateSubmapTransforms(
     } else if (result.empty()) {
       result.push_back(transform::Rigid3d::Identity());
     } else {
-      // Extrapolate to the remaining submaps. Accessing local_pose() in Submaps
+      // Extrapolate to the remaining submaps. Accessing 'local_pose' in Submaps
       // is okay, since the member is const.
       result.push_back(result.back() *
                        submap_states_.at(trajectory_id)
                            .at(result.size() - 1)
-                           .submap->local_pose()
-                           .inverse() *
-                       state.submap->local_pose());
+                           .submap->local_pose.inverse() *
+                       state.submap->local_pose);
     }
   }
 

--- a/cartographer/mapping_3d/sparse_pose_graph/constraint_builder.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph/constraint_builder.cc
@@ -88,6 +88,7 @@ void ConstraintBuilder::MaybeAddGlobalConstraint(
     const mapping::NodeId& node_id,
     const sensor::CompressedPointCloud* const compressed_point_cloud,
     const std::vector<mapping::TrajectoryNode>& submap_nodes,
+    const Eigen::Quaterniond& gravity_alignment,
     mapping::TrajectoryConnectivity* const trajectory_connectivity) {
   common::MutexLocker locker(&mutex_);
   constraints_.emplace_back();
@@ -97,10 +98,10 @@ void ConstraintBuilder::MaybeAddGlobalConstraint(
   ScheduleSubmapScanMatcherConstructionAndQueueWorkItem(
       submap_id, submap_nodes, &submap->high_resolution_hybrid_grid,
       [=]() EXCLUDES(mutex_) {
-        ComputeConstraint(submap_id, submap, node_id,
-                          true, /* match_full_submap */
-                          trajectory_connectivity, compressed_point_cloud,
-                          transform::Rigid3d::Identity(), constraint);
+        ComputeConstraint(
+            submap_id, submap, node_id, true, /* match_full_submap */
+            trajectory_connectivity, compressed_point_cloud,
+            transform::Rigid3d::Rotation(gravity_alignment), constraint);
         FinishComputation(current_computation);
       });
 }

--- a/cartographer/mapping_3d/sparse_pose_graph/constraint_builder.h
+++ b/cartographer/mapping_3d/sparse_pose_graph/constraint_builder.h
@@ -84,7 +84,9 @@ class ConstraintBuilder {
   // 'submap_id' and the 'compressed_point_cloud' for 'node_id'.
   // This performs full-submap matching.
   //
-  // The 'trajectory_connectivity' is updated if the full-submap match succeeds.
+  // The 'gravity_alignment' is the rotation to apply to the point cloud data
+  // to make it approximately gravity aligned. The 'trajectory_connectivity' is
+  // updated if the full-submap match succeeds.
   //
   // The pointees of 'submap' and 'compressed_point_cloud' must stay valid until
   // all computations are finished.
@@ -93,6 +95,7 @@ class ConstraintBuilder {
       const mapping::NodeId& node_id,
       const sensor::CompressedPointCloud* compressed_point_cloud,
       const std::vector<mapping::TrajectoryNode>& submap_nodes,
+      const Eigen::Quaterniond& gravity_alignment,
       mapping::TrajectoryConnectivity* trajectory_connectivity);
 
   // Must be called after all computations related to one node have been added.


### PR DESCRIPTION
3D submaps are now oriented approximately gravity aligned.
This is so that accumulating error in the local SLAM frame is
no longer a problem for finding loop closures. It also ensures
that the z search window size is approximately in the gravity
direction.

We now also pass an estimate of gravity orientation when doing
multi-trajectory matches. Otherwise trajectories starting with
different orientation relative to gravity could not be connected.

The gravity alignment is currently derived from the ImuTracker.
It might be possible to further improve on this by using the
latest gravity direction from the optimized poses.