### PR TITLE
Cleanup of cell index conversion in 2D.

### DIFF
--- a/cartographer/mapping_2d/map_limits.h
+++ b/cartographer/mapping_2d/map_limits.h
@@ -63,23 +63,22 @@ class MapLimits {
   // Returns the limits of the grid in number of cells.
   const CellLimits& cell_limits() const { return cell_limits_; }
 
-  // Returns the index of the cell containing the point ('x', 'y') which may be
-  // outside the map, i.e., negative or too large indices that will return
-  // false for Contains().
-  Eigen::Array2i GetXYIndexOfCellContainingPoint(const double x,
-                                                 const double y) const {
+  // Returns the index of the cell containing the 'point' which may be outside
+  // the map, i.e., negative or too large indices that will return false for
+  // Contains().
+  Eigen::Array2i GetCellIndex(const Eigen::Vector2f& point) const {
     // Index values are row major and the top left has Eigen::Array2i::Zero()
     // and contains (centered_max_x, centered_max_y). We need to flip and
     // rotate.
     return Eigen::Array2i(
-        common::RoundToInt((max_.y() - y) / resolution_ - 0.5),
-        common::RoundToInt((max_.x() - x) / resolution_ - 0.5));
+        common::RoundToInt((max_.y() - point.y()) / resolution_ - 0.5),
+        common::RoundToInt((max_.x() - point.x()) / resolution_ - 0.5));
   }
 
-  // Returns true of the ProbabilityGrid contains 'xy_index'.
-  bool Contains(const Eigen::Array2i& xy_index) const {
-    return (Eigen::Array2i(0, 0) <= xy_index).all() &&
-           (xy_index <
+  // Returns true if the ProbabilityGrid contains 'cell_index'.
+  bool Contains(const Eigen::Array2i& cell_index) const {
+    return (Eigen::Array2i(0, 0) <= cell_index).all() &&
+           (cell_index <
             Eigen::Array2i(cell_limits_.num_x_cells, cell_limits_.num_y_cells))
                .all();
   }

--- a/cartographer/mapping_2d/probability_grid_test.cc
+++ b/cartographer/mapping_2d/probability_grid_test.cc
@@ -125,20 +125,21 @@ TEST(ProbabilityGridTest, GetProbability) {
 
   probability_grid.StartUpdate();
   probability_grid.SetProbability(
-      limits.GetXYIndexOfCellContainingPoint(-0.5, 0.5),
+      limits.GetCellIndex(Eigen::Vector2f(-0.5f, 0.5f)),
       mapping::kMaxProbability);
-  EXPECT_NEAR(probability_grid.GetProbability(-0.5, 0.5),
+  EXPECT_NEAR(probability_grid.GetProbability(
+                  limits.GetCellIndex(Eigen::Vector2f(-0.5f, 0.5f))),
               mapping::kMaxProbability, 1e-6);
   for (const Eigen::Array2i& xy_index :
-       {limits.GetXYIndexOfCellContainingPoint(-0.5, 1.5),
-        limits.GetXYIndexOfCellContainingPoint(0.5, 0.5),
-        limits.GetXYIndexOfCellContainingPoint(0.5, 1.5)}) {
+       {limits.GetCellIndex(Eigen::Vector2f(-0.5f, 1.5f)),
+        limits.GetCellIndex(Eigen::Vector2f(0.5f, 0.5f)),
+        limits.GetCellIndex(Eigen::Vector2f(0.5f, 1.5f))}) {
     EXPECT_TRUE(limits.Contains(xy_index));
     EXPECT_FALSE(probability_grid.IsKnown(xy_index));
   }
 }
 
-TEST(ProbabilityGridTest, GetXYIndexOfCellContainingPoint) {
+TEST(ProbabilityGridTest, GetCellIndex) {
   ProbabilityGrid probability_grid(
       MapLimits(2., Eigen::Vector2d(8., 14.), CellLimits(14, 8)));
 
@@ -147,33 +148,33 @@ TEST(ProbabilityGridTest, GetXYIndexOfCellContainingPoint) {
   ASSERT_EQ(14, cell_limits.num_x_cells);
   ASSERT_EQ(8, cell_limits.num_y_cells);
   EXPECT_TRUE(
-      (Eigen::Array2i(0, 0) == limits.GetXYIndexOfCellContainingPoint(7, 13))
+      (Eigen::Array2i(0, 0) == limits.GetCellIndex(Eigen::Vector2f(7.f, 13.f)))
           .all());
+  EXPECT_TRUE((Eigen::Array2i(13, 0) ==
+               limits.GetCellIndex(Eigen::Vector2f(7.f, -13.f)))
+                  .all());
   EXPECT_TRUE(
-      (Eigen::Array2i(13, 0) == limits.GetXYIndexOfCellContainingPoint(7, -13))
+      (Eigen::Array2i(0, 7) == limits.GetCellIndex(Eigen::Vector2f(-7.f, 13.f)))
           .all());
-  EXPECT_TRUE(
-      (Eigen::Array2i(0, 7) == limits.GetXYIndexOfCellContainingPoint(-7, 13))
-          .all());
-  EXPECT_TRUE(
-      (Eigen::Array2i(13, 7) == limits.GetXYIndexOfCellContainingPoint(-7, -13))
-          .all());
+  EXPECT_TRUE((Eigen::Array2i(13, 7) ==
+               limits.GetCellIndex(Eigen::Vector2f(-7.f, -13.f)))
+                  .all());
 
   // Check around the origin.
   EXPECT_TRUE(
-      (Eigen::Array2i(6, 3) == limits.GetXYIndexOfCellContainingPoint(0.5, 0.5))
+      (Eigen::Array2i(6, 3) == limits.GetCellIndex(Eigen::Vector2f(0.5f, 0.5f)))
           .all());
   EXPECT_TRUE(
-      (Eigen::Array2i(6, 3) == limits.GetXYIndexOfCellContainingPoint(1.5, 1.5))
+      (Eigen::Array2i(6, 3) == limits.GetCellIndex(Eigen::Vector2f(1.5f, 1.5f)))
           .all());
   EXPECT_TRUE((Eigen::Array2i(7, 3) ==
-               limits.GetXYIndexOfCellContainingPoint(0.5, -0.5))
+               limits.GetCellIndex(Eigen::Vector2f(0.5f, -0.5f)))
                   .all());
   EXPECT_TRUE((Eigen::Array2i(6, 4) ==
-               limits.GetXYIndexOfCellContainingPoint(-0.5, 0.5))
+               limits.GetCellIndex(Eigen::Vector2f(-0.5f, 0.5f)))
                   .all());
   EXPECT_TRUE((Eigen::Array2i(7, 4) ==
-               limits.GetXYIndexOfCellContainingPoint(-0.5, -0.5))
+               limits.GetCellIndex(Eigen::Vector2f(-0.5f, -0.5f)))
                   .all());
 }
 

--- a/cartographer/mapping_2d/range_data_inserter_test.cc
+++ b/cartographer/mapping_2d/range_data_inserter_test.cc
@@ -45,12 +45,12 @@ class RangeDataInserterTest : public ::testing::Test {
 
   void InsertPointCloud() {
     sensor::RangeData range_data;
-    range_data.returns.emplace_back(-3.5, 0.5, 0.f);
-    range_data.returns.emplace_back(-2.5, 1.5, 0.f);
-    range_data.returns.emplace_back(-1.5, 2.5, 0.f);
-    range_data.returns.emplace_back(-0.5, 3.5, 0.f);
-    range_data.origin.x() = -0.5;
-    range_data.origin.y() = 0.5;
+    range_data.returns.emplace_back(-3.5f, 0.5f, 0.f);
+    range_data.returns.emplace_back(-2.5f, 1.5f, 0.f);
+    range_data.returns.emplace_back(-1.5f, 2.5f, 0.f);
+    range_data.returns.emplace_back(-0.5f, 3.5f, 0.f);
+    range_data.origin.x() = -0.5f;
+    range_data.origin.y() = 0.5f;
     probability_grid_.StartUpdate();
     range_data_inserter_->Insert(range_data, &probability_grid_);
   }
@@ -81,19 +81,19 @@ TEST_F(RangeDataInserterTest, InsertPointCloud) {
        State::HIT}};
   for (int row = 0; row != 5; ++row) {
     for (int column = 0; column != 5; ++column) {
-      Eigen::Array2i xy_index(row, column);
-      EXPECT_TRUE(probability_grid_.limits().Contains(xy_index));
+      Eigen::Array2i cell_index(row, column);
+      EXPECT_TRUE(probability_grid_.limits().Contains(cell_index));
       switch (expected_states[column][row]) {
         case State::UNKNOWN:
-          EXPECT_FALSE(probability_grid_.IsKnown(xy_index));
+          EXPECT_FALSE(probability_grid_.IsKnown(cell_index));
           break;
         case State::MISS:
           EXPECT_NEAR(options_.miss_probability(),
-                      probability_grid_.GetProbability(xy_index), 1e-4);
+                      probability_grid_.GetProbability(cell_index), 1e-4);
           break;
         case State::HIT:
           EXPECT_NEAR(options_.hit_probability(),
-                      probability_grid_.GetProbability(xy_index), 1e-4);
+                      probability_grid_.GetProbability(cell_index), 1e-4);
           break;
       }
     }
@@ -102,18 +102,30 @@ TEST_F(RangeDataInserterTest, InsertPointCloud) {
 
 TEST_F(RangeDataInserterTest, ProbabilityProgression) {
   InsertPointCloud();
-  EXPECT_NEAR(options_.hit_probability(),
-              probability_grid_.GetProbability(-3.5, 0.5), 1e-4);
-  EXPECT_NEAR(options_.miss_probability(),
-              probability_grid_.GetProbability(-2.5, 0.5), 1e-4);
+  EXPECT_NEAR(
+      options_.hit_probability(),
+      probability_grid_.GetProbability(probability_grid_.limits().GetCellIndex(
+          Eigen::Vector2f(-3.5f, 0.5f))),
+      1e-4);
+  EXPECT_NEAR(
+      options_.miss_probability(),
+      probability_grid_.GetProbability(probability_grid_.limits().GetCellIndex(
+          Eigen::Vector2f(-2.5f, 0.5f))),
+      1e-4);
 
   for (int i = 0; i < 1000; ++i) {
     InsertPointCloud();
   }
-  EXPECT_NEAR(mapping::kMaxProbability,
-              probability_grid_.GetProbability(-3.5, 0.5), 1e-3);
-  EXPECT_NEAR(mapping::kMinProbability,
-              probability_grid_.GetProbability(-2.5, 0.5), 1e-3);
+  EXPECT_NEAR(
+      mapping::kMaxProbability,
+      probability_grid_.GetProbability(probability_grid_.limits().GetCellIndex(
+          Eigen::Vector2f(-3.5f, 0.5f))),
+      1e-3);
+  EXPECT_NEAR(
+      mapping::kMinProbability,
+      probability_grid_.GetProbability(probability_grid_.limits().GetCellIndex(
+          Eigen::Vector2f(-2.5f, 0.5f))),
+      1e-3);
 }
 
 }  // namespace

--- a/cartographer/mapping_2d/scan_matching/ceres_scan_matcher_test.cc
+++ b/cartographer/mapping_2d/scan_matching/ceres_scan_matcher_test.cc
@@ -37,7 +37,7 @@ class CeresScanMatcherTest : public ::testing::Test {
       : probability_grid_(
             MapLimits(1., Eigen::Vector2d(10., 10.), CellLimits(20, 20))) {
     probability_grid_.SetProbability(
-        probability_grid_.limits().GetXYIndexOfCellContainingPoint(-3.5, 2.5),
+        probability_grid_.limits().GetCellIndex(Eigen::Vector2f(-3.5f, 2.5f)),
         mapping::kMaxProbability);
 
     point_cloud_.emplace_back(-3.f, 2.f, 0.f);

--- a/cartographer/mapping_2d/scan_matching/correlative_scan_matcher.cc
+++ b/cartographer/mapping_2d/scan_matching/correlative_scan_matcher.cc
@@ -120,8 +120,7 @@ std::vector<DiscreteScan> DiscretizeScans(
       const Eigen::Vector2f translated_point =
           Eigen::Affine2f(initial_translation) * point.head<2>();
       discrete_scans.back().push_back(
-          map_limits.GetXYIndexOfCellContainingPoint(translated_point.x(),
-                                                     translated_point.y()));
+          map_limits.GetCellIndex(translated_point));
     }
   }
   return discrete_scans;

--- a/cartographer/sensor/range_data.cc
+++ b/cartographer/sensor/range_data.cc
@@ -48,14 +48,16 @@ proto::CompressedRangeData ToProto(
 
 CompressedRangeData FromProto(const proto::CompressedRangeData& proto) {
   return CompressedRangeData{
-      transform::ToEigen(proto.origin()), CompressedPointCloud(proto.returns()),
+      transform::ToEigen(proto.origin()),
+      CompressedPointCloud(proto.returns()),
       CompressedPointCloud(proto.misses()),
   };
 }
 
 CompressedRangeData Compress(const RangeData& range_data) {
   return CompressedRangeData{
-      range_data.origin, CompressedPointCloud(range_data.returns),
+      range_data.origin,
+      CompressedPointCloud(range_data.returns),
       CompressedPointCloud(range_data.misses),
   };
 }


### PR DESCRIPTION
This makes 2D more similar to 3D. GetProbability() only takes
cell indices which are computed using GetCellIndex().