### PR TITLE
First implementation of initial pose

### DIFF
--- a/cartographer/mapping/global_trajectory_builder.h
+++ b/cartographer/mapping/global_trajectory_builder.h
@@ -33,6 +33,14 @@ class GlobalTrajectoryBuilder
       : trajectory_id_(trajectory_id),
         sparse_pose_graph_(sparse_pose_graph),
         local_trajectory_builder_(options) {}
+
+  GlobalTrajectoryBuilder(const LocalTrajectoryBuilderOptions& options,
+                          const int trajectory_id,
+                          SparsePoseGraph* const sparse_pose_graph,
+                          const transform::Rigid3d& initialpose_data)
+      : trajectory_id_(trajectory_id),
+        sparse_pose_graph_(sparse_pose_graph),
+        local_trajectory_builder_(options, initialpose_data) {}
   ~GlobalTrajectoryBuilder() override {}
 
   GlobalTrajectoryBuilder(const GlobalTrajectoryBuilder&) = delete;

--- a/cartographer/mapping/map_builder.h
+++ b/cartographer/mapping/map_builder.h
@@ -60,6 +60,13 @@ class MapBuilder {
       const std::unordered_set<string>& expected_sensor_ids,
       const proto::TrajectoryBuilderOptions& trajectory_options);
 
+  // Adding Initial pose during pure localization
+  int AddTrajectoryBuilderWithInitialpose(
+      const std::unordered_set<string>& expected_sensor_ids,
+      const proto::TrajectoryBuilderOptions& trajectory_options,
+      common::Time time,
+      const transform::Rigid3d& initialpose_data);
+
   // Returns the TrajectoryBuilder corresponding to the specified
   // 'trajectory_id'.
   mapping::TrajectoryBuilder* GetTrajectoryBuilder(int trajectory_id) const;

--- a/cartographer/mapping_2d/local_trajectory_builder.cc
+++ b/cartographer/mapping_2d/local_trajectory_builder.cc
@@ -32,7 +32,19 @@ LocalTrajectoryBuilder::LocalTrajectoryBuilder(
       motion_filter_(options_.motion_filter_options()),
       real_time_correlative_scan_matcher_(
           options_.real_time_correlative_scan_matcher_options()),
-      ceres_scan_matcher_(options_.ceres_scan_matcher_options()) {}
+      ceres_scan_matcher_(options_.ceres_scan_matcher_options()),
+      initialpose_(transform::Rigid3d::Identity()) {}
+
+LocalTrajectoryBuilder::LocalTrajectoryBuilder(
+    const proto::LocalTrajectoryBuilderOptions& options,
+    const transform::Rigid3d& initialpose_data)
+    : options_(options),
+      active_submaps_(options.submaps_options()),
+      motion_filter_(options_.motion_filter_options()),
+      real_time_correlative_scan_matcher_(
+          options_.real_time_correlative_scan_matcher_options()),
+      ceres_scan_matcher_(options_.ceres_scan_matcher_options()),
+      initialpose_(initialpose_data) {}
 
 LocalTrajectoryBuilder::~LocalTrajectoryBuilder() {}
 
@@ -220,7 +232,7 @@ void LocalTrajectoryBuilder::InitializeExtrapolator(const common::Time time) {
   extrapolator_ = common::make_unique<mapping::PoseExtrapolator>(
       ::cartographer::common::FromSeconds(kExtrapolationEstimationTimeSec),
       options_.imu_gravity_time_constant());
-  extrapolator_->AddPose(time, transform::Rigid3d::Identity());
+  extrapolator_->AddPose(time, initialpose_);
 }
 
 }  // namespace mapping_2d

--- a/cartographer/mapping_2d/local_trajectory_builder.h
+++ b/cartographer/mapping_2d/local_trajectory_builder.h
@@ -48,6 +48,11 @@ class LocalTrajectoryBuilder {
 
   explicit LocalTrajectoryBuilder(
       const proto::LocalTrajectoryBuilderOptions& options);
+
+  explicit LocalTrajectoryBuilder(
+      const proto::LocalTrajectoryBuilderOptions& options,
+      const transform::Rigid3d& initialpose_data);
+
   ~LocalTrajectoryBuilder();
 
   LocalTrajectoryBuilder(const LocalTrajectoryBuilder&) = delete;
@@ -92,6 +97,7 @@ class LocalTrajectoryBuilder {
   int num_accumulated_ = 0;
   transform::Rigid3f first_pose_estimate_ = transform::Rigid3f::Identity();
   sensor::RangeData accumulated_range_data_;
+  transform::Rigid3d initialpose_=transform::Rigid3d::Identity();
 };
 
 }  // namespace mapping_2d

