### PR TITLE
Fix odometry in the 2D pose graph optimization.

### DIFF
--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -250,9 +250,10 @@ void SparsePoseGraph::ComputeConstraintsForScan(
                                  ->first +
                              1)
           : 0};
-  const auto& scan_data = trajectory_nodes_.at(node_id).constant_data;
-  optimization_problem_.AddTrajectoryNode(
-      matching_id.trajectory_id, scan_data->time, pose, optimized_pose);
+  const auto& node_data = trajectory_nodes_.at(node_id).constant_data;
+  optimization_problem_.AddTrajectoryNode(matching_id.trajectory_id,
+                                          node_data->time, pose, optimized_pose,
+                                          node_data->gravity_alignment);
   for (size_t i = 0; i < insertion_submaps.size(); ++i) {
     const mapping::SubmapId submap_id = submap_ids[i];
     // Even if this was the last scan added to 'submap_id', the submap will only

--- a/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.h
+++ b/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.h
@@ -41,6 +41,7 @@ struct NodeData {
   common::Time time;
   transform::Rigid2d initial_pose;
   transform::Rigid2d pose;
+  Eigen::Quaterniond gravity_alignment;
 };
 
 struct SubmapData {
@@ -65,7 +66,8 @@ class OptimizationProblem {
                        const sensor::OdometryData& odometry_data);
   void AddTrajectoryNode(int trajectory_id, common::Time time,
                          const transform::Rigid2d& initial_pose,
-                         const transform::Rigid2d& pose);
+                         const transform::Rigid2d& pose,
+                         const Eigen::Quaterniond& gravity_alignment);
   void TrimTrajectoryNode(const mapping::NodeId& node_id);
   void AddSubmap(int trajectory_id, const transform::Rigid2d& submap_pose);
   void TrimSubmap(const mapping::SubmapId& submap_id);


### PR DESCRIPTION
Before, the relative change in pose due to odometry in the
2D pose graph optimization problem was incorrectly done in
the tracking frame. Instead, the gravity aligned frame in
which the 2D poses are stored must be used.

Fixes #515.

PAIR=cschuet