### PR TITLE
Remove 2D scan matcher covariances.

### DIFF
--- a/cartographer/mapping/proto/sparse_pose_graph_options.proto
+++ b/cartographer/mapping/proto/sparse_pose_graph_options.proto
@@ -28,6 +28,11 @@ message SparsePoseGraphOptions {
   optional mapping.sparse_pose_graph.proto.ConstraintBuilderOptions
       constraint_builder_options = 3;
 
+  // Weights used in the optimization problem for non-loop-closure scan matcher
+  // constraints.
+  optional double matcher_translation_weight = 7;
+  optional double matcher_rotation_weight = 8;
+
   // Options for the optimization problem.
   optional mapping.sparse_pose_graph.proto.OptimizationProblemOptions
       optimization_problem_options = 4;

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -35,6 +35,10 @@ namespace mapping {
 proto::SparsePoseGraphOptions CreateSparsePoseGraphOptions(
     common::LuaParameterDictionary* const parameter_dictionary);
 
+// TODO(whess): Change to two doubles for performance.
+Eigen::Matrix<double, 6, 6> FromTranslationRotationWeights(
+    double translation_weight, double rotation_weight);
+
 class SparsePoseGraph {
  public:
   // A "constraint" as in the paper by Konolige, Kurt, et al. "Efficient sparse

--- a/cartographer/mapping/sparse_pose_graph/constraint_builder.cc
+++ b/cartographer/mapping/sparse_pose_graph/constraint_builder.cc
@@ -40,6 +40,10 @@ proto::ConstraintBuilderOptions CreateConstraintBuilderOptions(
       parameter_dictionary->GetDouble("global_localization_min_score"));
   options.set_lower_covariance_eigenvalue_bound(
       parameter_dictionary->GetDouble("lower_covariance_eigenvalue_bound"));
+  options.set_loop_closure_translation_weight(
+      parameter_dictionary->GetDouble("loop_closure_translation_weight"));
+  options.set_loop_closure_rotation_weight(
+      parameter_dictionary->GetDouble("loop_closure_rotation_weight"));
   options.set_log_matches(parameter_dictionary->GetBool("log_matches"));
   *options.mutable_fast_correlative_scan_matcher_options() =
       mapping_2d::scan_matching::CreateFastCorrelativeScanMatcherOptions(

--- a/cartographer/mapping/sparse_pose_graph/proto/constraint_builder_options.proto
+++ b/cartographer/mapping/sparse_pose_graph/proto/constraint_builder_options.proto
@@ -42,7 +42,12 @@ message ConstraintBuilderOptions {
   optional double global_localization_min_score = 5;
 
   // Lower bound for covariance eigenvalues to limit the weight of matches.
+  // TODO(whess): Deprecated and only used in 3D. Replace usage and remove.
   optional double lower_covariance_eigenvalue_bound = 7;
+
+  // Weights used in the optimization problem for loop closure constraints.
+  optional double loop_closure_translation_weight = 13;
+  optional double loop_closure_rotation_weight = 14;
 
   // If enabled, logs information of loop-closing constraints for debugging.
   optional bool log_matches = 8;

--- a/cartographer/mapping_2d/global_trajectory_builder.cc
+++ b/cartographer/mapping_2d/global_trajectory_builder.cc
@@ -42,10 +42,8 @@ void GlobalTrajectoryBuilder::AddRangefinderData(
     sparse_pose_graph_->AddScan(
         insertion_result->time, insertion_result->tracking_to_tracking_2d,
         insertion_result->range_data_in_tracking_2d,
-        insertion_result->pose_estimate_2d,
-        kalman_filter::Project2D(insertion_result->covariance_estimate),
-        trajectory_id_, insertion_result->matching_submap,
-        insertion_result->insertion_submaps);
+        insertion_result->pose_estimate_2d, trajectory_id_,
+        insertion_result->matching_submap, insertion_result->insertion_submaps);
   }
 }
 

--- a/cartographer/mapping_2d/local_trajectory_builder.h
+++ b/cartographer/mapping_2d/local_trajectory_builder.h
@@ -46,7 +46,6 @@ class LocalTrajectoryBuilder {
     transform::Rigid3d tracking_to_tracking_2d;
     sensor::RangeData range_data_in_tracking_2d;
     transform::Rigid2d pose_estimate_2d;
-    kalman_filter::PoseCovariance covariance_estimate;
   };
 
   explicit LocalTrajectoryBuilder(
@@ -71,13 +70,12 @@ class LocalTrajectoryBuilder {
       const transform::Rigid3f& tracking_to_tracking_2d,
       const sensor::RangeData& range_data) const;
 
-  // Scan match 'range_data_in_tracking_2d' and fill in the
-  // 'pose_observation' and 'covariance_observation' with the result.
+  // Scan matches 'range_data_in_tracking_2d' and fill in the 'pose_observation'
+  // with the result.
   void ScanMatch(common::Time time, const transform::Rigid3d& pose_prediction,
                  const transform::Rigid3d& tracking_to_tracking_2d,
                  const sensor::RangeData& range_data_in_tracking_2d,
-                 transform::Rigid3d* pose_observation,
-                 kalman_filter::PoseCovariance* covariance_observation);
+                 transform::Rigid3d* pose_observation);
 
   // Lazily constructs an ImuTracker.
   void InitializeImuTracker(common::Time time);

--- a/cartographer/mapping_2d/scan_matching/ceres_scan_matcher.h
+++ b/cartographer/mapping_2d/scan_matching/ceres_scan_matcher.h
@@ -22,7 +22,6 @@
 
 #include "Eigen/Core"
 #include "cartographer/common/lua_parameter_dictionary.h"
-#include "cartographer/kalman_filter/pose_tracker.h"
 #include "cartographer/mapping_2d/probability_grid.h"
 #include "cartographer/mapping_2d/scan_matching/proto/ceres_scan_matcher_options.pb.h"
 #include "cartographer/sensor/point_cloud.h"
@@ -45,14 +44,13 @@ class CeresScanMatcher {
   CeresScanMatcher& operator=(const CeresScanMatcher&) = delete;
 
   // Aligns 'point_cloud' within the 'probability_grid' given an
-  // 'initial_pose_estimate' and returns 'pose_estimate', 'covariance', and
-  // the solver 'summary'.
+  // 'initial_pose_estimate' and returns a 'pose_estimate' and the solver
+  // 'summary'.
   void Match(const transform::Rigid2d& previous_pose,
              const transform::Rigid2d& initial_pose_estimate,
              const sensor::PointCloud& point_cloud,
              const ProbabilityGrid& probability_grid,
              transform::Rigid2d* pose_estimate,
-             kalman_filter::Pose2DCovariance* covariance,
              ceres::Solver::Summary* summary) const;
 
  private:

--- a/cartographer/mapping_2d/scan_matching/ceres_scan_matcher_test.cc
+++ b/cartographer/mapping_2d/scan_matching/ceres_scan_matcher_test.cc
@@ -47,7 +47,6 @@ class CeresScanMatcherTest : public ::testing::Test {
           occupied_space_weight = 1.,
           translation_weight = 0.1,
           rotation_weight = 1.5,
-          covariance_scale = 10.,
           ceres_solver_options = {
             use_nonmonotonic_steps = true,
             max_num_iterations = 50,
@@ -61,12 +60,11 @@ class CeresScanMatcherTest : public ::testing::Test {
 
   void TestFromInitialPose(const transform::Rigid2d& initial_pose) {
     transform::Rigid2d pose;
-    kalman_filter::Pose2DCovariance covariance;
     const transform::Rigid2d expected_pose =
         transform::Rigid2d::Translation({-0.5, 0.5});
     ceres::Solver::Summary summary;
     ceres_scan_matcher_->Match(initial_pose, initial_pose, point_cloud_,
-                               probability_grid_, &pose, &covariance, &summary);
+                               probability_grid_, &pose, &summary);
     EXPECT_NEAR(0., summary.final_cost, 1e-2) << summary.FullReport();
     EXPECT_THAT(pose, transform::IsNearly(expected_pose, 1e-2))
         << "Actual: " << transform::ToProto(pose).DebugString()

--- a/cartographer/mapping_2d/scan_matching/real_time_correlative_scan_matcher_test.cc
+++ b/cartographer/mapping_2d/scan_matching/real_time_correlative_scan_matcher_test.cc
@@ -22,7 +22,6 @@
 #include "Eigen/Geometry"
 #include "cartographer/common/lua_parameter_dictionary_test_helpers.h"
 #include "cartographer/common/make_unique.h"
-#include "cartographer/kalman_filter/pose_tracker.h"
 #include "cartographer/mapping_2d/probability_grid.h"
 #include "cartographer/mapping_2d/range_data_inserter.h"
 #include "cartographer/sensor/point_cloud.h"

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -30,7 +30,6 @@
 #include "cartographer/common/mutex.h"
 #include "cartographer/common/thread_pool.h"
 #include "cartographer/common/time.h"
-#include "cartographer/kalman_filter/pose_tracker.h"
 #include "cartographer/mapping/sparse_pose_graph.h"
 #include "cartographer/mapping/trajectory_connectivity.h"
 #include "cartographer/mapping_2d/sparse_pose_graph/constraint_builder.h"
@@ -68,9 +67,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   // into the 'insertion_submaps'.
   void AddScan(common::Time time, const transform::Rigid3d& tracking_to_pose,
                const sensor::RangeData& range_data_in_pose,
-               const transform::Rigid2d& pose,
-               const kalman_filter::Pose2DCovariance& pose_covariance,
-               int trajectory_id, const mapping::Submap* matching_submap,
+               const transform::Rigid2d& pose, int trajectory_id,
+               const mapping::Submap* matching_submap,
                const std::vector<const mapping::Submap*>& insertion_submaps)
       EXCLUDES(mutex_);
 
@@ -125,8 +123,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   void ComputeConstraintsForScan(
       const mapping::Submap* matching_submap,
       std::vector<const mapping::Submap*> insertion_submaps,
-      const mapping::Submap* finished_submap, const transform::Rigid2d& pose,
-      const kalman_filter::Pose2DCovariance& covariance) REQUIRES(mutex_);
+      const mapping::Submap* finished_submap, const transform::Rigid2d& pose)
+      REQUIRES(mutex_);
 
   // Computes constraints for a scan and submap pair.
   void ComputeConstraint(const mapping::NodeId& node_id,

--- a/cartographer/mapping_3d/scan_matching/ceres_scan_matcher.h
+++ b/cartographer/mapping_3d/scan_matching/ceres_scan_matcher.h
@@ -46,8 +46,8 @@ class CeresScanMatcher {
   CeresScanMatcher& operator=(const CeresScanMatcher&) = delete;
 
   // Aligns 'point_clouds' within the 'hybrid_grids' given an
-  // 'initial_pose_estimate' and returns 'pose_estimate', and
-  // the solver 'summary'.
+  // 'initial_pose_estimate' and returns a 'pose_estimate' and the solver
+  // 'summary'.
   void Match(const transform::Rigid3d& previous_pose,
              const transform::Rigid3d& initial_pose_estimate,
              const std::vector<PointCloudAndHybridGridPointers>&

--- a/configuration_files/sparse_pose_graph.lua
+++ b/configuration_files/sparse_pose_graph.lua
@@ -25,6 +25,8 @@ SPARSE_POSE_GRAPH = {
     min_score = 0.55,
     global_localization_min_score = 0.6,
     lower_covariance_eigenvalue_bound = 1e-11,
+    loop_closure_translation_weight = 1.1e4,
+    loop_closure_rotation_weight = 1e5,
     log_matches = true,
     fast_correlative_scan_matcher = {
       linear_search_window = 7.,
@@ -35,7 +37,6 @@ SPARSE_POSE_GRAPH = {
       occupied_space_weight = 20.,
       translation_weight = 10.,
       rotation_weight = 1.,
-      covariance_scale = 1e-4,
       ceres_solver_options = {
         use_nonmonotonic_steps = true,
         max_num_iterations = 10,
@@ -63,6 +64,8 @@ SPARSE_POSE_GRAPH = {
       },
     },
   },
+  matcher_translation_weight = 5e2,
+  matcher_rotation_weight = 1.6e3,
   optimization_problem = {
     huber_scale = 1e1,
     acceleration_weight = 1e4,

--- a/configuration_files/trajectory_builder_2d.lua
+++ b/configuration_files/trajectory_builder_2d.lua
@@ -39,7 +39,6 @@ TRAJECTORY_BUILDER_2D = {
     occupied_space_weight = 1e1,
     translation_weight = 1e1,
     rotation_weight = 1e2,
-    covariance_scale = 1e-2,
     ceres_solver_options = {
       use_nonmonotonic_steps = false,
       max_num_iterations = 20,


### PR DESCRIPTION
This replaces the scaled covariances derived from the Ceres
scan matcher by directly configurable weights. Using covariances
did not provide the expected benefit, and replacing the scaling
matrix by two values will allow a faster evaluation of the cost
function in the future.