### PR TITLE
Tiny cleanup of the MapBuilder.

### DIFF
--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -104,10 +104,6 @@ int MapBuilder::GetBlockingTrajectoryId() const {
   return sensor_collator_.GetBlockingTrajectoryId();
 }
 
-proto::TrajectoryConnectivity MapBuilder::GetTrajectoryConnectivity() {
-  return ToProto(sparse_pose_graph_->GetConnectedTrajectories());
-}
-
 string MapBuilder::SubmapToProto(const int trajectory_id,
                                  const int submap_index,
                                  proto::SubmapQuery::Response* const response) {

--- a/cartographer/mapping/map_builder.h
+++ b/cartographer/mapping/map_builder.h
@@ -71,9 +71,6 @@ class MapBuilder {
   // unblocked.
   int GetBlockingTrajectoryId() const;
 
-  // Returns the trajectory connectivity.
-  proto::TrajectoryConnectivity GetTrajectoryConnectivity();
-
   // Fills the SubmapQuery::Response corresponding to 'submap_index' from
   // 'trajectory_id'. Returns an error string on failure, or an empty string on
   // success.


### PR DESCRIPTION
GetTrajectoryConnectivity() was a convenience function.
Instead, sparse_pose_graph() should be used to get access to
GetConnectedTrajectories().