### PR TITLE
color.cc constexpr std::sqrt is not ISO C++

### DIFF
--- a/cartographer/io/color.cc
+++ b/cartographer/io/color.cc
@@ -29,7 +29,6 @@ namespace {
 constexpr float kInitialHue = 0.69f;
 constexpr float kSaturation = 0.85f;
 constexpr float kValue = 0.77f;
-constexpr float kGoldenRatioConjugate = (std::sqrt(5.f) - 1.f) / 2.f;
 
 Color CreateRgba(const float r, const float g, const float b) {
   return Color{{static_cast<uint8_t>(common::RoundToInt(r * 255.)),
@@ -69,6 +68,7 @@ Color GetColor(int id) {
   CHECK_GE(id, 0);
   // Uniform color sampling using the golden ratio from
   // http://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/
+  float kGoldenRatioConjugate = (std::sqrt(5.f) - 1.f) / 2.f;
   const float hue = std::fmod(kInitialHue + kGoldenRatioConjugate * id, 1.f);
   return HsvToRgb(hue, kSaturation, kValue);
 }

--- a/cartographer/io/color.cc
+++ b/cartographer/io/color.cc
@@ -68,7 +68,7 @@ Color GetColor(int id) {
   CHECK_GE(id, 0);
   // Uniform color sampling using the golden ratio from
   // http://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/
-  const float kGoldenRatioConjugate = (std::sqrt(5.f) - 1.f) / 2.f;
+  static const float kGoldenRatioConjugate = 0.6180339887498949f;
   const float hue = std::fmod(kInitialHue + kGoldenRatioConjugate * id, 1.f);
   return HsvToRgb(hue, kSaturation, kValue);
 }

--- a/cartographer/io/color.cc
+++ b/cartographer/io/color.cc
@@ -68,7 +68,7 @@ Color GetColor(int id) {
   CHECK_GE(id, 0);
   // Uniform color sampling using the golden ratio from
   // http://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/
-  float kGoldenRatioConjugate = (std::sqrt(5.f) - 1.f) / 2.f;
+  const float kGoldenRatioConjugate = (std::sqrt(5.f) - 1.f) / 2.f;
   const float hue = std::fmod(kInitialHue + kGoldenRatioConjugate * id, 1.f);
   return HsvToRgb(hue, kSaturation, kValue);
 }

--- a/cartographer/io/color.cc
+++ b/cartographer/io/color.cc
@@ -68,7 +68,7 @@ Color GetColor(int id) {
   CHECK_GE(id, 0);
   // Uniform color sampling using the golden ratio from
   // http://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/
-  static const float kGoldenRatioConjugate = 0.6180339887498949f;
+  constexpr float kGoldenRatioConjugate = 0.6180339887498949f;
   const float hue = std::fmod(kInitialHue + kGoldenRatioConjugate * id, 1.f);
   return HsvToRgb(hue, kSaturation, kValue);
 }


### PR DESCRIPTION
```
Semantic Issue Group
/Users/athundt/source/cartographer/cartographer/io/color.cc:32:17: Constexpr variable 'kGoldenRatioConjugate' must be initialized by a constant expression
```

https://stackoverflow.com/questions/8622256/in-c11-is-sqrt-defined-as-constexpr