### PR TITLE
Custom constraints

### DIFF
--- a/cartographer/mapping/proto/sparse_pose_graph.proto
+++ b/cartographer/mapping/proto/sparse_pose_graph.proto
@@ -37,7 +37,7 @@ message SparsePoseGraph {
     enum Tag {
       INTRA_SUBMAP = 0;
       INTER_SUBMAP = 1;
-      MANUAL = 2;
+      CUSTOM = 2;
     }
 
     optional SubmapId submap_id = 1;  // Submap ID.

--- a/cartographer/mapping/proto/sparse_pose_graph.proto
+++ b/cartographer/mapping/proto/sparse_pose_graph.proto
@@ -37,6 +37,7 @@ message SparsePoseGraph {
     enum Tag {
       INTRA_SUBMAP = 0;
       INTER_SUBMAP = 1;
+      MANUAL = 2;
     }
 
     optional SubmapId submap_id = 1;  // Submap ID.

--- a/cartographer/mapping/sparse_pose_graph.cc
+++ b/cartographer/mapping/sparse_pose_graph.cc
@@ -44,6 +44,8 @@ SparsePoseGraph::Constraint::Tag FromProto(
       return SparsePoseGraph::Constraint::Tag::INTRA_SUBMAP;
     case proto::SparsePoseGraph::Constraint::INTER_SUBMAP:
       return SparsePoseGraph::Constraint::Tag::INTER_SUBMAP;
+    case proto::SparsePoseGraph::Constraint::CUSTOM:
+      return SparsePoseGraph::Constraint::Tag::CUSTOM;
   }
   LOG(FATAL) << "Unsupported tag.";
 }

--- a/cartographer/mapping/sparse_pose_graph.cc
+++ b/cartographer/mapping/sparse_pose_graph.cc
@@ -31,6 +31,8 @@ proto::SparsePoseGraph::Constraint::Tag ToProto(
       return proto::SparsePoseGraph::Constraint::INTRA_SUBMAP;
     case SparsePoseGraph::Constraint::Tag::INTER_SUBMAP:
       return proto::SparsePoseGraph::Constraint::INTER_SUBMAP;
+    case SparsePoseGraph::Constraint::Tag::MANUAL:
+      return proto::SparsePoseGraph::Constraint::MANUAL;
   }
   LOG(FATAL) << "Unsupported tag.";
 }

