### PR TITLE
Make proto::ProbabilityGrid proto3 compatible.

### DIFF
--- a/cartographer/common/port.h
+++ b/cartographer/common/port.h
@@ -25,7 +25,6 @@
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 
-
 namespace cartographer {
 
 using int8 = int8_t;

--- a/cartographer/mapping_2d/probability_grid.h
+++ b/cartographer/mapping_2d/probability_grid.h
@@ -47,10 +47,11 @@ class ProbabilityGrid {
 
   explicit ProbabilityGrid(const proto::ProbabilityGrid& proto)
       : limits_(proto.limits()), cells_() {
-    if (proto.has_min_x()) {
+    if (proto.has_known_cells_box()) {
+      const auto& box = proto.known_cells_box();
       known_cells_box_ =
-          Eigen::AlignedBox2i(Eigen::Vector2i(proto.min_x(), proto.min_y()),
-                              Eigen::Vector2i(proto.max_x(), proto.max_y()));
+          Eigen::AlignedBox2i(Eigen::Vector2i(box.min_x(), box.min_y()),
+                              Eigen::Vector2i(box.max_x(), box.max_y()));
     }
     cells_.reserve(proto.cells_size());
     for (const auto cell : proto.cells()) {
@@ -175,10 +176,11 @@ class ProbabilityGrid {
     CHECK(update_indices_.empty()) << "Serializing a grid during an update is "
                                       "not supported. Finish the update first.";
     if (!known_cells_box_.isEmpty()) {
-      result.set_max_x(known_cells_box_.max().x());
-      result.set_max_y(known_cells_box_.max().y());
-      result.set_min_x(known_cells_box_.min().x());
-      result.set_min_y(known_cells_box_.min().y());
+      auto* const box = result.mutable_known_cells_box();
+      box->set_max_x(known_cells_box_.max().x());
+      box->set_max_y(known_cells_box_.max().y());
+      box->set_min_x(known_cells_box_.min().x());
+      box->set_min_y(known_cells_box_.min().y());
     }
     return result;
   }

--- a/cartographer/mapping_2d/probability_grid_test.cc
+++ b/cartographer/mapping_2d/probability_grid_test.cc
@@ -32,10 +32,10 @@ TEST(ProbabilityGridTest, ProtoConstructor) {
   for (int i = 6; i < 12; ++i) {
     proto.mutable_cells()->Add(static_cast<uint16>(i));
   }
-  proto.set_max_x(19);
-  proto.set_max_y(20);
-  proto.set_min_x(21);
-  proto.set_min_y(22);
+  proto.mutable_known_cells_box()->set_max_x(19);
+  proto.mutable_known_cells_box()->set_max_y(20);
+  proto.mutable_known_cells_box()->set_min_x(21);
+  proto.mutable_known_cells_box()->set_min_y(22);
 
   ProbabilityGrid grid(proto);
   EXPECT_EQ(proto.limits().DebugString(), ToProto(grid.limits()).DebugString());

--- a/cartographer/mapping_2d/proto/probability_grid.proto
+++ b/cartographer/mapping_2d/proto/probability_grid.proto
@@ -19,12 +19,16 @@ import "cartographer/mapping_2d/proto/map_limits.proto";
 package cartographer.mapping_2d.proto;
 
 message ProbabilityGrid {
+  message CellBox {
+    optional int32 max_x = 1;
+    optional int32 max_y = 2;
+    optional int32 min_x = 3;
+    optional int32 min_y = 4;
+  }
+
   optional MapLimits limits = 1;
   // These values are actually int16s, but protos don't have a native int16
   // type.
   repeated int32 cells = 2;
-  optional int32 max_x = 4;
-  optional int32 max_y = 5;
-  optional int32 min_x = 6;
-  optional int32 min_y = 7;
+  optional CellBox known_cells_box = 8;
 }


### PR DESCRIPTION
Moves the optional 'known_cells_box' into a message field.
This way its existence can still be checked in proto3.