### PR TITLE
rate_timer.h allow user specified pulse time

### DIFF
--- a/cartographer/common/rate_timer.h
+++ b/cartographer/common/rate_timer.h
@@ -68,8 +68,8 @@ class RateTimer {
   }
 
   // Records an event that will contribute to the computed rate.
-  void Pulse(common::Time time) {
-    events_.push_back(Event{time, ClockType::now()});
+  void Pulse(common::Time time, typename ClockType::time_point compare_time = ClockType::now()) {
+    events_.push_back(Event{time, compare_time});
     while (events_.size() > 2 &&
            (events_.back().wall_time - events_.front().wall_time) >
                window_duration_) {


### PR DESCRIPTION
I want to collect my second "pulse" time from a source other than the current time on the local clock, this change defaults to the current behavior but allows the user to specify their own time.

With the default behavior this also has the convenient side effect of collecting the time before starting the function call.