--- a/cartographer/mapping/sparse_pose_graph.cc
+++ b/cartographer/mapping/sparse_pose_graph.cc
@@ -31,8 +31,8 @@ proto::SparsePoseGraph::Constraint::Tag ToProto(
       return proto::SparsePoseGraph::Constraint::INTRA_SUBMAP;
     case SparsePoseGraph::Constraint::Tag::INTER_SUBMAP:
       return proto::SparsePoseGraph::Constraint::INTER_SUBMAP;
-    case SparsePoseGraph::Constraint::Tag::MANUAL:
-      return proto::SparsePoseGraph::Constraint::MANUAL;
+    case SparsePoseGraph::Constraint::Tag::CUSTOM:
+      return proto::SparsePoseGraph::Constraint::CUSTOM;
   }
   LOG(FATAL) << "Unsupported tag.";
 }

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -62,7 +62,7 @@ class SparsePoseGraph {
     // Differentiates between intra-submap (where scan 'j' was inserted into
     // submap 'i') and inter-submap constraints (where scan 'j' was not inserted
     // into submap 'i').
-    enum Tag { INTRA_SUBMAP, INTER_SUBMAP, MANUAL } tag;
+    enum Tag { INTRA_SUBMAP, INTER_SUBMAP, CUSTOM } tag;
   };
 
   struct SubmapData {
@@ -116,11 +116,11 @@ class SparsePoseGraph {
   // included in the pose graph.
   virtual void AddTrimmer(std::unique_ptr<PoseGraphTrimmer> trimmer) = 0;
 
-  // Add and remove manual constraints to/from the pose graph.
-  virtual void AddManualConstraint(const mapping::NodeId& node_id,
+  // Add and remove custom constraints to/from the pose graph.
+  virtual void AddCustomConstraint(const mapping::NodeId& node_id,
                                    const mapping::SubmapId& submap_id,
                                    const Constraint::Pose& pose) = 0;
-  virtual void RemoveManualConstraint(const mapping::NodeId& node_id,
+  virtual void RemoveCustomConstraint(const mapping::NodeId& node_id,
                                       const mapping::SubmapId& submap_id) = 0;
 
   // Computes optimized poses.

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -153,6 +153,8 @@ class SparsePoseGraph {
                                         int to_trajectory_id,
                                         const transform::Rigid3d& pose,
                                         const common::Time time) = 0;
+
+  virtual void UpdateManualConstraint(mapping::NodeId node_id, transform::Rigid3d pose) = 0;
 };
 
 std::vector<SparsePoseGraph::Constraint> FromProto(

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -116,6 +116,11 @@ class SparsePoseGraph {
   // included in the pose graph.
   virtual void AddTrimmer(std::unique_ptr<PoseGraphTrimmer> trimmer) = 0;
 
+  // Adds a manual constraint to the pose graph.
+  virtual void AddManualConstraint(const mapping::NodeId& node_id,
+                                   const mapping::SubmapId& submap_id,
+                                   const Constraint::Pose& pose) = 0;
+
   // Computes optimized poses.
   virtual void RunFinalOptimization() = 0;
 

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -153,8 +153,6 @@ class SparsePoseGraph {
                                         int to_trajectory_id,
                                         const transform::Rigid3d& pose,
                                         const common::Time time) = 0;
-
-  virtual void UpdateManualConstraint(mapping::NodeId node_id, transform::Rigid3d pose) = 0;
 };
 
 std::vector<SparsePoseGraph::Constraint> FromProto(

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -62,7 +62,7 @@ class SparsePoseGraph {
     // Differentiates between intra-submap (where scan 'j' was inserted into
     // submap 'i') and inter-submap constraints (where scan 'j' was not inserted
     // into submap 'i').
-    enum Tag { INTRA_SUBMAP, INTER_SUBMAP } tag;
+    enum Tag { INTRA_SUBMAP, INTER_SUBMAP, MANUAL } tag;
   };
 
   struct SubmapData {

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -116,10 +116,12 @@ class SparsePoseGraph {
   // included in the pose graph.
   virtual void AddTrimmer(std::unique_ptr<PoseGraphTrimmer> trimmer) = 0;
 
-  // Adds a manual constraint to the pose graph.
+  // Add and remove manual constraints to/from the pose graph.
   virtual void AddManualConstraint(const mapping::NodeId& node_id,
                                    const mapping::SubmapId& submap_id,
                                    const Constraint::Pose& pose) = 0;
+  virtual void RemoveManualConstraint(const mapping::NodeId& node_id,
+                                      const mapping::SubmapId& submap_id) = 0;
 
   // Computes optimized poses.
   virtual void RunFinalOptimization() = 0;

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -333,15 +333,11 @@ void SparsePoseGraph::AddCustomConstraint(const mapping::NodeId& node_id,
   common::MutexLocker locker(&mutex_);
   AddPriorityWorkItem([=]() REQUIRES(mutex_) {
     // Do not allow adding custom constraints for trimmed nodes and submaps.
-    if (node_id.trajectory_id < trajectory_nodes_.num_trajectories() &&
-        node_id.node_index <
-            trajectory_nodes_.num_indices(node_id.trajectory_id)) {
-      CHECK(!trajectory_nodes_.at(node_id).trimmed());
+    if (trajectory_nodes_.Contains(node_id)) {
+      CHECK(trajectory_nodes_.at(node_id).constant_data != nullptr);
     }
-    if (submap_id.trajectory_id < submap_data_.num_trajectories() &&
-        submap_id.submap_index <
-            submap_data_.num_indices(submap_id.trajectory_id)) {
-      CHECK(submap_data_.at(submap_id).state != SubmapState::kTrimmed);
+    if (submap_data_.Contains(submap_id)) {
+      CHECK(submap_data_.at(submap_id).submap != nullptr);
     }
     const auto gravity_aligned_pose =
         pose.zbar_ij * cartographer::transform::Rigid3d::Rotation(

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -229,6 +229,7 @@ void SparsePoseGraph::ComputeConstraintsForScan(
     const mapping::NodeId& node_id,
     std::vector<std::shared_ptr<const Submap>> insertion_submaps,
     const bool newly_finished_submap) {
+  CHECK(!run_loop_closure_);
   const auto& constant_data = trajectory_nodes_.at(node_id).constant_data;
   const std::vector<mapping::SubmapId> submap_ids = InitializeGlobalSubmapPoses(
       node_id.trajectory_id, constant_data->time, insertion_submaps);
@@ -290,7 +291,6 @@ void SparsePoseGraph::ComputeConstraintsForScan(
 }
 
 void SparsePoseGraph::DispatchOptimization() {
-  CHECK(!run_loop_closure_);
   run_loop_closure_ = true;
   // If there is a 'work_queue_' already, some other thread will take care.
   if (work_queue_ == nullptr) {
@@ -309,6 +309,7 @@ void SparsePoseGraph::AddManualConstraint(const mapping::NodeId& node_id,
   common::MutexLocker locker(&mutex_);
   AddWorkItem([=]() REQUIRES(mutex_) {
     InsertManualConstraint(node_id, submap_id, pose);
+    CHECK(!run_loop_closure_);
     DispatchOptimization();
   });
 }

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -583,14 +583,19 @@ void SparsePoseGraph::AddTrimmer(
 }
 
 void SparsePoseGraph::RunFinalOptimization() {
+  {
+    common::MutexLocker locker(&mutex_);
+    AddWorkItem([this]() REQUIRES(mutex_) {
+      optimization_problem_.SetMaxNumIterations(
+          options_.max_num_final_iterations());
+      DispatchOptimization();
+    });
+  }
   WaitForAllComputations();
-  optimization_problem_.SetMaxNumIterations(
-      options_.max_num_final_iterations());
-  RunOptimization();
-  optimization_problem_.SetMaxNumIterations(
+  /*optimization_problem_.SetMaxNumIterations(
       options_.optimization_problem_options()
           .ceres_solver_options()
-          .max_num_iterations());
+          .max_num_iterations());*/
 }
 
 void SparsePoseGraph::RunOptimization() {

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -448,7 +448,7 @@ void SparsePoseGraph::WaitForAllComputations() {
   while (!locker.AwaitWithTimeout(
       [this]() REQUIRES(mutex_) {
         return constraint_builder_.GetNumFinishedScans() ==
-               num_trajectory_nodes_;
+               num_trajectory_nodes_ && work_queue_ == nullptr;
       },
       common::FromSeconds(1.))) {
     std::ostringstream progress_info;

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -74,7 +74,8 @@ std::vector<mapping::SubmapId> SparsePoseGraph::InitializeGlobalSubmapPoses(
     CHECK_EQ(1, submap_data.SizeOfTrajectoryOrZero(trajectory_id));
     const mapping::SubmapId submap_id{trajectory_id, 0};
     CHECK(submap_data_.at(submap_id).submap == insertion_submaps.front());
-    if (optimization_problem_.missing_submaps().count(submap_id)) {
+    if (optimization_problem_.missing_submaps().count(submap_id) &&
+        num_priority_work_items_ == 0) {
       DispatchOptimization();
     }
     return {submap_id};
@@ -448,7 +449,8 @@ void SparsePoseGraph::WaitForAllComputations() {
   while (!locker.AwaitWithTimeout(
       [this]() REQUIRES(mutex_) {
         return constraint_builder_.GetNumFinishedScans() ==
-               num_trajectory_nodes_ && work_queue_ == nullptr;
+                   num_trajectory_nodes_ &&
+               work_queue_ == nullptr;
       },
       common::FromSeconds(1.))) {
     std::ostringstream progress_info;

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -302,13 +302,16 @@ void SparsePoseGraph::UpdateManualConstraint(mapping::NodeId node_id,
 
 void SparsePoseGraph::InsertManualConstraint(
     const ManualConstraint manual_constraint) {
-  constraints_.push_back(Constraint{
-      mapping::SubmapId{0, 0},
-      manual_constraint.node_id,
-      {manual_constraint.pose,
-       options_.constraint_builder_options().loop_closure_translation_weight(),
-       options_.constraint_builder_options().loop_closure_rotation_weight()},
-      Constraint::MANUAL});
+  constraints_.push_back(Constraint{mapping::SubmapId{0, 0},
+                                    manual_constraint.node_id,
+                                    {manual_constraint.pose,
+                                     10 *
+                                         options_.constraint_builder_options()
+                                             .loop_closure_translation_weight(),
+                                     10 *
+                                         options_.constraint_builder_options()
+                                             .loop_closure_rotation_weight()},
+                                    Constraint::MANUAL});
 }
 
 bool SparsePoseGraph::ScheduleOrPerformManualConstraintInsertion(

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -302,9 +302,14 @@ void SparsePoseGraph::UpdateManualConstraint(mapping::NodeId node_id,
 
 void SparsePoseGraph::InsertManualConstraint(
     const ManualConstraint manual_constraint) {
+  const auto gravity_aligned_pose =
+      manual_constraint.pose *
+      cartographer::transform::Rigid3d::Rotation(
+          trajectory_nodes_.at(manual_constraint.node_id)
+              .constant_data->gravity_alignment.inverse());
   constraints_.push_back(Constraint{mapping::SubmapId{0, 0},
                                     manual_constraint.node_id,
-                                    {manual_constraint.pose,
+                                    {gravity_aligned_pose,
                                      10 *
                                          options_.constraint_builder_options()
                                              .loop_closure_translation_weight(),

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -372,7 +372,8 @@ void SparsePoseGraph::RemoveCustomConstraint(
                          return constraint.node_id == node_id &&
                                 constraint.submap_id == submap_id &&
                                 constraint.tag == Constraint::Tag::CUSTOM;
-                       }));
+                       }),
+        constraints_.end());
 
     CHECK(!run_loop_closure_);
     if (num_priority_work_items_ == 1) {

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -164,7 +164,10 @@ void SparsePoseGraph::AddPriorityWorkItem(
     const std::function<void()>& work_item) {
   if (work_queue_ == nullptr) {
     CHECK_EQ(num_priority_work_items_, 0);
+    ++num_priority_work_items_;
     work_item();
+    --num_priority_work_items_;
+    CHECK_EQ(num_priority_work_items_, 0);
   } else {
     CHECK_GE(num_priority_work_items_, 0);
     CHECK_LE(num_priority_work_items_, work_queue_->size());

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -740,9 +740,10 @@ mapping::SparsePoseGraph::SubmapData SparsePoseGraph::GetSubmapDataUnderLock(
                 optimized_submap_transforms_.at(submap_id).global_pose)};
   }
   // We have to extrapolate.
-  return {submap, ComputeLocalToGlobalTransform(optimized_submap_transforms_,
-                                                submap_id.trajectory_id) *
-                      submap->local_pose()};
+  return {submap,
+          ComputeLocalToGlobalTransform(optimized_submap_transforms_,
+                                        submap_id.trajectory_id) *
+              submap->local_pose()};
 }
 
 SparsePoseGraph::TrimmingHandle::TrimmingHandle(SparsePoseGraph* const parent)

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -85,6 +85,10 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
       const sensor::FixedFramePoseData& fixed_frame_pose_data);
 
   void FinishTrajectory(int trajectory_id) override;
+
+  virtual void AddManualConstraint(const mapping::NodeId& node_id,
+                                   const mapping::SubmapId& submap_id,
+                                   const Constraint::Pose& pose) override;
   void FreezeTrajectory(int trajectory_id) override;
   void AddSubmapFromProto(const transform::Rigid3d& global_submap_pose,
                           const mapping::proto::Submap& submap) override;
@@ -208,6 +212,13 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
 
   // Whether the optimization has to be run before more data is added.
   bool run_loop_closure_ GUARDED_BY(mutex_) = false;
+
+  // Schedules optimization (i.e. loop closure) to run.
+  void DispatchOptimization();
+
+  void InsertManualConstraint(const mapping::NodeId& node_id,
+                              const mapping::SubmapId& submap_id,
+                              const Constraint::Pose& pose);
 
   // Current optimization problem.
   sparse_pose_graph::OptimizationProblem optimization_problem_;

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -140,6 +140,9 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   // Adds connectivity and sampler for a trajectory if it does not exist.
   void AddTrajectoryIfNeeded(int trajectory_id) REQUIRES(mutex_);
 
+  void AddPriorityWorkItem(const std::function<void()>& work_item)
+      REQUIRES(mutex_);
+
   // Grows the optimization problem to have an entry for every element of
   // 'insertion_submaps'. Returns the IDs for the 'insertion_submaps'.
   std::vector<mapping::SubmapId> InitializeGlobalSubmapPoses(
@@ -199,6 +202,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   // considered later.
   std::unique_ptr<std::deque<std::function<void()>>> work_queue_
       GUARDED_BY(mutex_);
+
+  int num_priority_work_items_ GUARDED_BY(mutex_) = 0;
 
   // How our various trajectories are related.
   mapping::TrajectoryConnectivityState trajectory_connectivity_state_;

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -223,7 +223,7 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   bool run_loop_closure_ GUARDED_BY(mutex_) = false;
 
   // Schedules optimization (i.e. loop closure) to run.
-  void DispatchOptimization();
+  void DispatchOptimization() REQUIRES(mutex_);
 
   // Current optimization problem.
   sparse_pose_graph::OptimizationProblem optimization_problem_;

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -86,11 +86,12 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
 
   void FinishTrajectory(int trajectory_id) override;
 
-  virtual void AddManualConstraint(const mapping::NodeId& node_id,
+  virtual void AddCustomConstraint(const mapping::NodeId& node_id,
                                    const mapping::SubmapId& submap_id,
                                    const Constraint::Pose& pose) override;
-  virtual void RemoveManualConstraint(const mapping::NodeId& node_id,
-                                   const mapping::SubmapId& submap_id) override;
+  virtual void RemoveCustomConstraint(
+      const mapping::NodeId& node_id,
+      const mapping::SubmapId& submap_id) override;
 
   void FreezeTrajectory(int trajectory_id) override;
   void AddSubmapFromProto(const transform::Rigid3d& global_submap_pose,
@@ -223,12 +224,6 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
 
   // Schedules optimization (i.e. loop closure) to run.
   void DispatchOptimization();
-
-  void InsertManualConstraint(const mapping::NodeId& node_id,
-                              const mapping::SubmapId& submap_id,
-                              const Constraint::Pose& pose);
-  void DeleteManualConstraint(const mapping::NodeId& node_id,
-                              const mapping::SubmapId& submap_id);
 
   // Current optimization problem.
   sparse_pose_graph::OptimizationProblem optimization_problem_;

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -89,6 +89,9 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   virtual void AddManualConstraint(const mapping::NodeId& node_id,
                                    const mapping::SubmapId& submap_id,
                                    const Constraint::Pose& pose) override;
+  virtual void RemoveManualConstraint(const mapping::NodeId& node_id,
+                                   const mapping::SubmapId& submap_id) override;
+
   void FreezeTrajectory(int trajectory_id) override;
   void AddSubmapFromProto(const transform::Rigid3d& global_submap_pose,
                           const mapping::proto::Submap& submap) override;
@@ -224,6 +227,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   void InsertManualConstraint(const mapping::NodeId& node_id,
                               const mapping::SubmapId& submap_id,
                               const Constraint::Pose& pose);
+  void DeleteManualConstraint(const mapping::NodeId& node_id,
+                              const mapping::SubmapId& submap_id);
 
   // Current optimization problem.
   sparse_pose_graph::OptimizationProblem optimization_problem_;

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -25,7 +25,6 @@
 #include <set>
 #include <unordered_map>
 #include <vector>
-#include <deque>
 
 #include "Eigen/Core"
 #include "Eigen/Geometry"
@@ -114,11 +113,6 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
       EXCLUDES(mutex_);
   transform::Rigid3d GetInterpolatedGlobalTrajectoryPose(
       int trajectory_id, const common::Time time) const REQUIRES(mutex_);
-
-  // Adds a manual constraint into the optimization problem.
-  void UpdateManualConstraint(
-      mapping::NodeId node_id, transform::Rigid3d pose) override;
-
 
  private:
   // The current state of the submap in the background threads. When this
@@ -214,19 +208,6 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
 
   // Whether the optimization has to be run before more data is added.
   bool run_loop_closure_ GUARDED_BY(mutex_) = false;
-
-  // Schedules optimization (i.e. loop closure) to run.
-  void DispatchOptimization();
-
-  struct ManualConstraint {
-    mapping::NodeId node_id;
-    transform::Rigid3d pose;
-  };
-
-  std::deque<ManualConstraint> manual_constraint_queue_ GUARDED_BY(mutex_) ;
-
-  bool ScheduleOrPerformManualConstraintInsertion(bool schedule);
-  void InsertManualConstraint(ManualConstraint manual_constraint);
 
   // Current optimization problem.
   sparse_pose_graph::OptimizationProblem optimization_problem_;

--- a/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
@@ -159,20 +159,14 @@ void OptimizationProblem::Solve(const std::vector<Constraint>& constraints,
   for (const Constraint& constraint : constraints) {
     // Check if the constraint refers to something that has not yet been
     // added to the optimization problem. Skip it if that is the case.
-    if (constraint.node_id.trajectory_id >=
-            static_cast<int>(node_data_.size()) ||
-        node_data_.at(constraint.node_id.trajectory_id)
-                .count(constraint.node_id.node_index) == 0) {
+    if (!node_data_.Contains(constraint.node_id)) {
       // It should not happen that prematurely added constraints
       // happen to be intra or inter submap constraints.
       CHECK(constraint.tag == Constraint::Tag::CUSTOM);
       missing_nodes_.insert(constraint.node_id);
       continue;
     }
-    if (constraint.submap_id.trajectory_id >=
-            static_cast<int>(submap_data_.size()) ||
-        submap_data_.at(constraint.submap_id.trajectory_id)
-                .count(constraint.submap_id.submap_index) == 0) {
+    if (!submap_data_.Contains(constraint.submap_id)) {
       CHECK(constraint.tag == Constraint::Tag::CUSTOM);
       missing_submaps_.insert(constraint.submap_id);
       continue;

--- a/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
@@ -153,6 +153,8 @@ void OptimizationProblem::Solve(const std::vector<Constraint>& constraints,
       problem.SetParameterBlockConstant(C_nodes.at(node_id_data.id).data());
     }
   }
+  missing_nodes_.clear();
+  missing_submaps_.clear();
   // Add cost functions for intra- and inter-submap constraints.
   for (const Constraint& constraint : constraints) {
     // Check if the constraint refers to something that has not yet been
@@ -164,6 +166,7 @@ void OptimizationProblem::Solve(const std::vector<Constraint>& constraints,
       // It should not happen that prematurely added constraints
       // happen to be intra or inter submap constraints.
       CHECK(constraint.tag == Constraint::Tag::MANUAL);
+      missing_nodes_.insert(constraint.node_id);
       continue;
     }
     if (constraint.submap_id.trajectory_id >=
@@ -171,6 +174,7 @@ void OptimizationProblem::Solve(const std::vector<Constraint>& constraints,
         submap_data_.at(constraint.submap_id.trajectory_id)
                 .count(constraint.submap_id.submap_index) == 0) {
       CHECK(constraint.tag == Constraint::Tag::MANUAL);
+      missing_submaps_.insert(constraint.submap_id);
       continue;
     }
     problem.AddResidualBlock(
@@ -262,6 +266,15 @@ OptimizationProblem::submap_data() const {
 const sensor::MapByTime<sensor::ImuData>& OptimizationProblem::imu_data()
     const {
   return imu_data_;
+}
+
+const std::set<mapping::NodeId>& OptimizationProblem::missing_nodes() const {
+  return missing_nodes_;
+}
+
+const std::set<mapping::SubmapId>& OptimizationProblem::missing_submaps()
+    const {
+  return missing_submaps_;
 }
 
 }  // namespace sparse_pose_graph

--- a/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
@@ -155,6 +155,24 @@ void OptimizationProblem::Solve(const std::vector<Constraint>& constraints,
   }
   // Add cost functions for intra- and inter-submap constraints.
   for (const Constraint& constraint : constraints) {
+    // Check if the constraint refers to something that has not yet been
+    // added to the optimization problem. Skip it if that is the case.
+    if (constraint.node_id.trajectory_id >=
+            static_cast<int>(node_data_.size()) ||
+        node_data_.at(constraint.node_id.trajectory_id)
+                .count(constraint.node_id.node_index) == 0) {
+      // It should not happen that prematurely added constraints
+      // happen to be intra or inter submap constraints.
+      CHECK(constraint.tag == Constraint::Tag::MANUAL);
+      continue;
+    }
+    if (constraint.submap_id.trajectory_id >=
+            static_cast<int>(submap_data_.size()) ||
+        submap_data_.at(constraint.submap_id.trajectory_id)
+                .count(constraint.submap_id.submap_index) == 0) {
+      CHECK(constraint.tag == Constraint::Tag::MANUAL);
+      continue;
+    }
     problem.AddResidualBlock(
         new ceres::AutoDiffCostFunction<SpaCostFunction, 3, 3, 3>(
             new SpaCostFunction(constraint.pose)),

--- a/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
@@ -165,7 +165,7 @@ void OptimizationProblem::Solve(const std::vector<Constraint>& constraints,
                 .count(constraint.node_id.node_index) == 0) {
       // It should not happen that prematurely added constraints
       // happen to be intra or inter submap constraints.
-      CHECK(constraint.tag == Constraint::Tag::MANUAL);
+      CHECK(constraint.tag == Constraint::Tag::CUSTOM);
       missing_nodes_.insert(constraint.node_id);
       continue;
     }
@@ -173,7 +173,7 @@ void OptimizationProblem::Solve(const std::vector<Constraint>& constraints,
             static_cast<int>(submap_data_.size()) ||
         submap_data_.at(constraint.submap_id.trajectory_id)
                 .count(constraint.submap_id.submap_index) == 0) {
-      CHECK(constraint.tag == Constraint::Tag::MANUAL);
+      CHECK(constraint.tag == Constraint::Tag::CUSTOM);
       missing_submaps_.insert(constraint.submap_id);
       continue;
     }

--- a/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.h
+++ b/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.h
@@ -90,6 +90,8 @@ class OptimizationProblem {
   const mapping::MapById<mapping::NodeId, NodeData>& node_data() const;
   const mapping::MapById<mapping::SubmapId, SubmapData>& submap_data() const;
   const sensor::MapByTime<sensor::ImuData>& imu_data() const;
+  const std::set<mapping::NodeId>& missing_nodes() const;
+  const std::set<mapping::SubmapId>& missing_submaps() const;
 
  private:
   mapping::sparse_pose_graph::proto::OptimizationProblemOptions options_;
@@ -97,6 +99,8 @@ class OptimizationProblem {
   mapping::MapById<mapping::NodeId, NodeData> node_data_;
   std::vector<transform::TransformInterpolationBuffer> odometry_data_;
   mapping::MapById<mapping::SubmapId, SubmapData> submap_data_;
+  std::set<mapping::NodeId> missing_nodes_;
+  std::set<mapping::SubmapId> missing_submaps_;
 };
 
 }  // namespace sparse_pose_graph

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -175,6 +175,12 @@ void SparsePoseGraph::AddFixedFramePoseData(
   });
 }
 
+void SparsePoseGraph::AddManualConstraint(const mapping::NodeId& node_id,
+                                          const mapping::SubmapId& submap_id,
+                                          const Constraint::Pose& pose) {
+  LOG(FATAL) << "Not implemented.";
+}
+
 void SparsePoseGraph::ComputeConstraint(const mapping::NodeId& node_id,
                                         const mapping::SubmapId& submap_id) {
   CHECK(submap_data_.at(submap_id).state == SubmapState::kFinished);

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -181,6 +181,11 @@ void SparsePoseGraph::AddManualConstraint(const mapping::NodeId& node_id,
   LOG(FATAL) << "Not implemented.";
 }
 
+void SparsePoseGraph::RemoveManualConstraint(const mapping::NodeId& node_id,
+                                          const mapping::SubmapId& submap_id) {
+  LOG(FATAL) << "Not implemented.";
+}
+
 void SparsePoseGraph::ComputeConstraint(const mapping::NodeId& node_id,
                                         const mapping::SubmapId& submap_id) {
   CHECK(submap_data_.at(submap_id).state == SubmapState::kFinished);

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -238,10 +238,6 @@ void SparsePoseGraph::ComputeConstraintsForOldScans(
   }
 }
 
-void SparsePoseGraph::UpdateManualConstraint(mapping::NodeId, transform::Rigid3d) {
-  LOG(FATAL) << "Not implemented.";
-}
-
 void SparsePoseGraph::ComputeConstraintsForScan(
     const mapping::NodeId& node_id,
     std::vector<std::shared_ptr<const Submap>> insertion_submaps,

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -238,6 +238,10 @@ void SparsePoseGraph::ComputeConstraintsForOldScans(
   }
 }
 
+void SparsePoseGraph::UpdateManualConstraint(mapping::NodeId, transform::Rigid3d) {
+  LOG(FATAL) << "Not implemented.";
+}
+
 void SparsePoseGraph::ComputeConstraintsForScan(
     const mapping::NodeId& node_id,
     std::vector<std::shared_ptr<const Submap>> insertion_submaps,

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -175,14 +175,14 @@ void SparsePoseGraph::AddFixedFramePoseData(
   });
 }
 
-void SparsePoseGraph::AddManualConstraint(const mapping::NodeId& node_id,
+void SparsePoseGraph::AddCustomConstraint(const mapping::NodeId& node_id,
                                           const mapping::SubmapId& submap_id,
                                           const Constraint::Pose& pose) {
   LOG(FATAL) << "Not implemented.";
 }
 
-void SparsePoseGraph::RemoveManualConstraint(const mapping::NodeId& node_id,
-                                          const mapping::SubmapId& submap_id) {
+void SparsePoseGraph::RemoveCustomConstraint(
+    const mapping::NodeId& node_id, const mapping::SubmapId& submap_id) {
   LOG(FATAL) << "Not implemented.";
 }
 

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -89,6 +89,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   virtual void AddManualConstraint(const mapping::NodeId& node_id,
                                    const mapping::SubmapId& submap_id,
                                    const Constraint::Pose& pose) override;
+  virtual void RemoveManualConstraint(const mapping::NodeId& node_id,
+                                   const mapping::SubmapId& submap_id) override;
 
   void FreezeTrajectory(int trajectory_id) override;
   void AddSubmapFromProto(const transform::Rigid3d& global_submap_pose,

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -114,6 +114,9 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   transform::Rigid3d GetInterpolatedGlobalTrajectoryPose(
       int trajectory_id, const common::Time time) const REQUIRES(mutex_);
 
+  void UpdateManualConstraint(
+      mapping::NodeId node_id, transform::Rigid3d pose) override;
+
  private:
   // The current state of the submap in the background threads. When this
   // transitions to kFinished, all scans are tried to match against this submap.

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -85,6 +85,11 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
       const sensor::FixedFramePoseData& fixed_frame_pose_data);
 
   void FinishTrajectory(int trajectory_id) override;
+
+  virtual void AddManualConstraint(const mapping::NodeId& node_id,
+                                   const mapping::SubmapId& submap_id,
+                                   const Constraint::Pose& pose) override;
+
   void FreezeTrajectory(int trajectory_id) override;
   void AddSubmapFromProto(const transform::Rigid3d& global_submap_pose,
                           const mapping::proto::Submap& submap) override;

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -86,11 +86,12 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
 
   void FinishTrajectory(int trajectory_id) override;
 
-  virtual void AddManualConstraint(const mapping::NodeId& node_id,
+  virtual void AddCustomConstraint(const mapping::NodeId& node_id,
                                    const mapping::SubmapId& submap_id,
                                    const Constraint::Pose& pose) override;
-  virtual void RemoveManualConstraint(const mapping::NodeId& node_id,
-                                   const mapping::SubmapId& submap_id) override;
+  virtual void RemoveCustomConstraint(
+      const mapping::NodeId& node_id,
+      const mapping::SubmapId& submap_id) override;
 
   void FreezeTrajectory(int trajectory_id) override;
   void AddSubmapFromProto(const transform::Rigid3d& global_submap_pose,

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -114,9 +114,6 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   transform::Rigid3d GetInterpolatedGlobalTrajectoryPose(
       int trajectory_id, const common::Time time) const REQUIRES(mutex_);
 
-  void UpdateManualConstraint(
-      mapping::NodeId node_id, transform::Rigid3d pose) override;
-
  private:
   // The current state of the submap in the background threads. When this
   // transitions to kFinished, all scans are tried to match against this submap.


### PR DESCRIPTION
As fixed frame constraints are now an active topic, I decided to chime in with my implementation of something similar for 2D (I called them '~~manual~~ custom constraints'). It's quite hack-ish (~~they are inserted with respect to  submap 0~~ not anymore) and not nearly considered complete (~~I wanted to also implement editing/removing them~~ removing implemented). Although this is conceptually similar to adding fixed pose measurements, its indended use is different - it bypasses the trajectory builder completely and enables the library user to directly edit the sparse pose graph. After a block of custom constraints is inserted, optimization akin to loop closures is re-run.  This enables the user to see the immediate effects of the added constraints.

Todo:
- update ConnectedComponents and TrajectoryConnectivityState?
- check that there are no unused custom constraints after final optimization