### PR TITLE
fix ceres dependency name to match rosdep key

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -37,9 +37,9 @@
   <build_depend>python-sphinx</build_depend>
 
   <depend>boost</depend>
-  <depend>ceres-solver</depend>
   <depend>eigen</depend>
   <depend>libcairo2-dev</depend>
+  <depend>libceres-dev</depend>
   <depend>libgflags-dev</depend>
   <depend>libgoogle-glog-dev</depend>
   <depend>lua5.2-dev</depend>


### PR DESCRIPTION
use `libceres-dev` as it is the key defined in the rosdep database for the ceres-solver package: 
https://github.com/ros/rosdistro/blob/0eb70bb82cc6b0dcb613ad8c6e045ab9eee8d24e/rosdep/base.yaml#L1426-L1432