### PR TITLE
Improve handling of grid updates.

### DIFF
--- a/cartographer/mapping_2d/proto/probability_grid.proto
+++ b/cartographer/mapping_2d/proto/probability_grid.proto
@@ -23,7 +23,6 @@ message ProbabilityGrid {
   // These values are actually int16s, but protos don't have a native int16
   // type.
   repeated int32 cells = 2;
-  repeated int32 update_indices = 3;
   optional int32 max_x = 4;
   optional int32 max_y = 5;
   optional int32 min_x = 6;

--- a/cartographer/mapping_2d/range_data_inserter.cc
+++ b/cartographer/mapping_2d/range_data_inserter.cc
@@ -53,11 +53,11 @@ RangeDataInserter::RangeDataInserter(
 
 void RangeDataInserter::Insert(const sensor::RangeData& range_data,
                                ProbabilityGrid* const probability_grid) const {
-  // By not starting a new update after hits are inserted, we give hits priority
+  // By not finishing the update after hits are inserted, we give hits priority
   // (i.e. no hits will be ignored because of a miss in the same cell).
-  CHECK_NOTNULL(probability_grid)->StartUpdate();
   CastRays(range_data, hit_table_, miss_table_, options_.insert_free_space(),
-           probability_grid);
+           CHECK_NOTNULL(probability_grid));
+  probability_grid->FinishUpdate();
 }
 
 }  // namespace mapping_2d

--- a/cartographer/mapping_2d/range_data_inserter_test.cc
+++ b/cartographer/mapping_2d/range_data_inserter_test.cc
@@ -51,8 +51,8 @@ class RangeDataInserterTest : public ::testing::Test {
     range_data.returns.emplace_back(-0.5f, 3.5f, 0.f);
     range_data.origin.x() = -0.5f;
     range_data.origin.y() = 0.5f;
-    probability_grid_.StartUpdate();
     range_data_inserter_->Insert(range_data, &probability_grid_);
+    probability_grid_.FinishUpdate();
   }
 
   ProbabilityGrid probability_grid_;

