### PR TITLE
Check Travis cache size

### DIFF
--- a/scripts/load_docker_cache.sh
+++ b/scripts/load_docker_cache.sh
@@ -22,5 +22,10 @@ set -o verbose
 set -o pipefail
 
 if [ -f ${DOCKER_CACHE_FILE} ]; then
-  gunzip -c ${DOCKER_CACHE_FILE} | docker load;
+  gunzip -c ${DOCKER_CACHE_FILE} > /tmp/docker_cache_file
+  if [ -s /tmp/docker_cache_file ]; then
+    docker load -i /tmp/docker_cache_file
+  else
+    echo "Warning: skipped loading cache (empty file)."
+  fi
 fi


### PR DESCRIPTION
@damonkohler please have a look if this would be acceptable. If yes, let me know so I can make a similar pull request in cartographer_ros as well.

'docker load' errors out if is called to load an empty file. When
pushing branches rapidly, an empty Travis cache sometimes gets saved,
which subsequently breaks Travis builds.

This should fix #292.