### PR TITLE
Deserialize SPG constraints

### DIFF
--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -188,14 +188,6 @@ void MapBuilder::LoadMap(io::ProtoStreamReader* const reader) {
     sparse_pose_graph_->FreezeTrajectory(new_trajectory_id);
   }
 
-  // Apply the calculated remapping to constraints in the SparsePoseGraph proto
-  for (auto& constraint_proto : *pose_graph.mutable_constraint()) {
-    constraint_proto.mutable_submap_id()->set_trajectory_id(
-        trajectory_remapping.at(constraint_proto.submap_id().trajectory_id()));
-    constraint_proto.mutable_node_id()->set_trajectory_id(
-        trajectory_remapping.at(constraint_proto.node_id().trajectory_id()));
-  }
-
   MapById<SubmapId, transform::Rigid3d> submap_poses;
   for (const proto::Trajectory& trajectory_proto : pose_graph.trajectory()) {
     for (const proto::Trajectory::Submap& submap_proto :
@@ -238,7 +230,6 @@ void MapBuilder::LoadMap(io::ProtoStreamReader* const reader) {
     }
   }
   CHECK(reader->eof());
-  sparse_pose_graph_->AddConstraints(FromProto(pose_graph.constraint()));
 }
 
 int MapBuilder::num_trajectory_builders() const {

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -188,6 +188,14 @@ void MapBuilder::LoadMap(io::ProtoStreamReader* const reader) {
     sparse_pose_graph_->FreezeTrajectory(new_trajectory_id);
   }
 
+  // Apply the calculated remapping to constraints in the SparsePoseGraph proto
+  for (auto& constraint_proto : *pose_graph.mutable_constraint()) {
+    constraint_proto.mutable_submap_id()->set_trajectory_id(
+        trajectory_remapping.at(constraint_proto.submap_id().trajectory_id()));
+    constraint_proto.mutable_node_id()->set_trajectory_id(
+        trajectory_remapping.at(constraint_proto.node_id().trajectory_id()));
+  }
+
   MapById<SubmapId, transform::Rigid3d> submap_poses;
   for (const proto::Trajectory& trajectory_proto : pose_graph.trajectory()) {
     for (const proto::Trajectory::Submap& submap_proto :

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -188,6 +188,14 @@ void MapBuilder::LoadMap(io::ProtoStreamReader* const reader) {
     sparse_pose_graph_->FreezeTrajectory(new_trajectory_id);
   }
 
+  // Apply the calculated remapping to constraints in the SparsePoseGraph proto
+  for (auto& constraint_proto : *pose_graph.mutable_constraint()) {
+    constraint_proto.mutable_submap_id()->set_trajectory_id(
+        trajectory_remapping.at(constraint_proto.submap_id().trajectory_id()));
+    constraint_proto.mutable_node_id()->set_trajectory_id(
+        trajectory_remapping.at(constraint_proto.node_id().trajectory_id()));
+  }
+
   MapById<SubmapId, transform::Rigid3d> submap_poses;
   for (const proto::Trajectory& trajectory_proto : pose_graph.trajectory()) {
     for (const proto::Trajectory::Submap& submap_proto :
@@ -230,6 +238,7 @@ void MapBuilder::LoadMap(io::ProtoStreamReader* const reader) {
     }
   }
   CHECK(reader->eof());
+  sparse_pose_graph_->AddConstraints(FromProto(pose_graph.constraint()));
 }
 
 int MapBuilder::num_trajectory_builders() const {

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -239,6 +239,7 @@ void MapBuilder::LoadMap(io::ProtoStreamReader* const reader) {
     }
   }
   CHECK(reader->eof());
+  sparse_pose_graph_->AddConstraintsFromProto(pose_graph);
 }
 
 int MapBuilder::num_trajectory_builders() const {

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -174,12 +174,11 @@ void MapBuilder::SerializeState(io::ProtoStreamWriter* const writer) {
 }
 
 void MapBuilder::LoadMap(io::ProtoStreamReader* const reader) {
-  const std::shared_ptr<proto::SparsePoseGraph> pose_graph =
-      std::make_shared<proto::SparsePoseGraph>();
-  CHECK(reader->ReadProto(pose_graph.get()));
+  proto::SparsePoseGraph pose_graph;
+  CHECK(reader->ReadProto(&pose_graph));
 
   std::map<int, int> trajectory_remapping;
-  for (auto& trajectory_proto : *pose_graph->mutable_trajectory()) {
+  for (auto& trajectory_proto : *pose_graph.mutable_trajectory()) {
     const int new_trajectory_id = AddTrajectoryForDeserialization();
     CHECK(trajectory_remapping
               .emplace(trajectory_proto.trajectory_id(), new_trajectory_id)
@@ -190,7 +189,7 @@ void MapBuilder::LoadMap(io::ProtoStreamReader* const reader) {
   }
 
   MapById<SubmapId, transform::Rigid3d> submap_poses;
-  for (const proto::Trajectory& trajectory_proto : pose_graph->trajectory()) {
+  for (const proto::Trajectory& trajectory_proto : pose_graph.trajectory()) {
     for (const proto::Trajectory::Submap& submap_proto :
          trajectory_proto.submap()) {
       submap_poses.Insert(SubmapId{trajectory_proto.trajectory_id(),
@@ -200,7 +199,7 @@ void MapBuilder::LoadMap(io::ProtoStreamReader* const reader) {
   }
 
   MapById<NodeId, transform::Rigid3d> node_poses;
-  for (const proto::Trajectory& trajectory_proto : pose_graph->trajectory()) {
+  for (const proto::Trajectory& trajectory_proto : pose_graph.trajectory()) {
     for (const proto::Trajectory::Node& node_proto : trajectory_proto.node()) {
       node_poses.Insert(
           NodeId{trajectory_proto.trajectory_id(), node_proto.node_index()},

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -189,14 +189,6 @@ void MapBuilder::LoadMap(io::ProtoStreamReader* const reader) {
     sparse_pose_graph_->FreezeTrajectory(new_trajectory_id);
   }
 
-  // Apply the calculated remapping to constraints in the SparsePoseGraph proto
-  for (auto& constraint_proto : *pose_graph->mutable_constraint()) {
-    constraint_proto.mutable_submap_id()->set_trajectory_id(
-        trajectory_remapping.at(constraint_proto.submap_id().trajectory_id()));
-    constraint_proto.mutable_node_id()->set_trajectory_id(
-        trajectory_remapping.at(constraint_proto.node_id().trajectory_id()));
-  }
-
   MapById<SubmapId, transform::Rigid3d> submap_poses;
   for (const proto::Trajectory& trajectory_proto : pose_graph->trajectory()) {
     for (const proto::Trajectory::Submap& submap_proto :
@@ -239,7 +231,6 @@ void MapBuilder::LoadMap(io::ProtoStreamReader* const reader) {
     }
   }
   CHECK(reader->eof());
-  sparse_pose_graph_->AddConstraintsFromProto(pose_graph);
 }
 
 int MapBuilder::num_trajectory_builders() const {

--- a/cartographer/mapping/sparse_pose_graph.cc
+++ b/cartographer/mapping/sparse_pose_graph.cc
@@ -46,6 +46,29 @@ SparsePoseGraph::Constraint::Tag FromProto(
   LOG(FATAL) << "Unsupported tag.";
 }
 
+std::vector<SparsePoseGraph::Constraint> FromProto(
+    const ::google::protobuf::RepeatedPtrField<
+        ::cartographer::mapping::proto::SparsePoseGraph::Constraint>&
+        constraint_protos) {
+  std::vector<SparsePoseGraph::Constraint> constraints;
+  for (const auto& constraint_proto : constraint_protos) {
+    const mapping::SubmapId submap_id{
+        constraint_proto.submap_id().trajectory_id(),
+        constraint_proto.submap_id().submap_index()};
+    const mapping::NodeId node_id{constraint_proto.node_id().trajectory_id(),
+                                  constraint_proto.node_id().node_index()};
+    const SparsePoseGraph::Constraint::Pose pose{
+        transform::ToRigid3(constraint_proto.relative_pose()),
+        constraint_proto.translation_weight(),
+        constraint_proto.rotation_weight()};
+    const SparsePoseGraph::Constraint::Tag tag =
+        mapping::FromProto(constraint_proto.tag());
+    constraints.push_back(
+        SparsePoseGraph::Constraint{submap_id, node_id, pose, tag});
+  }
+  return constraints;
+}
+
 proto::SparsePoseGraphOptions CreateSparsePoseGraphOptions(
     common::LuaParameterDictionary* const parameter_dictionary) {
   proto::SparsePoseGraphOptions options;

--- a/cartographer/mapping/sparse_pose_graph.cc
+++ b/cartographer/mapping/sparse_pose_graph.cc
@@ -35,6 +35,17 @@ proto::SparsePoseGraph::Constraint::Tag ToProto(
   LOG(FATAL) << "Unsupported tag.";
 }
 
+SparsePoseGraph::Constraint::Tag FromProto(
+    const proto::SparsePoseGraph::Constraint::Tag& proto) {
+  switch (proto) {
+    case proto::SparsePoseGraph::Constraint::INTRA_SUBMAP:
+      return SparsePoseGraph::Constraint::Tag::INTRA_SUBMAP;
+    case proto::SparsePoseGraph::Constraint::INTER_SUBMAP:
+      return SparsePoseGraph::Constraint::Tag::INTER_SUBMAP;
+  }
+  LOG(FATAL) << "Unsupported tag.";
+}
+
 proto::SparsePoseGraphOptions CreateSparsePoseGraphOptions(
     common::LuaParameterDictionary* const parameter_dictionary) {
   proto::SparsePoseGraphOptions options;

--- a/cartographer/mapping/sparse_pose_graph.cc
+++ b/cartographer/mapping/sparse_pose_graph.cc
@@ -62,7 +62,7 @@ std::vector<SparsePoseGraph::Constraint> FromProto(
         constraint_proto.translation_weight(),
         constraint_proto.rotation_weight()};
     const SparsePoseGraph::Constraint::Tag tag =
-        mapping::FromProto(constraint_proto.tag());
+        FromProto(constraint_proto.tag());
     constraints.push_back(
         SparsePoseGraph::Constraint{submap_id, node_id, pose, tag});
   }

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -125,8 +125,10 @@ class SparsePoseGraph {
   virtual std::vector<Constraint> constraints() = 0;
 };
 
-SparsePoseGraph::Constraint::Tag FromProto(
-    const proto::SparsePoseGraph::Constraint::Tag& proto);
+std::vector<SparsePoseGraph::Constraint> FromProto(
+    const ::google::protobuf::RepeatedPtrField<
+        ::cartographer::mapping::proto::SparsePoseGraph::Constraint>&
+        constraint_protos);
 
 }  // namespace mapping
 }  // namespace cartographer

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -87,9 +87,10 @@ class SparsePoseGraph {
   virtual void AddNodeFromProto(const transform::Rigid3d& global_pose,
                                 const proto::Node& node) = 0;
 
-  // Adds constraints data from a proto. Trajectory nodes and submaps have to be
-  // deserialized before calling this function.
-  virtual void AddConstraints(const std::vector<Constraint>& constraints) = 0;
+  // Adds serialized constraints. The corresponding trajectory nodes and submaps
+  // have to be deserialized before calling this function.
+  virtual void AddSerializedConstraints(
+      const std::vector<Constraint>& constraints) = 0;
 
   // Adds a 'trimmer'. It will be used after all data added before it has been
   // included in the pose graph.

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -120,6 +120,9 @@ class SparsePoseGraph {
   virtual std::vector<Constraint> constraints() = 0;
 };
 
+SparsePoseGraph::Constraint::Tag FromProto(
+    const proto::SparsePoseGraph::Constraint::Tag& proto);
+
 }  // namespace mapping
 }  // namespace cartographer
 

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -87,6 +87,11 @@ class SparsePoseGraph {
   virtual void AddNodeFromProto(const transform::Rigid3d& global_pose,
                                 const proto::Node& node) = 0;
 
+  // Adds constraints data from a proto. Trajectory nodes and submaps have to be
+  // deserialized before calling this function.
+  virtual void AddConstraintsFromProto(
+      std::shared_ptr<const proto::SparsePoseGraph> proto) = 0;
+
   // Adds a 'trimmer'. It will be used after all data added before it has been
   // included in the pose graph.
   virtual void AddTrimmer(std::unique_ptr<PoseGraphTrimmer> trimmer) = 0;

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -89,8 +89,7 @@ class SparsePoseGraph {
 
   // Adds constraints data from a proto. Trajectory nodes and submaps have to be
   // deserialized before calling this function.
-  virtual void AddConstraintsFromProto(
-      std::shared_ptr<const proto::SparsePoseGraph> proto) = 0;
+  virtual void AddConstraints(const std::vector<Constraint>& constraints) = 0;
 
   // Adds a 'trimmer'. It will be used after all data added before it has been
   // included in the pose graph.

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -426,7 +426,7 @@ void SparsePoseGraph::AddNodeFromProto(const transform::Rigid3d& global_pose,
   });
 }
 
-void SparsePoseGraph::AddConstraints(
+void SparsePoseGraph::AddSerializedConstraints(
     const std::vector<Constraint>& constraints) {
   common::MutexLocker locker(&mutex_);
   AddWorkItem([this, constraints]() REQUIRES(mutex_) {

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -426,6 +426,39 @@ void SparsePoseGraph::AddNodeFromProto(const transform::Rigid3d& global_pose,
   });
 }
 
+void SparsePoseGraph::AddConstraintsFromProto(
+    const std::shared_ptr<const mapping::proto::SparsePoseGraph> proto) {
+  common::MutexLocker locker(&mutex_);
+  AddWorkItem([this, proto]() REQUIRES(mutex_) {
+    for (const auto& constraint_proto : proto->constraint()) {
+      const mapping::SubmapId submap_id{
+          constraint_proto.submap_id().trajectory_id(),
+          constraint_proto.submap_id().submap_index()};
+      const mapping::NodeId node_id{constraint_proto.node_id().trajectory_id(),
+                                    constraint_proto.node_id().node_index()};
+      const Constraint::Pose pose{
+          transform::ToRigid3(constraint_proto.relative_pose()) *
+              transform::Rigid3d::Rotation(
+                  trajectory_nodes_.at(node_id)
+                      .constant_data->gravity_alignment.inverse()),
+          constraint_proto.translation_weight(),
+          constraint_proto.rotation_weight()};
+      const Constraint::Tag tag = mapping::FromProto(constraint_proto.tag());
+
+      CHECK(trajectory_nodes_.Contains(node_id));
+      CHECK(submap_data_.Contains(submap_id));
+      CHECK(trajectory_nodes_.at(node_id).constant_data != nullptr);
+      CHECK(submap_data_.at(submap_id).submap != nullptr);
+
+      if (tag == Constraint::Tag::INTRA_SUBMAP) {
+        submap_data_.at(submap_id).node_ids.emplace(node_id);
+      }
+      constraints_.push_back(Constraint{submap_id, node_id, pose, tag});
+    }
+    LOG(INFO) << "Loaded " << proto->constraint_size() << " constraints.";
+  });
+}
+
 void SparsePoseGraph::AddTrimmer(
     std::unique_ptr<mapping::PoseGraphTrimmer> trimmer) {
   common::MutexLocker locker(&mutex_);

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -88,7 +88,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
                           const mapping::proto::Submap& submap) override;
   void AddNodeFromProto(const transform::Rigid3d& global_pose,
                         const mapping::proto::Node& node) override;
-  void AddConstraints(const std::vector<Constraint>& constraints) override;
+  void AddSerializedConstraints(
+      const std::vector<Constraint>& constraints) override;
   void AddTrimmer(std::unique_ptr<mapping::PoseGraphTrimmer> trimmer) override;
   void RunFinalOptimization() override;
   std::vector<std::vector<int>> GetConnectedTrajectories() override;

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -88,6 +88,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
                           const mapping::proto::Submap& submap) override;
   void AddNodeFromProto(const transform::Rigid3d& global_pose,
                         const mapping::proto::Node& node) override;
+  void AddConstraintsFromProto(
+      std::shared_ptr<const mapping::proto::SparsePoseGraph> proto) override;
   void AddTrimmer(std::unique_ptr<mapping::PoseGraphTrimmer> trimmer) override;
   void RunFinalOptimization() override;
   std::vector<std::vector<int>> GetConnectedTrajectories() override;

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -88,8 +88,7 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
                           const mapping::proto::Submap& submap) override;
   void AddNodeFromProto(const transform::Rigid3d& global_pose,
                         const mapping::proto::Node& node) override;
-  void AddConstraintsFromProto(
-      std::shared_ptr<const mapping::proto::SparsePoseGraph> proto) override;
+  void AddConstraints(const std::vector<Constraint>& constraints) override;
   void AddTrimmer(std::unique_ptr<mapping::PoseGraphTrimmer> trimmer) override;
   void RunFinalOptimization() override;
   std::vector<std::vector<int>> GetConnectedTrajectories() override;

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -440,6 +440,11 @@ void SparsePoseGraph::AddNodeFromProto(const transform::Rigid3d& global_pose,
   });
 }
 
+void SparsePoseGraph::AddConstraintsFromProto(
+    const std::shared_ptr<const mapping::proto::SparsePoseGraph> proto) {
+  LOG(FATAL) << "Not yet implemented for 3D.";
+}
+
 void SparsePoseGraph::AddTrimmer(
     std::unique_ptr<mapping::PoseGraphTrimmer> trimmer) {
   common::MutexLocker locker(&mutex_);

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -440,7 +440,7 @@ void SparsePoseGraph::AddNodeFromProto(const transform::Rigid3d& global_pose,
   });
 }
 
-void SparsePoseGraph::AddConstraints(
+void SparsePoseGraph::AddSerializedConstraints(
     const std::vector<Constraint>& constraints) {
   LOG(FATAL) << "Not yet implemented for 3D.";
 }

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -442,7 +442,22 @@ void SparsePoseGraph::AddNodeFromProto(const transform::Rigid3d& global_pose,
 
 void SparsePoseGraph::AddSerializedConstraints(
     const std::vector<Constraint>& constraints) {
-  LOG(FATAL) << "Not yet implemented for 3D.";
+  common::MutexLocker locker(&mutex_);
+  AddWorkItem([this, constraints]() REQUIRES(mutex_) {
+    for (const auto& constraint : constraints) {
+      CHECK(trajectory_nodes_.Contains(constraint.node_id));
+      CHECK(submap_data_.Contains(constraint.submap_id));
+      CHECK(trajectory_nodes_.at(constraint.node_id).constant_data != nullptr);
+      CHECK(submap_data_.at(constraint.submap_id).submap != nullptr);
+      if (constraint.tag == Constraint::Tag::INTRA_SUBMAP) {
+        CHECK(submap_data_.at(constraint.submap_id)
+                  .node_ids.emplace(constraint.node_id)
+                  .second);
+      }
+      constraints_.push_back(constraint);
+    }
+    LOG(INFO) << "Loaded " << constraints.size() << " constraints.";
+  });
 }
 
 void SparsePoseGraph::AddTrimmer(

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -440,8 +440,8 @@ void SparsePoseGraph::AddNodeFromProto(const transform::Rigid3d& global_pose,
   });
 }
 
-void SparsePoseGraph::AddConstraintsFromProto(
-    const std::shared_ptr<const mapping::proto::SparsePoseGraph> proto) {
+void SparsePoseGraph::AddConstraints(
+    const std::vector<Constraint>& constraints) {
   LOG(FATAL) << "Not yet implemented for 3D.";
 }
 

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -88,7 +88,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
                           const mapping::proto::Submap& submap) override;
   void AddNodeFromProto(const transform::Rigid3d& global_pose,
                         const mapping::proto::Node& node) override;
-  void AddConstraints(const std::vector<Constraint>& constraints) override;
+  void AddSerializedConstraints(
+      const std::vector<Constraint>& constraints) override;
   void AddTrimmer(std::unique_ptr<mapping::PoseGraphTrimmer> trimmer) override;
   void RunFinalOptimization() override;
   std::vector<std::vector<int>> GetConnectedTrajectories() override;

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -88,6 +88,8 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
                           const mapping::proto::Submap& submap) override;
   void AddNodeFromProto(const transform::Rigid3d& global_pose,
                         const mapping::proto::Node& node) override;
+  void AddConstraintsFromProto(
+      std::shared_ptr<const mapping::proto::SparsePoseGraph> proto) override;
   void AddTrimmer(std::unique_ptr<mapping::PoseGraphTrimmer> trimmer) override;
   void RunFinalOptimization() override;
   std::vector<std::vector<int>> GetConnectedTrajectories() override;

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -88,8 +88,7 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
                           const mapping::proto::Submap& submap) override;
   void AddNodeFromProto(const transform::Rigid3d& global_pose,
                         const mapping::proto::Node& node) override;
-  void AddConstraintsFromProto(
-      std::shared_ptr<const mapping::proto::SparsePoseGraph> proto) override;
+  void AddConstraints(const std::vector<Constraint>& constraints) override;
   void AddTrimmer(std::unique_ptr<mapping::PoseGraphTrimmer> trimmer) override;
   void RunFinalOptimization() override;
   std::vector<std::vector<int>> GetConnectedTrajectories() override;


### PR DESCRIPTION
Depends on ~~#541~~ ~~#569~~ and ~~#567~~ (merged).

Also, I would prefer if we didn't have to multiply by the gravity alignment inverse during deserialization. Consider removing it from serialization of constraints?