### PR TITLE
Remove connected_components_ from SPG.

### DIFF
--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -503,7 +503,6 @@ transform::Rigid3d SparsePoseGraph::GetLocalToGlobalTransform(
 }
 
 std::vector<std::vector<int>> SparsePoseGraph::GetConnectedTrajectories() {
-  common::MutexLocker locker(&mutex_);
   return trajectory_connectivity_.ConnectedComponents();
 }
 

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -307,6 +307,7 @@ void SparsePoseGraph::HandleWorkQueue() {
           common::MutexLocker locker(&mutex_);
           constraints_.insert(constraints_.end(), result.begin(), result.end());
         }
+        RunOptimization();
 
         // Update the trajectory connectivity structure with the new
         // constraints.
@@ -316,7 +317,6 @@ void SparsePoseGraph::HandleWorkQueue() {
           trajectory_connectivity_.Connect(constraint.node_id.trajectory_id,
                                            constraint.submap_id.trajectory_id);
         }
-        RunOptimization();
 
         common::MutexLocker locker(&mutex_);
         num_scans_since_last_loop_closure_ = 0;
@@ -465,7 +465,6 @@ void SparsePoseGraph::RunOptimization() {
     }
   }
   optimized_submap_transforms_ = submap_data;
-  connected_components_ = trajectory_connectivity_.ConnectedComponents();
 
   TrimmingHandle trimming_handle(this);
   for (auto& trimmer : trimmers_) {
@@ -505,7 +504,7 @@ transform::Rigid3d SparsePoseGraph::GetLocalToGlobalTransform(
 
 std::vector<std::vector<int>> SparsePoseGraph::GetConnectedTrajectories() {
   common::MutexLocker locker(&mutex_);
-  return connected_components_;
+  return trajectory_connectivity_.ConnectedComponents();
 }
 
 int SparsePoseGraph::num_submaps(const int trajectory_id) {

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -194,9 +194,6 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   mapping::NestedVectorsById<SubmapData, mapping::SubmapId> submap_data_
       GUARDED_BY(mutex_);
 
-  // Connectivity structure of our trajectories by IDs.
-  std::vector<std::vector<int>> connected_components_;
-
   // Data that are currently being shown.
   mapping::NestedVectorsById<mapping::TrajectoryNode, mapping::NodeId>
       trajectory_nodes_ GUARDED_BY(mutex_);

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -534,7 +534,6 @@ transform::Rigid3d SparsePoseGraph::GetLocalToGlobalTransform(
 }
 
 std::vector<std::vector<int>> SparsePoseGraph::GetConnectedTrajectories() {
-  common::MutexLocker locker(&mutex_);
   return trajectory_connectivity_.ConnectedComponents();
 }
 

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -323,6 +323,7 @@ void SparsePoseGraph::HandleWorkQueue() {
           common::MutexLocker locker(&mutex_);
           constraints_.insert(constraints_.end(), result.begin(), result.end());
         }
+        RunOptimization();
 
         // Update the trajectory connectivity structure with the new
         // constraints.
@@ -332,7 +333,6 @@ void SparsePoseGraph::HandleWorkQueue() {
           trajectory_connectivity_.Connect(constraint.node_id.trajectory_id,
                                            constraint.submap_id.trajectory_id);
         }
-        RunOptimization();
 
         common::MutexLocker locker(&mutex_);
         num_scans_since_last_loop_closure_ = 0;
@@ -503,7 +503,6 @@ void SparsePoseGraph::RunOptimization() {
     }
   }
   optimized_submap_transforms_ = optimization_problem_.submap_data();
-  connected_components_ = trajectory_connectivity_.ConnectedComponents();
 
   TrimmingHandle trimming_handle(this);
   for (auto& trimmer : trimmers_) {
@@ -536,7 +535,7 @@ transform::Rigid3d SparsePoseGraph::GetLocalToGlobalTransform(
 
 std::vector<std::vector<int>> SparsePoseGraph::GetConnectedTrajectories() {
   common::MutexLocker locker(&mutex_);
-  return connected_components_;
+  return trajectory_connectivity_.ConnectedComponents();
 }
 
 int SparsePoseGraph::num_submaps(const int trajectory_id) {

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -199,9 +199,6 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   mapping::NestedVectorsById<SubmapData, mapping::SubmapId> submap_data_
       GUARDED_BY(mutex_);
 
-  // Connectivity structure of our trajectories by IDs.
-  std::vector<std::vector<int>> connected_components_;
-
   // Data that are currently being shown.
   mapping::NestedVectorsById<mapping::TrajectoryNode, mapping::NodeId>
       trajectory_nodes_ GUARDED_BY(mutex_);


### PR DESCRIPTION
This PR removes connected_components_ from the SparsePoseGraph. Since
the connectivity structure is no longer updated by the
ConstraintBuilders it is no longer necessary for SPG to keep a copy of
the connected components for data consistency.