### PR TITLE
Estimate angular velocities from odometry.

### DIFF
--- a/cartographer/mapping/pose_extrapolator.h
+++ b/cartographer/mapping/pose_extrapolator.h
@@ -81,6 +81,7 @@ class PoseExtrapolator {
 
   std::deque<sensor::OdometryData> odometry_data_;
   Eigen::Vector3d linear_velocity_from_odometry_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d angular_velocity_from_odometry_ = Eigen::Vector3d::Zero();
 };
 
 }  // namespace mapping


### PR DESCRIPTION
If no IMU is available we will now use odometry to estimate
angular velocities if available instead of the last poses.

Fixes #453.