### PR TITLE
Fix debug build

### DIFF
--- a/cartographer/io/hybrid_grid_points_processor.cc
+++ b/cartographer/io/hybrid_grid_points_processor.cc
@@ -61,6 +61,9 @@ PointsProcessor::FlushResult HybridGridPointsProcessor::Flush() {
       return FlushResult::kFinished;
   }
   LOG(FATAL) << "Failed to receive FlushResult::kFinished";
+  // The following unreachable return statement is needed to avoid a GCC bug
+  // described at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81508
+  return FlushResult::kFinished;
 }
 
 }  // namespace io


### PR DESCRIPTION
Add a fake return value after LOG(FATAL) in
HybridGridPointsProcessor::Flush(). This keeps gcc versions lower
than 7 happy when building without optimisation (i.e. debug build).
Fixes #412.