### PR TITLE
Allow rotating histograms in the rotational scan matcher.

### DIFF
--- a/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher.cc
+++ b/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher.cc
@@ -125,6 +125,24 @@ struct Candidate {
   bool operator>(const Candidate& other) const { return score > other.score; }
 };
 
+namespace {
+
+scan_matching::RotationalScanMatcher CreateRotationalScanMatcher(
+    const std::vector<mapping::TrajectoryNode>& nodes,
+    const int histogram_size) {
+  Eigen::VectorXf histogram = Eigen::VectorXf::Zero(histogram_size);
+  for (const mapping::TrajectoryNode& node : nodes) {
+    histogram += scan_matching::RotationalScanMatcher::ComputeHistogram(
+        sensor::TransformPointCloud(
+            node.constant_data->range_data.returns.Decompress(),
+            node.pose.cast<float>()),
+        histogram_size);
+  }
+  return scan_matching::RotationalScanMatcher({{histogram, 0.f}});
+}
+
+}  // namespace
+
 FastCorrelativeScanMatcher::FastCorrelativeScanMatcher(
     const HybridGrid& hybrid_grid,
     const HybridGrid* const low_resolution_hybrid_grid,
@@ -136,7 +154,8 @@ FastCorrelativeScanMatcher::FastCorrelativeScanMatcher(
       precomputation_grid_stack_(
           common::make_unique<PrecomputationGridStack>(hybrid_grid, options)),
       low_resolution_hybrid_grid_(low_resolution_hybrid_grid),
-      rotational_scan_matcher_(nodes, options_.rotational_histogram_size()) {}
+      rotational_scan_matcher_(CreateRotationalScanMatcher(
+          nodes, options_.rotational_histogram_size())) {}
 
 FastCorrelativeScanMatcher::~FastCorrelativeScanMatcher() {}
 
@@ -286,7 +305,10 @@ std::vector<DiscreteScan> FastCorrelativeScanMatcher::GenerateDiscreteScans(
     angles.push_back(rz * angular_step_size);
   }
   const std::vector<float> scores = rotational_scan_matcher_.Match(
-      sensor::TransformPointCloud(fine_point_cloud, initial_pose), angles);
+      RotationalScanMatcher::ComputeHistogram(
+          sensor::TransformPointCloud(fine_point_cloud, initial_pose),
+          options_.rotational_histogram_size()),
+      0.f, angles);
   for (size_t i = 0; i != angles.size(); ++i) {
     if (scores[i] < options_.min_rotational_score()) {
       continue;

--- a/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher.cc
+++ b/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher.cc
@@ -308,7 +308,7 @@ std::vector<DiscreteScan> FastCorrelativeScanMatcher::GenerateDiscreteScans(
       RotationalScanMatcher::ComputeHistogram(
           sensor::TransformPointCloud(fine_point_cloud, initial_pose),
           options_.rotational_histogram_size()),
-      0.f, angles);
+      0.f /* initial_angle */, angles);
   for (size_t i = 0; i != angles.size(); ++i) {
     if (scores[i] < options_.min_rotational_score()) {
       continue;

--- a/cartographer/mapping_3d/scan_matching/rotational_scan_matcher.h
+++ b/cartographer/mapping_3d/scan_matching/rotational_scan_matcher.h
@@ -20,7 +20,6 @@
 #include <vector>
 
 #include "Eigen/Geometry"
-#include "cartographer/mapping/trajectory_node.h"
 #include "cartographer/sensor/point_cloud.h"
 
 namespace cartographer {
@@ -29,21 +28,25 @@ namespace scan_matching {
 
 class RotationalScanMatcher {
  public:
+  // Computes the histogram for a gravity aligned 'point_cloud'.
+  static Eigen::VectorXf ComputeHistogram(const sensor::PointCloud& point_cloud,
+                                          int histogram_size);
+
+  // Creates a matcher from the given histograms rotated by the given angles.
+  // The angles should be chosen to bring the histograms into approximately the
+  // same frame.
   explicit RotationalScanMatcher(
-      const std::vector<mapping::TrajectoryNode>& nodes, int histogram_size);
+      const std::vector<std::pair<Eigen::VectorXf, float>>&
+          histograms_at_angles);
 
-  RotationalScanMatcher(const RotationalScanMatcher&) = delete;
-  RotationalScanMatcher& operator=(const RotationalScanMatcher&) = delete;
-
-  // Scores how well a 'point_cloud' can be understood as rotated by certain
-  // 'angles' relative to the 'nodes'. Each angle results in a score between
-  // 0 (worst) and 1 (best).
-  std::vector<float> Match(const sensor::PointCloud& point_cloud,
+  // Scores how well 'histogram' rotated by 'initial_angle' can be understood as
+  // further rotated by certain 'angles' relative to the 'nodes'. Each angle
+  // results in a score between 0 (worst) and 1 (best).
+  std::vector<float> Match(const Eigen::VectorXf& histogram,
+                           float initial_angle,
                            const std::vector<float>& angles) const;
 
  private:
-  float MatchHistogram(const Eigen::VectorXf& scan_histogram) const;
-
   Eigen::VectorXf histogram_;
 };
 

--- a/cartographer/mapping_3d/scan_matching/rotational_scan_matcher_test.cc
+++ b/cartographer/mapping_3d/scan_matching/rotational_scan_matcher_test.cc
@@ -38,24 +38,27 @@ TEST(RotationalScanMatcherTest, OnlySameHistogramIsScoreOne) {
 TEST(RotationalScanMatcherTest, InterpolatesAsExpected) {
   constexpr int kNumBuckets = 10;
   constexpr float kAnglePerBucket = M_PI / kNumBuckets;
-  RotationalScanMatcher matcher({{Eigen::VectorXf::Unit(kNumBuckets, 3), 0.f}});
+  constexpr float kNoInitialRotation = 0.f;
+  RotationalScanMatcher matcher(
+      {{Eigen::VectorXf::Unit(kNumBuckets, 3), kNoInitialRotation}});
   for (float t = 0.f; t < 1.f; t += 0.1f) {
     // 't' is the fraction of overlap and we have to divide by the norm of the
     // histogram to get the expected score.
     const float expected_score = t / std::hypot(t, 1 - t);
     // We rotate the 't'-th fraction of a bucket into the matcher's histogram.
-    auto scores = matcher.Match(Eigen::VectorXf::Unit(kNumBuckets, 2), 0.f,
-                                {t * kAnglePerBucket});
+    auto scores = matcher.Match(Eigen::VectorXf::Unit(kNumBuckets, 2),
+                                kNoInitialRotation, {t * kAnglePerBucket});
     ASSERT_EQ(1, scores.size());
     EXPECT_NEAR(expected_score, scores[0], 1e-6);
     // Also verify rotating out of a bucket.
-    scores = matcher.Match(Eigen::VectorXf::Unit(kNumBuckets, 2), 0.f,
-                           {(2 - t) * kAnglePerBucket});
+    scores = matcher.Match(Eigen::VectorXf::Unit(kNumBuckets, 2),
+                           kNoInitialRotation, {(2 - t) * kAnglePerBucket});
     ASSERT_EQ(1, scores.size());
     EXPECT_NEAR(expected_score, scores[0], 1e-6);
     // And into and out of a bucket with negative angle.
-    scores = matcher.Match(Eigen::VectorXf::Unit(kNumBuckets, 4), 0.f,
-                           {-t * kAnglePerBucket, (t - 2) * kAnglePerBucket});
+    scores =
+        matcher.Match(Eigen::VectorXf::Unit(kNumBuckets, 4), kNoInitialRotation,
+                      {-t * kAnglePerBucket, (t - 2) * kAnglePerBucket});
     ASSERT_EQ(2, scores.size());
     EXPECT_NEAR(expected_score, scores[0], 1e-6);
     EXPECT_NEAR(expected_score, scores[1], 1e-6);

--- a/cartographer/mapping_3d/scan_matching/rotational_scan_matcher_test.cc
+++ b/cartographer/mapping_3d/scan_matching/rotational_scan_matcher_test.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 The Cartographer Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cartographer/mapping_3d/scan_matching/rotational_scan_matcher.h"
+
+#include <cmath>
+
+#include "gtest/gtest.h"
+
+namespace cartographer {
+namespace mapping_3d {
+namespace scan_matching {
+namespace {
+
+TEST(RotationalScanMatcherTest, OnlySameHistogramIsScoreOne) {
+  Eigen::VectorXf histogram(7);
+  histogram << 1.f, 43.f, 0.5f, 0.3123f, 23.f, 42.f, 0.f;
+  RotationalScanMatcher matcher({{histogram, 0.f}});
+  const auto scores = matcher.Match(histogram, 0.f, {0.f, 1.f});
+  ASSERT_EQ(2, scores.size());
+  EXPECT_NEAR(1.f, scores[0], 1e-6);
+  EXPECT_GT(1.f, scores[1]);
+}
+
+TEST(RotationalScanMatcherTest, InterpolatesAsExpected) {
+  constexpr int kNumBuckets = 10;
+  constexpr float kAnglePerBucket = M_PI / kNumBuckets;
+  RotationalScanMatcher matcher({{Eigen::VectorXf::Unit(kNumBuckets, 3), 0.f}});
+  for (float t = 0.f; t < 1.f; t += 0.1f) {
+    // 't' is the fraction of overlap and we have to divide by the norm of the
+    // histogram to get the expected score.
+    const float expected_score = t / std::hypot(t, 1 - t);
+    // We rotate the 't'-th fraction of a bucket into the matcher's histogram.
+    auto scores = matcher.Match(Eigen::VectorXf::Unit(kNumBuckets, 2), 0.f,
+                                {t * kAnglePerBucket});
+    ASSERT_EQ(1, scores.size());
+    EXPECT_NEAR(expected_score, scores[0], 1e-6);
+    // Also verify rotating out of a bucket.
+    scores = matcher.Match(Eigen::VectorXf::Unit(kNumBuckets, 2), 0.f,
+                           {(2 - t) * kAnglePerBucket});
+    ASSERT_EQ(1, scores.size());
+    EXPECT_NEAR(expected_score, scores[0], 1e-6);
+    // And into and out of a bucket with negative angle.
+    scores = matcher.Match(Eigen::VectorXf::Unit(kNumBuckets, 4), 0.f,
+                           {-t * kAnglePerBucket, (t - 2) * kAnglePerBucket});
+    ASSERT_EQ(2, scores.size());
+    EXPECT_NEAR(expected_score, scores[0], 1e-6);
+    EXPECT_NEAR(expected_score, scores[1], 1e-6);
+  }
+}
+
+}  // namespace
+}  // namespace scan_matching
+}  // namespace mapping_3d
+}  // namespace cartographer


### PR DESCRIPTION
This allows reusing histograms to match for different yaws.
Adds a unit test to test that rotated histograms match as expected.