### PR TITLE
Add 2D trajectory builder option to accept initial pose estimation

### DIFF
--- a/cartographer/mapping_2d/local_trajectory_builder.cc
+++ b/cartographer/mapping_2d/local_trajectory_builder.cc
@@ -32,7 +32,12 @@ LocalTrajectoryBuilder::LocalTrajectoryBuilder(
       real_time_correlative_scan_matcher_(
           options_.real_time_correlative_scan_matcher_options()),
       ceres_scan_matcher_(options_.ceres_scan_matcher_options()),
-      odometry_state_tracker_(options_.num_odometry_states()) {}
+      odometry_state_tracker_(options_.num_odometry_states()) {
+  if (options_.has_initial_pose_estimate()) {
+    pose_estimate_ = transform::ToRigid3(options_.initial_pose_estimate());
+    last_pose_estimate_.pose = pose_estimate_;
+  }
+}
 
 LocalTrajectoryBuilder::~LocalTrajectoryBuilder() {}
 

--- a/cartographer/mapping_2d/proto/local_trajectory_builder_options.proto
+++ b/cartographer/mapping_2d/proto/local_trajectory_builder_options.proto
@@ -21,6 +21,7 @@ import "cartographer/sensor/proto/adaptive_voxel_filter_options.proto";
 import "cartographer/mapping_2d/proto/submaps_options.proto";
 import "cartographer/mapping_2d/scan_matching/proto/ceres_scan_matcher_options.proto";
 import "cartographer/mapping_2d/scan_matching/proto/real_time_correlative_scan_matcher_options.proto";
+import "cartographer/transform/proto/transform.proto";
 
 message LocalTrajectoryBuilderOptions {
   // Rangefinder points outside these ranges will be dropped.
@@ -65,4 +66,7 @@ message LocalTrajectoryBuilderOptions {
 
   // True if IMU data should be expected and used.
   optional bool use_imu_data = 12;
+
+  // Initial pose estimate of a new trajectory
+  optional transform.proto.Rigid3d initial_pose_estimate = 19;
 }


### PR DESCRIPTION
This PR add an option to `mapping_2d::LocalTrajectoryBuilder` to accept initial pose estimation.
User can provide initial pose estimation when they start a new trajectory.