### PR TITLE
Draw Trajectories onto X-Rays and ProbabilityGrids.

### DIFF
--- a/cartographer/io/draw_trajectories.cc
+++ b/cartographer/io/draw_trajectories.cc
@@ -49,7 +49,7 @@ void DrawTrajectory(const mapping::proto::Trajectory& trajectory,
   {
     const Eigen::Array2i pixel =
         pose_to_pixel(transform::ToRigid3(trajectory.node(0).pose()));
-    cairo_set_source_rgba(cr.get(), 0., 255., 0., kAlpha);
+    cairo_set_source_rgba(cr.get(), 0., 1., 0., kAlpha);
     cairo_arc(cr.get(), pixel.x(), pixel.y(), kTrajectoryEndMarkers, 0,
               2 * M_PI);
     cairo_fill(cr.get());
@@ -57,7 +57,7 @@ void DrawTrajectory(const mapping::proto::Trajectory& trajectory,
   {
     const Eigen::Array2i pixel = pose_to_pixel(transform::ToRigid3(
         trajectory.node(trajectory.node_size() - 1).pose()));
-    cairo_set_source_rgba(cr.get(), 255., 0., 0., kAlpha);
+    cairo_set_source_rgba(cr.get(), 1., 0., 0., kAlpha);
     cairo_arc(cr.get(), pixel.x(), pixel.y(), kTrajectoryEndMarkers, 0,
               2 * M_PI);
     cairo_fill(cr.get());

--- a/cartographer/io/draw_trajectories.cc
+++ b/cartographer/io/draw_trajectories.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 The Cartographer Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cartographer/io/draw_trajectories.h"
+
+#include "cartographer/io/image.h"
+#include "cartographer/transform/transform.h"
+
+namespace cartographer {
+namespace io {
+
+void DrawTrajectory(const mapping::proto::Trajectory& trajectory,
+                    const Color& color, PoseToPixelFunction pose_to_pixel,
+                    cairo_surface_t* surface) {
+  if (trajectory.node_size() == 0) {
+    return;
+  }
+  constexpr double kTrajectoryWidth = 4.;
+  constexpr double kTrajectoryEndMarkers = 6.;
+
+  auto cr = ::cartographer::io::MakeUniqueCairoPtr(cairo_create(surface));
+
+  cairo_set_source_rgba(cr.get(), color[0] / 255., color[1] / 255.,
+                        color[2] / 255., 1.);
+  cairo_set_line_width(cr.get(), kTrajectoryWidth);
+
+  for (const auto& node : trajectory.node()) {
+    const Eigen::Array2i pixel =
+        pose_to_pixel(transform::ToRigid3(node.pose()));
+    cairo_line_to(cr.get(), pixel.x(), pixel.y());
+  }
+  cairo_stroke(cr.get());
+
+  // Draw beginning and end markers.
+  {
+    const Eigen::Array2i pixel =
+        pose_to_pixel(transform::ToRigid3(trajectory.node(0).pose()));
+    cairo_set_source_rgba(cr.get(), 0., 255., 0., 1.);
+    cairo_arc(cr.get(), pixel.x(), pixel.y(), kTrajectoryEndMarkers, 0,
+              2 * M_PI);
+    cairo_fill(cr.get());
+  }
+  {
+    const Eigen::Array2i pixel = pose_to_pixel(transform::ToRigid3(
+        trajectory.node(trajectory.node_size() - 1).pose()));
+    cairo_set_source_rgba(cr.get(), 255., 0., 0., 1.);
+    cairo_arc(cr.get(), pixel.x(), pixel.y(), kTrajectoryEndMarkers, 0,
+              2 * M_PI);
+    cairo_fill(cr.get());
+  }
+  cairo_surface_flush(surface);
+}
+
+}  // namespace io
+}  // namespace cartographer

--- a/cartographer/io/draw_trajectories.cc
+++ b/cartographer/io/draw_trajectories.cc
@@ -30,11 +30,12 @@ void DrawTrajectory(const mapping::proto::Trajectory& trajectory,
   }
   constexpr double kTrajectoryWidth = 4.;
   constexpr double kTrajectoryEndMarkers = 6.;
+  constexpr double kAlpha = 0.7;
 
   auto cr = ::cartographer::io::MakeUniqueCairoPtr(cairo_create(surface));
 
   cairo_set_source_rgba(cr.get(), color[0] / 255., color[1] / 255.,
-                        color[2] / 255., 1.);
+                        color[2] / 255., kAlpha);
   cairo_set_line_width(cr.get(), kTrajectoryWidth);
 
   for (const auto& node : trajectory.node()) {
@@ -48,7 +49,7 @@ void DrawTrajectory(const mapping::proto::Trajectory& trajectory,
   {
     const Eigen::Array2i pixel =
         pose_to_pixel(transform::ToRigid3(trajectory.node(0).pose()));
-    cairo_set_source_rgba(cr.get(), 0., 255., 0., 1.);
+    cairo_set_source_rgba(cr.get(), 0., 255., 0., kAlpha);
     cairo_arc(cr.get(), pixel.x(), pixel.y(), kTrajectoryEndMarkers, 0,
               2 * M_PI);
     cairo_fill(cr.get());
@@ -56,7 +57,7 @@ void DrawTrajectory(const mapping::proto::Trajectory& trajectory,
   {
     const Eigen::Array2i pixel = pose_to_pixel(transform::ToRigid3(
         trajectory.node(trajectory.node_size() - 1).pose()));
-    cairo_set_source_rgba(cr.get(), 255., 0., 0., 1.);
+    cairo_set_source_rgba(cr.get(), 255., 0., 0., kAlpha);
     cairo_arc(cr.get(), pixel.x(), pixel.y(), kTrajectoryEndMarkers, 0,
               2 * M_PI);
     cairo_fill(cr.get());

--- a/cartographer/io/draw_trajectories.h
+++ b/cartographer/io/draw_trajectories.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 The Cartographer Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CARTOGRAPHER_IO_DRAW_TRAJECTORIES_H_
+#define CARTOGRAPHER_IO_DRAW_TRAJECTORIES_H_
+
+#include "cairo/cairo.h"
+#include "cartographer/io/color.h"
+#include "cartographer/mapping/proto/trajectory.pb.h"
+#include "cartographer/transform/rigid_transform.h"
+
+namespace cartographer {
+namespace io {
+
+using PoseToPixelFunction =
+    std::function<Eigen::Array2i(const transform::Rigid3d& pose)>;
+
+// Draws the 'trajectory' with the given 'color' onto 'surface'. The
+// 'pose_to_pixel' function must translate a trajectory node's position into the
+// pixel on 'surface'.
+void DrawTrajectory(const mapping::proto::Trajectory& trajectory,
+                    const Color& color, PoseToPixelFunction pose_to_pixel,
+                    cairo_surface_t* surface);
+
+}  // namespace io
+}  // namespace cartographer
+
+#endif  // CARTOGRAPHER_IO_DRAW_TRAJECTORIES_H_

--- a/cartographer/io/image.h
+++ b/cartographer/io/image.h
@@ -33,13 +33,13 @@ class Image {
   void SetPixel(int x, int y, const Color& color);
   void WritePng(FileWriter* const file_writer);
 
- private:
   // Returns a pointer to a cairo surface that contains the current pixel data.
   // The 'Image' object must therefore outlive the returned surface object. It
   // is undefined behavior to call any of the mutating functions while a pointer
   // to this surface is alive.
   UniqueCairoSurfacePtr GetCairoSurface();
 
+ private:
   int width_;
   int height_;
   int stride_;

--- a/cartographer/io/points_processor_pipeline_builder.h
+++ b/cartographer/io/points_processor_pipeline_builder.h
@@ -61,7 +61,7 @@ class PointsProcessorPipelineBuilder {
 // Register all 'PointsProcessor' that ship with Cartographer with this
 // 'builder'.
 void RegisterBuiltInPointsProcessors(
-    const mapping::proto::Trajectory& trajectory,
+    const std::vector<mapping::proto::Trajectory>& trajectories,
     FileWriterFactory file_writer_factory,
     PointsProcessorPipelineBuilder* builder);
 

--- a/cartographer/io/probability_grid_points_processor.h
+++ b/cartographer/io/probability_grid_points_processor.h
@@ -7,6 +7,7 @@
 #include "cartographer/io/file_writer.h"
 #include "cartographer/io/points_batch.h"
 #include "cartographer/io/points_processor.h"
+#include "cartographer/mapping/proto/trajectory.pb.h"
 #include "cartographer/mapping_2d/probability_grid.h"
 #include "cartographer/mapping_2d/proto/range_data_inserter_options.pb.h"
 #include "cartographer/mapping_2d/range_data_inserter.h"
@@ -22,17 +23,22 @@ class ProbabilityGridPointsProcessor : public PointsProcessor {
  public:
   constexpr static const char* kConfigurationFileActionName =
       "write_probability_grid";
+  enum class DrawTrajectories { kNo, kYes };
   ProbabilityGridPointsProcessor(
       double resolution,
       const mapping_2d::proto::RangeDataInserterOptions&
           range_data_inserter_options,
-      std::unique_ptr<FileWriter> file_writer, PointsProcessor* next);
+      const DrawTrajectories& draw_trajectories,
+      std::unique_ptr<FileWriter> file_writer,
+      const std::vector<mapping::proto::Trajectory>& trajectorios,
+      PointsProcessor* next);
   ProbabilityGridPointsProcessor(const ProbabilityGridPointsProcessor&) =
       delete;
   ProbabilityGridPointsProcessor& operator=(
       const ProbabilityGridPointsProcessor&) = delete;
 
   static std::unique_ptr<ProbabilityGridPointsProcessor> FromDictionary(
+      const std::vector<mapping::proto::Trajectory>& trajectories,
       FileWriterFactory file_writer_factory,
       common::LuaParameterDictionary* dictionary, PointsProcessor* next);
 
@@ -42,8 +48,10 @@ class ProbabilityGridPointsProcessor : public PointsProcessor {
   FlushResult Flush() override;
 
  private:
-  PointsProcessor* const next_;
+  const DrawTrajectories draw_trajectories_;
+  const std::vector<mapping::proto::Trajectory> trajectories_;
   std::unique_ptr<FileWriter> file_writer_;
+  PointsProcessor* const next_;
   mapping_2d::RangeDataInserter range_data_inserter_;
   mapping_2d::ProbabilityGrid probability_grid_;
 };

--- a/cartographer/io/xray_points_processor.h
+++ b/cartographer/io/xray_points_processor.h
@@ -36,14 +36,16 @@ class XRayPointsProcessor : public PointsProcessor {
  public:
   constexpr static const char* kConfigurationFileActionName =
       "write_xray_image";
-  XRayPointsProcessor(double voxel_size, const transform::Rigid3f& transform,
-                      const std::vector<mapping::Floor>& floors,
-                      const string& output_filename,
-                      FileWriterFactory file_writer_factory,
-                      PointsProcessor* next);
+  enum class DrawTrajectories { kNo, kYes };
+  XRayPointsProcessor(
+      double voxel_size, const transform::Rigid3f& transform,
+      const std::vector<mapping::Floor>& floors,
+      const DrawTrajectories& draw_trajectories, const string& output_filename,
+      const std::vector<mapping::proto::Trajectory>& trajectories,
+      FileWriterFactory file_writer_factory, PointsProcessor* next);
 
   static std::unique_ptr<XRayPointsProcessor> FromDictionary(
-      const mapping::proto::Trajectory& trajectory,
+      const std::vector<mapping::proto::Trajectory>& trajectories,
       FileWriterFactory file_writer_factory,
       common::LuaParameterDictionary* dictionary, PointsProcessor* next);
 
@@ -71,8 +73,10 @@ class XRayPointsProcessor : public PointsProcessor {
                    FileWriter* const file_writer);
   void Insert(const PointsBatch& batch, Aggregation* aggregation);
 
-  PointsProcessor* const next_;
+  const DrawTrajectories draw_trajectories_;
+  const std::vector<mapping::proto::Trajectory> trajectories_;
   FileWriterFactory file_writer_factory_;
+  PointsProcessor* const next_;
 
   // If empty, we do not separate into floors.
   std::vector<mapping::Floor> floors_;


### PR DESCRIPTION
This behavior can be turned off with the 'draw_trajectories' setting in Lua.

Fixes #174.