### PR TITLE
move string and size specific int/uint typedefs into cartographer namespace

### DIFF
--- a/cartographer/common/configuration_files_test.cc
+++ b/cartographer/common/configuration_files_test.cc
@@ -23,6 +23,8 @@
 #include "cartographer/mapping/map_builder.h"
 #include "gtest/gtest.h"
 
+using std::string;
+
 namespace cartographer_ros {
 namespace {
 

--- a/cartographer/common/port.h
+++ b/cartographer/common/port.h
@@ -25,6 +25,9 @@
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 
+
+namespace cartographer {
+
 using int8 = int8_t;
 using int16 = int16_t;
 using int32 = int32_t;
@@ -36,7 +39,6 @@ using uint64 = uint64_t;
 
 using std::string;
 
-namespace cartographer {
 namespace common {
 
 inline int RoundToInt(const float x) { return std::lround(x); }


### PR DESCRIPTION
move string and size specific int/uint typedefs into cartographer namespace as minimal change necessary to keep global namespace clean

Alternate, more complete pull request forthcoming.