### PR TITLE
Rename ScanId to NodeId in the serialization.

### DIFF
--- a/cartographer/mapping/proto/sparse_pose_graph.proto
+++ b/cartographer/mapping/proto/sparse_pose_graph.proto
@@ -24,9 +24,9 @@ message SubmapId {
   optional int32 submap_index = 2;  // Submap index in the given trajectory.
 }
 
-message ScanId {
+message NodeId {
   optional int32 trajectory_id = 1;
-  optional int32 scan_index = 2;  // Scan index in the given trajectory.
+  optional int32 node_index = 2;  // Node index in the given trajectory.
 }
 
 message SparsePoseGraph {
@@ -40,7 +40,7 @@ message SparsePoseGraph {
     }
 
     optional SubmapId submap_id = 1;  // Submap ID.
-    optional ScanId scan_id = 2;  // Scan ID.
+    optional NodeId node_id = 2;  // Scan ID.
     // Pose of the scan relative to submap, i.e. taking data from the scan frame
     // into the submap frame.
     optional transform.proto.Rigid3d relative_pose = 3;

--- a/cartographer/mapping/sparse_pose_graph.cc
+++ b/cartographer/mapping/sparse_pose_graph.cc
@@ -120,9 +120,9 @@ proto::SparsePoseGraph SparsePoseGraph::ToProto() {
         submap_id.submap_index);
 
     const NodeId node_id = node_id_remapping.at(constraint.node_id);
-    constraint_proto->mutable_scan_id()->set_trajectory_id(
+    constraint_proto->mutable_node_id()->set_trajectory_id(
         node_id.trajectory_id);
-    constraint_proto->mutable_scan_id()->set_scan_index(node_id.node_index);
+    constraint_proto->mutable_node_id()->set_node_index(node_id.node_index);
 
     constraint_proto->set_tag(mapping::ToProto(constraint.tag));
   }


### PR DESCRIPTION
This is consistent with the naming in the C++ structs.