### PR TITLE
Build relocatable code.

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -72,7 +72,7 @@ macro(google_initialize_cartographer_project)
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
   endif()
-  set(GOOG_CXX_FLAGS "-pthread -std=c++11 ${GOOG_CXX_FLAGS}")
+  set(GOOG_CXX_FLAGS "-pthread -std=c++11 -fPIC ${GOOG_CXX_FLAGS}")
 
   google_add_flag(GOOG_CXX_FLAGS "-Wall")
   google_add_flag(GOOG_CXX_FLAGS "-Wpedantic")


### PR DESCRIPTION
This is required to reuse code from cartographer_ros in cartographer_rviz. Otherwise linking fails with errors like these:

~~~
/usr/bin/ld: libcartographer_ros.a(msg_conversion.cc.o): relocation R_X86_64_32S against `_ZNSs4_Rep20_S_empty_rep_storageE' can not be use
d when making a shared object; recompile with -fPIC
~~~

While this could be fixed locally in cartographer_ros, it is a reasonable default to compile with `-fPIC` always.