--- a/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher_test.cc
+++ b/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher_test.cc
@@ -41,7 +41,6 @@ TEST(PrecomputationGridTest, CorrectValues) {
   std::uniform_int_distribution<int> distribution(0, 255);
   ProbabilityGrid probability_grid(
       MapLimits(0.05, Eigen::Vector2d(5., 5.), CellLimits(250, 250)));
-  probability_grid.StartUpdate();
   for (const Eigen::Array2i& xy_index :
        XYIndexRangeIterator(Eigen::Array2i(50, 50), Eigen::Array2i(249, 249))) {
     probability_grid.SetProbability(
@@ -76,7 +75,6 @@ TEST(PrecomputationGridTest, TinyProbabilityGrid) {
   std::uniform_int_distribution<int> distribution(0, 255);
   ProbabilityGrid probability_grid(
       MapLimits(0.05, Eigen::Vector2d(0.1, 0.1), CellLimits(4, 4)));
-  probability_grid.StartUpdate();
   for (const Eigen::Array2i& xy_index :
        XYIndexRangeIterator(probability_grid.limits().cell_limits())) {
     probability_grid.SetProbability(
@@ -151,7 +149,6 @@ TEST(FastCorrelativeScanMatcherTest, CorrectPose) {
 
     ProbabilityGrid probability_grid(
         MapLimits(0.05, Eigen::Vector2d(5., 5.), CellLimits(200, 200)));
-    probability_grid.StartUpdate();
     range_data_inserter.Insert(
         sensor::RangeData{
             Eigen::Vector3f(expected_pose.translation().x(),
@@ -160,6 +157,7 @@ TEST(FastCorrelativeScanMatcherTest, CorrectPose) {
                 point_cloud, transform::Embed3D(expected_pose.cast<float>())),
             {}},
         &probability_grid);
+    probability_grid.FinishUpdate();
 
     FastCorrelativeScanMatcher fast_correlative_scan_matcher(probability_grid,
                                                              options);
@@ -204,7 +202,6 @@ TEST(FastCorrelativeScanMatcherTest, FullSubmapMatching) {
 
     ProbabilityGrid probability_grid(
         MapLimits(0.05, Eigen::Vector2d(5., 5.), CellLimits(200, 200)));
-    probability_grid.StartUpdate();
     range_data_inserter.Insert(
         sensor::RangeData{
             transform::Embed3D(expected_pose * perturbation).translation(),
@@ -212,6 +209,7 @@ TEST(FastCorrelativeScanMatcherTest, FullSubmapMatching) {
                                         transform::Embed3D(expected_pose)),
             {}},
         &probability_grid);
+    probability_grid.FinishUpdate();
 
     FastCorrelativeScanMatcher fast_correlative_scan_matcher(probability_grid,
                                                              options);

--- a/cartographer/mapping_2d/scan_matching/real_time_correlative_scan_matcher_test.cc
+++ b/cartographer/mapping_2d/scan_matching/real_time_correlative_scan_matcher_test.cc
@@ -55,10 +55,10 @@ class RealTimeCorrelativeScanMatcherTest : public ::testing::Test {
     point_cloud_.emplace_back(-0.125f, 0.125f, 0.f);
     point_cloud_.emplace_back(-0.125f, 0.075f, 0.f);
     point_cloud_.emplace_back(-0.125f, 0.025f, 0.f);
-    probability_grid_.StartUpdate();
     range_data_inserter_->Insert(
         sensor::RangeData{Eigen::Vector3f::Zero(), point_cloud_, {}},
         &probability_grid_);
+    probability_grid_.FinishUpdate();
     {
       auto parameter_dictionary = common::MakeDictionary(
           "return {"

--- a/cartographer/mapping_2d/submaps.cc
+++ b/cartographer/mapping_2d/submaps.cc
@@ -40,7 +40,6 @@ ProbabilityGrid ComputeCroppedProbabilityGrid(
       probability_grid.limits().max() -
       resolution * Eigen::Vector2d(offset.y(), offset.x());
   ProbabilityGrid cropped_grid(MapLimits(resolution, max, limits));
-  cropped_grid.StartUpdate();
   for (const Eigen::Array2i& xy_index : XYIndexRangeIterator(limits)) {
     if (probability_grid.IsKnown(xy_index + offset)) {
       cropped_grid.SetProbability(

--- a/cartographer/mapping_3d/hybrid_grid.h
+++ b/cartographer/mapping_3d/hybrid_grid.h
@@ -485,8 +485,8 @@ class HybridGrid : public HybridGridBase<uint16> {
     *mutable_value(index) = mapping::ProbabilityToValue(probability);
   }
 
-  // Starts the next update sequence.
-  void StartUpdate() {
+  // Finishes the update sequence.
+  void FinishUpdate() {
     while (!update_indices_.empty()) {
       DCHECK_GE(*update_indices_.back(), mapping::kUpdateMarker);
       *update_indices_.back() -= mapping::kUpdateMarker;
@@ -497,7 +497,7 @@ class HybridGrid : public HybridGridBase<uint16> {
   // Applies the 'odds' specified when calling ComputeLookupTableToApplyOdds()
   // to the probability of the cell at 'index' if the cell has not already been
   // updated. Multiple updates of the same cell will be ignored until
-  // StartUpdate() is called. Returns true if the cell was updated.
+  // FinishUpdate() is called. Returns true if the cell was updated.
   //
   // If this is the first call to ApplyOdds() for the specified cell, its value
   // will be set to probability corresponding to 'odds'.

--- a/cartographer/mapping_3d/hybrid_grid_test.cc
+++ b/cartographer/mapping_3d/hybrid_grid_test.cc
@@ -40,33 +40,32 @@ TEST(HybridGridTest, ApplyOdds) {
 
   hybrid_grid.SetProbability(Eigen::Array3i(1, 0, 1), 0.5f);
 
-  hybrid_grid.StartUpdate();
   hybrid_grid.ApplyLookupTable(
       Eigen::Array3i(1, 0, 1),
       mapping::ComputeLookupTableToApplyOdds(mapping::Odds(0.9f)));
+  hybrid_grid.FinishUpdate();
   EXPECT_GT(hybrid_grid.GetProbability(Eigen::Array3i(1, 0, 1)), 0.5f);
 
   hybrid_grid.SetProbability(Eigen::Array3i(0, 1, 0), 0.5f);
 
-  hybrid_grid.StartUpdate();
   hybrid_grid.ApplyLookupTable(
       Eigen::Array3i(0, 1, 0),
       mapping::ComputeLookupTableToApplyOdds(mapping::Odds(0.1f)));
+  hybrid_grid.FinishUpdate();
   EXPECT_LT(hybrid_grid.GetProbability(Eigen::Array3i(0, 1, 0)), 0.5f);
 
   // Tests adding odds to an unknown cell.
-  hybrid_grid.StartUpdate();
   hybrid_grid.ApplyLookupTable(
       Eigen::Array3i(1, 1, 1),
       mapping::ComputeLookupTableToApplyOdds(mapping::Odds(0.42f)));
   EXPECT_NEAR(hybrid_grid.GetProbability(Eigen::Array3i(1, 1, 1)), 0.42f, 1e-4);
 
-  // Tests that further updates are ignored if StartUpdate() isn't called.
+  // Tests that further updates are ignored if FinishUpdate() isn't called.
   hybrid_grid.ApplyLookupTable(
       Eigen::Array3i(1, 1, 1),
       mapping::ComputeLookupTableToApplyOdds(mapping::Odds(0.9f)));
   EXPECT_NEAR(hybrid_grid.GetProbability(Eigen::Array3i(1, 1, 1)), 0.42f, 1e-4);
-  hybrid_grid.StartUpdate();
+  hybrid_grid.FinishUpdate();
   hybrid_grid.ApplyLookupTable(
       Eigen::Array3i(1, 1, 1),
       mapping::ComputeLookupTableToApplyOdds(mapping::Odds(0.9f)));

--- a/cartographer/mapping_3d/range_data_inserter.cc
+++ b/cartographer/mapping_3d/range_data_inserter.cc
@@ -78,7 +78,7 @@ RangeDataInserter::RangeDataInserter(
 
 void RangeDataInserter::Insert(const sensor::RangeData& range_data,
                                HybridGrid* hybrid_grid) const {
-  CHECK_NOTNULL(hybrid_grid)->StartUpdate();
+  CHECK_NOTNULL(hybrid_grid);
 
   for (const Eigen::Vector3f& hit : range_data.returns) {
     const Eigen::Array3i hit_cell = hybrid_grid->GetCellIndex(hit);
@@ -89,6 +89,7 @@ void RangeDataInserter::Insert(const sensor::RangeData& range_data,
   // (i.e. no hits will be ignored because of a miss in the same cell).
   InsertMissesIntoGrid(miss_table_, range_data.origin, range_data.returns,
                        hybrid_grid, options_.num_free_space_voxels());
+  hybrid_grid->FinishUpdate();
 }
 
 }  // namespace mapping_3d

--- a/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher_test.cc
+++ b/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher_test.cc
@@ -88,13 +88,13 @@ TEST(FastCorrelativeScanMatcherTest, CorrectPose) {
             Eigen::AngleAxisf(theta, Eigen::Vector3f::UnitZ()));
 
     HybridGrid hybrid_grid(0.05f);
-    hybrid_grid.StartUpdate();
     range_data_inserter.Insert(
         sensor::RangeData{
             expected_pose.translation(),
             sensor::TransformPointCloud(point_cloud, expected_pose),
             {}},
         &hybrid_grid);
+    hybrid_grid.FinishUpdate();
 
     FastCorrelativeScanMatcher fast_correlative_scan_matcher(hybrid_grid, {},
                                                              options);


### PR DESCRIPTION
Changes the grids to only contain update markers during updates.
Serialized grids will never contain them.