### PR TITLE
Apply SPG serialization ID remapping in MapBuilder::SerializeState.

### DIFF
--- a/cartographer/mapping/sparse_pose_graph.cc
+++ b/cartographer/mapping/sparse_pose_graph.cc
@@ -63,7 +63,8 @@ proto::SparsePoseGraphOptions CreateSparsePoseGraphOptions(
   return options;
 }
 
-proto::SparsePoseGraph SparsePoseGraph::ToProto() {
+proto::SparsePoseGraph SparsePoseGraph::ToProto(
+    SerializationRemapping* serialization_remapping) {
   proto::SparsePoseGraph proto;
 
   std::map<NodeId, NodeId> node_id_remapping;        // Due to trimming.
@@ -96,7 +97,7 @@ proto::SparsePoseGraph SparsePoseGraph::ToProto() {
          old_submap_index != single_trajectory_submap_data.size();
          ++old_submap_index) {
       const auto& submap_data = single_trajectory_submap_data[old_submap_index];
-      if (submap_data.submap != nullptr) {
+      if (!submap_data.trimmed()) {
         submap_id_remapping[SubmapId{static_cast<int>(trajectory_id),
                                      static_cast<int>(old_submap_index)}] =
             SubmapId{static_cast<int>(trajectory_id),
@@ -127,6 +128,11 @@ proto::SparsePoseGraph SparsePoseGraph::ToProto() {
     constraint_proto->mutable_node_id()->set_node_index(node_id.node_index);
 
     constraint_proto->set_tag(mapping::ToProto(constraint.tag));
+  }
+
+  if (serialization_remapping != nullptr) {
+    *serialization_remapping =
+        SerializationRemapping{node_id_remapping, submap_id_remapping};
   }
 
   return proto;

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -66,6 +66,8 @@ class SparsePoseGraph {
   struct SubmapData {
     std::shared_ptr<const Submap> submap;
     transform::Rigid3d pose;
+
+    bool trimmed() const { return submap == nullptr; }
   };
 
   SparsePoseGraph() {}
@@ -117,8 +119,16 @@ class SparsePoseGraph {
   // Returns the current optimized trajectories.
   virtual std::vector<std::vector<TrajectoryNode>> GetTrajectoryNodes() = 0;
 
-  // Serializes the constraints and trajectories.
-  proto::SparsePoseGraph ToProto();
+  struct SerializationRemapping {
+    std::map<NodeId, NodeId> node_id_remapping;
+    std::map<SubmapId, SubmapId> submap_id_remapping;
+  };
+
+  // Serializes the constraints and trajectories. Optionally, store the
+  // remapping of node and submap IDs due to trimming (pass nullptr if
+  // unneeded).
+  proto::SparsePoseGraph ToProto(
+      SerializationRemapping* serialization_remapping);
 
   // Returns the collection of constraints.
   virtual std::vector<Constraint> constraints() = 0;


### PR DESCRIPTION
Related to #567. @wohe will this alleviate your concerns about that [`CHECK`](https://github.com/googlecartographer/cartographer/pull/567#discussion_r142923769) in #567 breaking loading of states with trimmed data?

I am not sure if extracting the remapping by passing a pointer to `SPG::ToProto()` is the most elegant thing to do, I am open to suggestions.