--- a/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher.cc
+++ b/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher.cc
@@ -219,6 +219,7 @@ bool FastCorrelativeScanMatcher::Match(
 }
 
 bool FastCorrelativeScanMatcher::MatchFullSubmap(
+    const transform::Rigid2d& initial_pose_estimate,
     const sensor::PointCloud& point_cloud, float min_score, float* score,
     transform::Rigid2d* pose_estimate) const {
   // Compute a search window around the center of the submap that includes it
@@ -231,8 +232,9 @@ bool FastCorrelativeScanMatcher::MatchFullSubmap(
       limits_.max() - 0.5 * limits_.resolution() *
                           Eigen::Vector2d(limits_.cell_limits().num_y_cells,
                                           limits_.cell_limits().num_x_cells));
-  return MatchWithSearchParameters(search_parameters, center, point_cloud,
-                                   min_score, score, pose_estimate);
+  return MatchWithSearchParameters(search_parameters, initial_pose_estimate,
+                                   point_cloud, min_score, score,
+                                   pose_estimate);
 }
 
 bool FastCorrelativeScanMatcher::MatchWithSearchParameters(

--- a/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher.h
+++ b/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher.h
@@ -118,7 +118,8 @@ class FastCorrelativeScanMatcher {
   // restricted to the configured search window. If a score above 'min_score'
   // (excluding equality) is possible, true is returned, and 'score' and
   // 'pose_estimate' are updated with the result.
-  bool MatchFullSubmap(const sensor::PointCloud& point_cloud, float min_score,
+  bool MatchFullSubmap(const transform::Rigid2d& initial_pose_estimate,
+                       const sensor::PointCloud& point_cloud, float min_score,
                        float* score, transform::Rigid2d* pose_estimate) const;
 
  private:

--- a/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher_test.cc
+++ b/cartographer/mapping_2d/scan_matching/fast_correlative_scan_matcher_test.cc
@@ -216,7 +216,8 @@ TEST(FastCorrelativeScanMatcherTest, FullSubmapMatching) {
     transform::Rigid2d pose_estimate;
     float score;
     EXPECT_TRUE(fast_correlative_scan_matcher.MatchFullSubmap(
-        point_cloud, kMinScore, &score, &pose_estimate));
+        transform::Rigid2d::Identity(), point_cloud, kMinScore,
+        &score, &pose_estimate));
     EXPECT_LT(kMinScore, score);
     EXPECT_THAT(expected_pose,
                 transform::IsNearly(pose_estimate.cast<float>(), 0.03f))

--- a/cartographer/mapping_2d/scan_matching/fast_global_localizer.cc
+++ b/cartographer/mapping_2d/scan_matching/fast_global_localizer.cc
@@ -45,7 +45,8 @@ bool PerformGlobalLocalization(
   for (auto& matcher : matchers) {
     float score = -1;
     transform::Rigid2d pose_estimate;
-    if (matcher->MatchFullSubmap(filtered_point_cloud, *best_score, &score,
+    if (matcher->MatchFullSubmap(transform::Rigid2d::Identity(),
+                                 filtered_point_cloud, *best_score, &score,
                                  &pose_estimate)) {
       CHECK_GT(score, *best_score) << "MatchFullSubmap lied!";
       *best_score = score;

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -179,7 +179,7 @@ void SparsePoseGraph::ComputeConstraint(const mapping::NodeId& node_id,
     constraint_builder_.MaybeAddGlobalConstraint(
         submap_id, submap_data_.at(submap_id).submap.get(), node_id,
         trajectory_nodes_.at(node_id).constant_data.get(),
-        &trajectory_connectivity_);
+        &trajectory_connectivity_, best_current_optimized_pose_);
   } else {
     const bool scan_and_submap_trajectories_connected =
         reverse_connected_components_.count(node_id.trajectory_id) > 0 &&
@@ -238,6 +238,7 @@ void SparsePoseGraph::ComputeConstraintsForScan(
       sparse_pose_graph::ComputeSubmapPose(*insertion_submaps.front())
           .inverse() *
       pose;
+  best_current_optimized_pose_=optimized_pose;
   const mapping::NodeId node_id{
       matching_id.trajectory_id,
       static_cast<size_t>(matching_id.trajectory_id) <

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -215,8 +215,12 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
   // Set of all frozen trajectories not being optimized.
   std::set<int> frozen_trajectories_ GUARDED_BY(mutex_);
 
+  // for searching around the current best pose with repect to the submap
+  transform::Rigid2d best_current_optimized_pose_;
+
   // Allows querying and manipulating the pose graph by the 'trimmers_'. The
   // 'mutex_' of the pose graph is held while this class is used.
+
   class TrimmingHandle : public mapping::Trimmable {
    public:
     TrimmingHandle(SparsePoseGraph* parent);

--- a/cartographer/mapping_2d/sparse_pose_graph/constraint_builder.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph/constraint_builder.cc
@@ -88,7 +88,8 @@ void ConstraintBuilder::MaybeAddGlobalConstraint(
     const mapping::SubmapId& submap_id, const Submap* const submap,
     const mapping::NodeId& node_id,
     const mapping::TrajectoryNode::Data* const constant_data,
-    mapping::TrajectoryConnectivity* const trajectory_connectivity) {
+    mapping::TrajectoryConnectivity* const trajectory_connectivity,
+    const transform::Rigid2d pose_of_robot) {
   common::MutexLocker locker(&mutex_);
   constraints_.emplace_back();
   auto* const constraint = &constraints_.back();
@@ -99,7 +100,7 @@ void ConstraintBuilder::MaybeAddGlobalConstraint(
         ComputeConstraint(submap_id, submap, node_id,
                           true, /* match_full_submap */
                           trajectory_connectivity, constant_data,
-                          transform::Rigid2d::Identity(), constraint);
+                          pose_of_robot , constraint);
         FinishComputation(current_computation);
       });
 }
@@ -185,6 +186,7 @@ void ConstraintBuilder::ComputeConstraint(
   // 3. Refine.
   if (match_full_submap) {
     if (submap_scan_matcher->fast_correlative_scan_matcher->MatchFullSubmap(
+            initial_pose,
             constant_data->filtered_gravity_aligned_point_cloud,
             options_.global_localization_min_score(), &score, &pose_estimate)) {
       CHECK_GT(score, options_.global_localization_min_score());

--- a/cartographer/mapping_2d/sparse_pose_graph/constraint_builder.h
+++ b/cartographer/mapping_2d/sparse_pose_graph/constraint_builder.h
@@ -95,8 +95,8 @@ class ConstraintBuilder {
       const mapping::SubmapId& submap_id, const Submap* submap,
       const mapping::NodeId& node_id,
       const mapping::TrajectoryNode::Data* const constant_data,
-      mapping::TrajectoryConnectivity* trajectory_connectivity);
-
+      mapping::TrajectoryConnectivity* trajectory_connectivity,
+      const transform::Rigid2d pose_of_robot);
   // Must be called after all computations related to one node have been added.
   void NotifyEndOfScan();
 

--- a/cartographer/mapping_3d/local_trajectory_builder.cc
+++ b/cartographer/mapping_3d/local_trajectory_builder.cc
@@ -41,6 +41,18 @@ LocalTrajectoryBuilder::LocalTrajectoryBuilder(
           options_.ceres_scan_matcher_options())),
       accumulated_range_data_{Eigen::Vector3f::Zero(), {}, {}} {}
 
+LocalTrajectoryBuilder::LocalTrajectoryBuilder(
+    const proto::LocalTrajectoryBuilderOptions& options,
+    const transform::Rigid3d& initialpose_data)
+    : options_(options),
+      active_submaps_(options.submaps_options()),
+      motion_filter_(options.motion_filter_options()),
+      real_time_correlative_scan_matcher_(
+          common::make_unique<scan_matching::RealTimeCorrelativeScanMatcher>(
+              options_.real_time_correlative_scan_matcher_options())),
+      ceres_scan_matcher_(common::make_unique<scan_matching::CeresScanMatcher>(
+          options_.ceres_scan_matcher_options())),
+      accumulated_range_data_{Eigen::Vector3f::Zero(), {}, {}} {}
 LocalTrajectoryBuilder::~LocalTrajectoryBuilder() {}
 
 void LocalTrajectoryBuilder::AddImuData(const sensor::ImuData& imu_data) {

--- a/cartographer/mapping_3d/local_trajectory_builder.h
+++ b/cartographer/mapping_3d/local_trajectory_builder.h
@@ -48,6 +48,11 @@ class LocalTrajectoryBuilder {
 
   explicit LocalTrajectoryBuilder(
       const proto::LocalTrajectoryBuilderOptions& options);
+
+  explicit LocalTrajectoryBuilder(
+      const proto::LocalTrajectoryBuilderOptions& options,
+      const transform::Rigid3d& initialpose_data);
+
   ~LocalTrajectoryBuilder();
 
   LocalTrajectoryBuilder(const LocalTrajectoryBuilder&) = delete;


### PR DESCRIPTION
This is the first basic implementation of initial pose. I have implemented this similar to what we have in AMCL(for pure localization). I am currently using the following strategy when an initial pose is given. 
1.Need to writer a subscriber in node.cc that would subscribe to /initialpose (eg from:rviz).
2.Whenever we receive an /initialpose we need to first finish the current Trajectory and then run final optimization.
3.Then a new trajectory needs to be started from the pose given by /initialpose and need to make sure it is with respect to map frame.
4.Push this pose all the way back to LocalTrajectoryBuilder class where the PoseEstimate is defined and change the value from identity to this pose.
5.Then pass the current pose estimate from localtrajectorybuilder to the sparse_pose_graph and then constraint_builder and finally to fast correlative scan matcher (MatchFullSubmap)
6.And instead of starting to scan match from the origin(or centre) of the submap, scan match from the current best pose estimate(only when robot is in or near that submap).

I haven't sent a request for  cartographer_ros changes yet. Will do once this is fixed.

Further Work:
1.Delete all submaps from the unwanted trajectory or delete the trajectory itself.
2.Ordering the submaps based on their proximity to the current pose of the scan.

Would love to have your feedback. 

Thanks,
Akshay 