### PR TITLE
Support multiple trajectories in LoadMap

### DIFF
--- a/cartographer/mapping/id.h
+++ b/cartographer/mapping/id.h
@@ -249,6 +249,8 @@ class MapById {
 
   // Inserts data (which must not exist already) into a trajectory.
   void Insert(const IdType& id, const DataType& data) {
+    CHECK_GE(id.trajectory_id, 0);
+    CHECK_GE(GetIndex(id), 0);
     auto& trajectory = trajectories_[id.trajectory_id];
     trajectory.can_append_ = false;
     CHECK(trajectory.data_.emplace(GetIndex(id), data).second);

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -188,14 +188,6 @@ void MapBuilder::LoadMap(io::ProtoStreamReader* const reader) {
     sparse_pose_graph_->FreezeTrajectory(new_trajectory_id);
   }
 
-  // Apply the calculated remapping to constraints in the SparsePoseGraph proto
-  for (auto& constraint_proto : *pose_graph.mutable_constraint()) {
-    constraint_proto.mutable_submap_id()->set_trajectory_id(
-        trajectory_remapping.at(constraint_proto.submap_id().trajectory_id()));
-    constraint_proto.mutable_node_id()->set_trajectory_id(
-        trajectory_remapping.at(constraint_proto.node_id().trajectory_id()));
-  }
-
   MapById<SubmapId, transform::Rigid3d> submap_poses;
   for (const proto::Trajectory& trajectory_proto : pose_graph.trajectory()) {
     for (const proto::Trajectory::Submap& submap_proto :

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -77,13 +77,13 @@ class SparsePoseGraph {
   // Freezes a trajectory. Poses in this trajectory will not be optimized.
   virtual void FreezeTrajectory(int trajectory_id) = 0;
 
-  // Adds a 'submap' from a proto with the given 'pose' to the appropriate
-  // frozen trajectory.
+  // Adds a 'submap' from a proto with the given 'global_pose' to the
+  // appropriate frozen trajectory.
   virtual void AddSubmapFromProto(const transform::Rigid3d& global_pose,
                                   const proto::Submap& submap) = 0;
 
-  // Adds a 'node' from a proto with the given 'pose' to the appropriate
-  // frozen trajectory.
+  // Adds a 'node' from a proto with the given 'global_pose' to the
+  // appropriate frozen trajectory.
   virtual void AddNodeFromProto(const transform::Rigid3d& global_pose,
                                 const proto::Node& node) = 0;
 

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -77,16 +77,14 @@ class SparsePoseGraph {
   // Freezes a trajectory. Poses in this trajectory will not be optimized.
   virtual void FreezeTrajectory(int trajectory_id) = 0;
 
-  // Adds a 'submap' from a proto with the given 'initial_pose' to the frozen
-  // trajectory with 'trajectory_id'.
-  virtual void AddSubmapFromProto(int trajectory_id,
-                                  const transform::Rigid3d& initial_pose,
+  // Adds a 'submap' from a proto with the given 'pose' to the appropriate
+  // frozen trajectory.
+  virtual void AddSubmapFromProto(const transform::Rigid3d& pose,
                                   const proto::Submap& submap) = 0;
 
-  // Adds a 'node' from a proto with the given 'pose' to the frozen trajectory
-  // with 'trajectory_id'.
-  virtual void AddNodeFromProto(int trajectory_id,
-                                const transform::Rigid3d& pose,
+  // Adds a 'node' from a proto with the given 'pose' to the appropriate
+  // frozen trajectory.
+  virtual void AddNodeFromProto(const transform::Rigid3d& pose,
                                 const proto::Node& node) = 0;
 
   // Adds a 'trimmer'. It will be used after all data added before it has been

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -79,12 +79,12 @@ class SparsePoseGraph {
 
   // Adds a 'submap' from a proto with the given 'pose' to the appropriate
   // frozen trajectory.
-  virtual void AddSubmapFromProto(const transform::Rigid3d& pose,
+  virtual void AddSubmapFromProto(const transform::Rigid3d& global_pose,
                                   const proto::Submap& submap) = 0;
 
   // Adds a 'node' from a proto with the given 'pose' to the appropriate
   // frozen trajectory.
-  virtual void AddNodeFromProto(const transform::Rigid3d& pose,
+  virtual void AddNodeFromProto(const transform::Rigid3d& global_pose,
                                 const proto::Node& node) = 0;
 
   // Adds a 'trimmer'. It will be used after all data added before it has been

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -381,13 +381,12 @@ void SparsePoseGraph::AddSubmapFromProto(const transform::Rigid3d& pose,
 
   const mapping::SubmapId proto_submap_id = {submap.submap_id().trajectory_id(),
                                              submap.submap_id().submap_index()};
-  const int trajectory_id = proto_submap_id.trajectory_id;
   std::shared_ptr<const Submap> submap_ptr =
       std::make_shared<const Submap>(submap.submap_2d());
   const transform::Rigid2d pose_2d = transform::Project2D(pose);
 
   common::MutexLocker locker(&mutex_);
-  AddTrajectoryIfNeeded(trajectory_id);
+  AddTrajectoryIfNeeded(proto_submap_id.trajectory_id);
   submap_data_.Insert(proto_submap_id, SubmapData());
   submap_data_.at(proto_submap_id).submap = submap_ptr;
   // Immediately show the submap at the optimized pose.
@@ -404,13 +403,12 @@ void SparsePoseGraph::AddNodeFromProto(const transform::Rigid3d& pose,
                                        const mapping::proto::Node& node) {
   const mapping::NodeId proto_node_id = {node.node_id().trajectory_id(),
                                          node.node_id().node_index()};
-  const int trajectory_id = proto_node_id.trajectory_id;
   std::shared_ptr<const mapping::TrajectoryNode::Data> constant_data =
       std::make_shared<const mapping::TrajectoryNode::Data>(
           mapping::FromProto(node.node_data()));
 
   common::MutexLocker locker(&mutex_);
-  AddTrajectoryIfNeeded(trajectory_id);
+  AddTrajectoryIfNeeded(proto_node_id.trajectory_id);
   trajectory_nodes_.Insert(proto_node_id,
                            mapping::TrajectoryNode{constant_data, pose});
 

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -84,9 +84,9 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
       const sensor::FixedFramePoseData& fixed_frame_pose_data);
 
   void FreezeTrajectory(int trajectory_id) override;
-  void AddSubmapFromProto(const transform::Rigid3d& pose,
+  void AddSubmapFromProto(const transform::Rigid3d& global_pose,
                           const mapping::proto::Submap& submap) override;
-  void AddNodeFromProto(const transform::Rigid3d& pose,
+  void AddNodeFromProto(const transform::Rigid3d& global_pose,
                         const mapping::proto::Node& node) override;
   void AddTrimmer(std::unique_ptr<mapping::PoseGraphTrimmer> trimmer) override;
   void RunFinalOptimization() override;

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -84,10 +84,9 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
       const sensor::FixedFramePoseData& fixed_frame_pose_data);
 
   void FreezeTrajectory(int trajectory_id) override;
-  void AddSubmapFromProto(int trajectory_id,
-                          const transform::Rigid3d& initial_pose,
+  void AddSubmapFromProto(const transform::Rigid3d& pose,
                           const mapping::proto::Submap& submap) override;
-  void AddNodeFromProto(int trajectory_id, const transform::Rigid3d& pose,
+  void AddNodeFromProto(const transform::Rigid3d& pose,
                         const mapping::proto::Node& node) override;
   void AddTrimmer(std::unique_ptr<mapping::PoseGraphTrimmer> trimmer) override;
   void RunFinalOptimization() override;

--- a/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
@@ -78,6 +78,14 @@ void OptimizationProblem::AddOdometerData(
   odometry_data_[trajectory_id].Push(odometry_data.time, odometry_data.pose);
 }
 
+void OptimizationProblem::InsertTrajectoryNode(
+    const mapping::NodeId& node_id, const common::Time time,
+    const transform::Rigid2d& initial_pose, const transform::Rigid2d& pose,
+    const Eigen::Quaterniond& gravity_alignment) {
+  node_data_.Insert(node_id,
+                    NodeData{time, initial_pose, pose, gravity_alignment});
+}
+
 void OptimizationProblem::AddTrajectoryNode(
     const int trajectory_id, const common::Time time,
     const transform::Rigid2d& initial_pose, const transform::Rigid2d& pose,
@@ -99,6 +107,11 @@ void OptimizationProblem::TrimTrajectoryNode(const mapping::NodeId& node_id) {
       imu_data.pop_front();
     }
   }
+}
+
+void OptimizationProblem::InsertSubmap(const mapping::SubmapId& submap_id,
+                                       const transform::Rigid2d& submap_pose) {
+  submap_data_.Insert(submap_id, SubmapData{submap_pose});
 }
 
 void OptimizationProblem::AddSubmap(const int trajectory_id,

--- a/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
@@ -78,6 +78,14 @@ void OptimizationProblem::AddOdometerData(
   odometry_data_[trajectory_id].Push(odometry_data.time, odometry_data.pose);
 }
 
+void OptimizationProblem::AddTrajectoryNode(
+    const int trajectory_id, const common::Time time,
+    const transform::Rigid2d& initial_pose, const transform::Rigid2d& pose,
+    const Eigen::Quaterniond& gravity_alignment) {
+  node_data_.Append(trajectory_id,
+                    NodeData{time, initial_pose, pose, gravity_alignment});
+}
+
 void OptimizationProblem::InsertTrajectoryNode(
     const mapping::NodeId& node_id, const common::Time time,
     const transform::Rigid2d& initial_pose, const transform::Rigid2d& pose,
@@ -86,13 +94,6 @@ void OptimizationProblem::InsertTrajectoryNode(
                     NodeData{time, initial_pose, pose, gravity_alignment});
 }
 
-void OptimizationProblem::AddTrajectoryNode(
-    const int trajectory_id, const common::Time time,
-    const transform::Rigid2d& initial_pose, const transform::Rigid2d& pose,
-    const Eigen::Quaterniond& gravity_alignment) {
-  node_data_.Append(trajectory_id,
-                    NodeData{time, initial_pose, pose, gravity_alignment});
-}
 
 void OptimizationProblem::TrimTrajectoryNode(const mapping::NodeId& node_id) {
   node_data_.Trim(node_id);
@@ -109,14 +110,14 @@ void OptimizationProblem::TrimTrajectoryNode(const mapping::NodeId& node_id) {
   }
 }
 
-void OptimizationProblem::InsertSubmap(const mapping::SubmapId& submap_id,
-                                       const transform::Rigid2d& submap_pose) {
-  submap_data_.Insert(submap_id, SubmapData{submap_pose});
-}
-
 void OptimizationProblem::AddSubmap(const int trajectory_id,
                                     const transform::Rigid2d& submap_pose) {
   submap_data_.Append(trajectory_id, SubmapData{submap_pose});
+}
+
+void OptimizationProblem::InsertSubmap(const mapping::SubmapId& submap_id,
+                                       const transform::Rigid2d& submap_pose) {
+  submap_data_.Insert(submap_id, SubmapData{submap_pose});
 }
 
 void OptimizationProblem::TrimSubmap(const mapping::SubmapId& submap_id) {

--- a/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.h
+++ b/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.h
@@ -65,14 +65,14 @@ class OptimizationProblem {
   void AddImuData(int trajectory_id, const sensor::ImuData& imu_data);
   void AddOdometerData(int trajectory_id,
                        const sensor::OdometryData& odometry_data);
-  void InsertTrajectoryNode(const mapping::NodeId& node_id, common::Time time,
-                            const transform::Rigid2d& initial_pose,
-                            const transform::Rigid2d& pose,
-                            const Eigen::Quaterniond& gravity_alignment);
   void AddTrajectoryNode(int trajectory_id, common::Time time,
                          const transform::Rigid2d& initial_pose,
                          const transform::Rigid2d& pose,
                          const Eigen::Quaterniond& gravity_alignment);
+  void InsertTrajectoryNode(const mapping::NodeId& node_id, common::Time time,
+                            const transform::Rigid2d& initial_pose,
+                            const transform::Rigid2d& pose,
+                            const Eigen::Quaterniond& gravity_alignment);
   void TrimTrajectoryNode(const mapping::NodeId& node_id);
   void AddSubmap(int trajectory_id, const transform::Rigid2d& submap_pose);
   void InsertSubmap(const mapping::SubmapId& submap_id,

--- a/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.h
+++ b/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.h
@@ -65,12 +65,18 @@ class OptimizationProblem {
   void AddImuData(int trajectory_id, const sensor::ImuData& imu_data);
   void AddOdometerData(int trajectory_id,
                        const sensor::OdometryData& odometry_data);
+  void InsertTrajectoryNode(const mapping::NodeId& node_id, common::Time time,
+                            const transform::Rigid2d& initial_pose,
+                            const transform::Rigid2d& pose,
+                            const Eigen::Quaterniond& gravity_alignment);
   void AddTrajectoryNode(int trajectory_id, common::Time time,
                          const transform::Rigid2d& initial_pose,
                          const transform::Rigid2d& pose,
                          const Eigen::Quaterniond& gravity_alignment);
   void TrimTrajectoryNode(const mapping::NodeId& node_id);
   void AddSubmap(int trajectory_id, const transform::Rigid2d& submap_pose);
+  void InsertSubmap(const mapping::SubmapId& submap_id,
+                    const transform::Rigid2d& submap_pose);
   void TrimSubmap(const mapping::SubmapId& submap_id);
 
   void SetMaxNumIterations(int32 max_num_iterations);

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -401,26 +401,20 @@ void SparsePoseGraph::AddSubmapFromProto(const transform::Rigid3d& pose,
 
   const mapping::SubmapId proto_submap_id = {submap.submap_id().trajectory_id(),
                                              submap.submap_id().submap_index()};
-  const int trajectory_id = proto_submap_id.trajectory_id;
   std::shared_ptr<const Submap> submap_ptr =
       std::make_shared<const Submap>(submap.submap_3d());
 
   common::MutexLocker locker(&mutex_);
-  AddTrajectoryIfNeeded(trajectory_id);
-  const mapping::SubmapId submap_id =
-      submap_data_.Append(trajectory_id, SubmapData());
-  // TODO: remove this check when the optimization problem is refactored to
-  // use MapById for submaps
-  CHECK_EQ(submap_id, proto_submap_id);
-  submap_data_.at(submap_id).submap = submap_ptr;
+  AddTrajectoryIfNeeded(proto_submap_id.trajectory_id);
+  submap_data_.Insert(proto_submap_id, SubmapData());
+  submap_data_.at(proto_submap_id).submap = submap_ptr;
   // Immediately show the submap at the optimized pose.
-  CHECK_EQ(submap_id,
-           optimized_submap_transforms_.Append(
-               trajectory_id, sparse_pose_graph::SubmapData{pose}));
-  AddWorkItem([this, submap_id, pose]() REQUIRES(mutex_) {
-    CHECK_EQ(frozen_trajectories_.count(submap_id.trajectory_id), 1);
-    submap_data_.at(submap_id).state = SubmapState::kFinished;
-    optimization_problem_.AddSubmap(submap_id.trajectory_id, pose);
+  optimized_submap_transforms_.Insert(proto_submap_id,
+                                      sparse_pose_graph::SubmapData{pose});
+  AddWorkItem([this, proto_submap_id, pose]() REQUIRES(mutex_) {
+    CHECK_EQ(frozen_trajectories_.count(proto_submap_id.trajectory_id), 1);
+    submap_data_.at(proto_submap_id).state = SubmapState::kFinished;
+    optimization_problem_.InsertSubmap(proto_submap_id, pose);
   });
 }
 
@@ -428,25 +422,21 @@ void SparsePoseGraph::AddNodeFromProto(const transform::Rigid3d& pose,
                                        const mapping::proto::Node& node) {
   const mapping::NodeId proto_node_id = {node.node_id().trajectory_id(),
                                          node.node_id().node_index()};
-  const int trajectory_id = proto_node_id.trajectory_id;
   std::shared_ptr<const mapping::TrajectoryNode::Data> constant_data =
       std::make_shared<const mapping::TrajectoryNode::Data>(
           mapping::FromProto(node.node_data()));
 
   common::MutexLocker locker(&mutex_);
-  AddTrajectoryIfNeeded(trajectory_id);
-  const mapping::NodeId node_id = trajectory_nodes_.Append(
-      trajectory_id, mapping::TrajectoryNode{constant_data, pose});
-  // TODO: remove this check when the optimization problem is refactored to
-  // use MapById for trajectory nodes
-  CHECK_EQ(node_id, proto_node_id);
+  AddTrajectoryIfNeeded(proto_node_id.trajectory_id);
+  trajectory_nodes_.Insert(proto_node_id,
+                           mapping::TrajectoryNode{constant_data, pose});
 
-  AddWorkItem([this, node_id, pose]() REQUIRES(mutex_) {
-    CHECK_EQ(frozen_trajectories_.count(node_id.trajectory_id), 1);
-    const auto& constant_data = trajectory_nodes_.at(node_id).constant_data;
-    optimization_problem_.AddTrajectoryNode(node_id.trajectory_id,
-                                            constant_data->time,
-                                            constant_data->local_pose, pose);
+  AddWorkItem([this, proto_node_id, pose]() REQUIRES(mutex_) {
+    CHECK_EQ(frozen_trajectories_.count(proto_node_id.trajectory_id), 1);
+    const auto& constant_data =
+        trajectory_nodes_.at(proto_node_id).constant_data;
+    optimization_problem_.InsertTrajectoryNode(
+        proto_node_id, constant_data->time, constant_data->local_pose, pose);
   });
 }
 

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -399,45 +399,43 @@ void SparsePoseGraph::AddSubmapFromProto(const transform::Rigid3d& global_pose,
     return;
   }
 
-  const mapping::SubmapId proto_submap_id = {submap.submap_id().trajectory_id(),
-                                             submap.submap_id().submap_index()};
+  const mapping::SubmapId submap_id = {submap.submap_id().trajectory_id(),
+                                       submap.submap_id().submap_index()};
   std::shared_ptr<const Submap> submap_ptr =
       std::make_shared<const Submap>(submap.submap_3d());
 
   common::MutexLocker locker(&mutex_);
-  AddTrajectoryIfNeeded(proto_submap_id.trajectory_id);
-  submap_data_.Insert(proto_submap_id, SubmapData());
-  submap_data_.at(proto_submap_id).submap = submap_ptr;
+  AddTrajectoryIfNeeded(submap_id.trajectory_id);
+  submap_data_.Insert(submap_id, SubmapData());
+  submap_data_.at(submap_id).submap = submap_ptr;
   // Immediately show the submap at the optimized pose.
   optimized_submap_transforms_.Insert(
-      proto_submap_id, sparse_pose_graph::SubmapData{global_pose});
-  AddWorkItem([this, proto_submap_id, global_pose]() REQUIRES(mutex_) {
-    CHECK_EQ(frozen_trajectories_.count(proto_submap_id.trajectory_id), 1);
-    submap_data_.at(proto_submap_id).state = SubmapState::kFinished;
-    optimization_problem_.InsertSubmap(proto_submap_id, global_pose);
+      submap_id, sparse_pose_graph::SubmapData{global_pose});
+  AddWorkItem([this, submap_id, global_pose]() REQUIRES(mutex_) {
+    CHECK_EQ(frozen_trajectories_.count(submap_id.trajectory_id), 1);
+    submap_data_.at(submap_id).state = SubmapState::kFinished;
+    optimization_problem_.InsertSubmap(submap_id, global_pose);
   });
 }
 
 void SparsePoseGraph::AddNodeFromProto(const transform::Rigid3d& global_pose,
                                        const mapping::proto::Node& node) {
-  const mapping::NodeId proto_node_id = {node.node_id().trajectory_id(),
-                                         node.node_id().node_index()};
+  const mapping::NodeId node_id = {node.node_id().trajectory_id(),
+                                   node.node_id().node_index()};
   std::shared_ptr<const mapping::TrajectoryNode::Data> constant_data =
       std::make_shared<const mapping::TrajectoryNode::Data>(
           mapping::FromProto(node.node_data()));
 
   common::MutexLocker locker(&mutex_);
-  AddTrajectoryIfNeeded(proto_node_id.trajectory_id);
-  trajectory_nodes_.Insert(proto_node_id,
+  AddTrajectoryIfNeeded(node_id.trajectory_id);
+  trajectory_nodes_.Insert(node_id,
                            mapping::TrajectoryNode{constant_data, global_pose});
 
-  AddWorkItem([this, proto_node_id, global_pose]() REQUIRES(mutex_) {
-    CHECK_EQ(frozen_trajectories_.count(proto_node_id.trajectory_id), 1);
-    const auto& constant_data =
-        trajectory_nodes_.at(proto_node_id).constant_data;
+  AddWorkItem([this, node_id, global_pose]() REQUIRES(mutex_) {
+    CHECK_EQ(frozen_trajectories_.count(node_id.trajectory_id), 1);
+    const auto& constant_data = trajectory_nodes_.at(node_id).constant_data;
     optimization_problem_.InsertTrajectoryNode(
-        proto_node_id, constant_data->time, constant_data->local_pose,
-        global_pose);
+        node_id, constant_data->time, constant_data->local_pose, global_pose);
   });
 }
 

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -393,7 +393,7 @@ void SparsePoseGraph::FreezeTrajectory(const int trajectory_id) {
   });
 }
 
-void SparsePoseGraph::AddSubmapFromProto(const transform::Rigid3d& pose,
+void SparsePoseGraph::AddSubmapFromProto(const transform::Rigid3d& global_pose,
                                          const mapping::proto::Submap& submap) {
   if (!submap.has_submap_3d()) {
     return;
@@ -409,16 +409,16 @@ void SparsePoseGraph::AddSubmapFromProto(const transform::Rigid3d& pose,
   submap_data_.Insert(proto_submap_id, SubmapData());
   submap_data_.at(proto_submap_id).submap = submap_ptr;
   // Immediately show the submap at the optimized pose.
-  optimized_submap_transforms_.Insert(proto_submap_id,
-                                      sparse_pose_graph::SubmapData{pose});
-  AddWorkItem([this, proto_submap_id, pose]() REQUIRES(mutex_) {
+  optimized_submap_transforms_.Insert(
+      proto_submap_id, sparse_pose_graph::SubmapData{global_pose});
+  AddWorkItem([this, proto_submap_id, global_pose]() REQUIRES(mutex_) {
     CHECK_EQ(frozen_trajectories_.count(proto_submap_id.trajectory_id), 1);
     submap_data_.at(proto_submap_id).state = SubmapState::kFinished;
-    optimization_problem_.InsertSubmap(proto_submap_id, pose);
+    optimization_problem_.InsertSubmap(proto_submap_id, global_pose);
   });
 }
 
-void SparsePoseGraph::AddNodeFromProto(const transform::Rigid3d& pose,
+void SparsePoseGraph::AddNodeFromProto(const transform::Rigid3d& global_pose,
                                        const mapping::proto::Node& node) {
   const mapping::NodeId proto_node_id = {node.node_id().trajectory_id(),
                                          node.node_id().node_index()};
@@ -429,14 +429,15 @@ void SparsePoseGraph::AddNodeFromProto(const transform::Rigid3d& pose,
   common::MutexLocker locker(&mutex_);
   AddTrajectoryIfNeeded(proto_node_id.trajectory_id);
   trajectory_nodes_.Insert(proto_node_id,
-                           mapping::TrajectoryNode{constant_data, pose});
+                           mapping::TrajectoryNode{constant_data, global_pose});
 
-  AddWorkItem([this, proto_node_id, pose]() REQUIRES(mutex_) {
+  AddWorkItem([this, proto_node_id, global_pose]() REQUIRES(mutex_) {
     CHECK_EQ(frozen_trajectories_.count(proto_node_id.trajectory_id), 1);
     const auto& constant_data =
         trajectory_nodes_.at(proto_node_id).constant_data;
     optimization_problem_.InsertTrajectoryNode(
-        proto_node_id, constant_data->time, constant_data->local_pose, pose);
+        proto_node_id, constant_data->time, constant_data->local_pose,
+        global_pose);
   });
 }
 

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -84,9 +84,9 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
       const sensor::FixedFramePoseData& fixed_frame_pose_data);
 
   void FreezeTrajectory(int trajectory_id) override;
-  void AddSubmapFromProto(const transform::Rigid3d& pose,
+  void AddSubmapFromProto(const transform::Rigid3d& global_pose,
                           const mapping::proto::Submap& submap) override;
-  void AddNodeFromProto(const transform::Rigid3d& pose,
+  void AddNodeFromProto(const transform::Rigid3d& global_pose,
                         const mapping::proto::Node& node) override;
   void AddTrimmer(std::unique_ptr<mapping::PoseGraphTrimmer> trimmer) override;
   void RunFinalOptimization() override;

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -84,10 +84,9 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
       const sensor::FixedFramePoseData& fixed_frame_pose_data);
 
   void FreezeTrajectory(int trajectory_id) override;
-  void AddSubmapFromProto(int trajectory_id,
-                          const transform::Rigid3d& initial_pose,
+  void AddSubmapFromProto(const transform::Rigid3d& pose,
                           const mapping::proto::Submap& submap) override;
-  void AddNodeFromProto(int trajectory_id, const transform::Rigid3d& pose,
+  void AddNodeFromProto(const transform::Rigid3d& pose,
                         const mapping::proto::Node& node) override;
   void AddTrimmer(std::unique_ptr<mapping::PoseGraphTrimmer> trimmer) override;
   void RunFinalOptimization() override;

--- a/cartographer/mapping_3d/sparse_pose_graph/optimization_problem.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph/optimization_problem.cc
@@ -89,6 +89,15 @@ void OptimizationProblem::AddTrajectoryNode(
   node_data_.Append(trajectory_id, NodeData{time, initial_pose, pose});
 }
 
+void OptimizationProblem::InsertTrajectoryNode(
+    const mapping::NodeId& node_id, const common::Time time,
+    const transform::Rigid3d& initial_pose, const transform::Rigid3d& pose) {
+  CHECK_GE(node_id.trajectory_id, 0);
+  trajectory_data_.resize(std::max(
+      trajectory_data_.size(), static_cast<size_t>(node_id.trajectory_id) + 1));
+  node_data_.Insert(node_id, NodeData{time, initial_pose, pose});
+}
+
 void OptimizationProblem::TrimTrajectoryNode(const mapping::NodeId& node_id) {
   node_data_.Trim(node_id);
 
@@ -110,6 +119,15 @@ void OptimizationProblem::AddSubmap(const int trajectory_id,
   trajectory_data_.resize(std::max(trajectory_data_.size(),
                                    static_cast<size_t>(trajectory_id) + 1));
   submap_data_.Append(trajectory_id, SubmapData{submap_pose});
+}
+
+void OptimizationProblem::InsertSubmap(const mapping::SubmapId& submap_id,
+                                       const transform::Rigid3d& submap_pose) {
+  CHECK_GE(submap_id.trajectory_id, 0);
+  trajectory_data_.resize(
+      std::max(trajectory_data_.size(),
+               static_cast<size_t>(submap_id.trajectory_id) + 1));
+  submap_data_.Insert(submap_id, SubmapData{submap_pose});
 }
 
 void OptimizationProblem::TrimSubmap(const mapping::SubmapId& submap_id) {

--- a/cartographer/mapping_3d/sparse_pose_graph/optimization_problem.h
+++ b/cartographer/mapping_3d/sparse_pose_graph/optimization_problem.h
@@ -74,8 +74,13 @@ class OptimizationProblem {
   void AddTrajectoryNode(int trajectory_id, common::Time time,
                          const transform::Rigid3d& initial_pose,
                          const transform::Rigid3d& pose);
+  void InsertTrajectoryNode(const mapping::NodeId& node_id, common::Time time,
+                            const transform::Rigid3d& initial_pose,
+                            const transform::Rigid3d& pose);
   void TrimTrajectoryNode(const mapping::NodeId& node_id);
   void AddSubmap(int trajectory_id, const transform::Rigid3d& submap_pose);
+  void InsertSubmap(const mapping::SubmapId& submap_id,
+                    const transform::Rigid3d& submap_pose);
   void TrimSubmap(const mapping::SubmapId& submap_id);
 
   void SetMaxNumIterations(int32 max_num_iterations);


### PR DESCRIPTION
Depends on ~~#569.~~ (merged) and probably ~~#576~~ (closed, not merged) ~~#603~~ (merged, replaces #576)

Also change the prototype of AddSubmapFromProto's argument "initial_pose" to "pose". The loaded pose may be the result of prior optimisation. "initial pose" is a term I associate with an unoptimized pose.

Partially replaces #541.

Note: LoadMap will be renamed in #554 to LoadState.