### PR TITLE
Extrapolator reuses result using additional IMU trackers.

### DIFF
--- a/cartographer/mapping/pose_extrapolator.cc
+++ b/cartographer/mapping/pose_extrapolator.cc
@@ -57,7 +57,10 @@ common::Time PoseExtrapolator::GetLastPoseTime() const {
 }
 
 common::Time PoseExtrapolator::GetLastExtrapolatedTime() const {
-  return GetLastPoseTime();
+  if (!extrapolation_imu_tracker_) {
+    return common::Time::min();
+  }
+  return extrapolation_imu_tracker_->time();
 }
 
 void PoseExtrapolator::AddPose(const common::Time time,

--- a/cartographer/mapping/pose_extrapolator.cc
+++ b/cartographer/mapping/pose_extrapolator.cc
@@ -76,7 +76,7 @@ void PoseExtrapolator::AddPose(const common::Time time,
   TrimImuData();
   TrimOdometryData();
   odometry_imu_tracker_ = common::make_unique<ImuTracker>(*imu_tracker_);
-  pose_imu_tracker_ = common::make_unique<ImuTracker>(*imu_tracker_);
+  extrapolation_imu_tracker_ = common::make_unique<ImuTracker>(*imu_tracker_);
 }
 
 void PoseExtrapolator::AddImuData(const sensor::ImuData& imu_data) {
@@ -129,7 +129,7 @@ transform::Rigid3d PoseExtrapolator::ExtrapolatePose(const common::Time time) {
   return transform::Rigid3d::Translation(ExtrapolateTranslation(time)) *
          newest_timed_pose.pose *
          transform::Rigid3d::Rotation(
-             ExtrapolateRotation(time, pose_imu_tracker_.get()));
+             ExtrapolateRotation(time, extrapolation_imu_tracker_.get()));
 }
 
 Eigen::Quaterniond PoseExtrapolator::EstimateGravityOrientation(

--- a/cartographer/mapping/pose_extrapolator.h
+++ b/cartographer/mapping/pose_extrapolator.h
@@ -78,7 +78,7 @@ class PoseExtrapolator {
   std::deque<sensor::ImuData> imu_data_;
   std::unique_ptr<ImuTracker> imu_tracker_;
   std::unique_ptr<ImuTracker> odometry_imu_tracker_;
-  std::unique_ptr<ImuTracker> pose_imu_tracker_;
+  std::unique_ptr<ImuTracker> extrapolation_imu_tracker_;
 
   std::deque<sensor::OdometryData> odometry_data_;
   Eigen::Vector3d linear_velocity_from_odometry_ = Eigen::Vector3d::Zero();

--- a/cartographer/mapping/pose_extrapolator.h
+++ b/cartographer/mapping/pose_extrapolator.h
@@ -60,8 +60,9 @@ class PoseExtrapolator {
   void UpdateVelocitiesFromPoses();
   void TrimImuData();
   void TrimOdometryData();
-  void AdvanceImuTracker(common::Time time, ImuTracker* imu_tracker);
-  Eigen::Quaterniond ExtrapolateRotation(common::Time time);
+  void AdvanceImuTracker(common::Time time, ImuTracker* imu_tracker) const;
+  Eigen::Quaterniond ExtrapolateRotation(common::Time time,
+                                         ImuTracker* imu_tracker) const;
   Eigen::Vector3d ExtrapolateTranslation(common::Time time);
 
   const common::Duration pose_queue_duration_;
@@ -76,6 +77,8 @@ class PoseExtrapolator {
   const double gravity_time_constant_;
   std::deque<sensor::ImuData> imu_data_;
   std::unique_ptr<ImuTracker> imu_tracker_;
+  std::unique_ptr<ImuTracker> odometry_imu_tracker_;
+  std::unique_ptr<ImuTracker> pose_imu_tracker_;
 
   std::deque<sensor::OdometryData> odometry_data_;
   Eigen::Vector3d linear_velocity_from_odometry_ = Eigen::Vector3d::Zero();


### PR DESCRIPTION
Avoids extrapolating from the last known pose buts reuses an
intermediate result from a previous ExtrapolatePose call if
time is in the future. This makes the extrapolator stricter that time 
arguments must be monotonously increasing when calling the
Extrapolate methods.