### PR TITLE
FastCorrelativeScanMatcher outputs unique_ptr.

### DIFF
--- a/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher_test.cc
+++ b/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher_test.cc
@@ -140,7 +140,7 @@ TEST_F(FastCorrelativeScanMatcherTest, CorrectPoseForMatch) {
     std::unique_ptr<FastCorrelativeScanMatcher> fast_correlative_scan_matcher(
         GetFastCorrelativeScanMatcher(options_, expected_pose));
 
-    std::unique_ptr<FastCorrelativeScanMatcher::Result> result =
+    const std::unique_ptr<FastCorrelativeScanMatcher::Result> result =
         fast_correlative_scan_matcher->Match(
             transform::Rigid3d::Identity(), transform::Rigid3d::Identity(),
             CreateConstantData(point_cloud_), kMinScore);
@@ -152,10 +152,13 @@ TEST_F(FastCorrelativeScanMatcherTest, CorrectPoseForMatch) {
                 transform::IsNearly(result->pose_estimate.cast<float>(), 0.05f))
         << "Actual: " << transform::ToProto(result->pose_estimate).DebugString()
         << "\nExpected: " << transform::ToProto(expected_pose).DebugString();
-    result = fast_correlative_scan_matcher->Match(
-        transform::Rigid3d::Identity(), transform::Rigid3d::Identity(),
-        CreateConstantData({Eigen::Vector3f(42.f, 42.f, 42.f)}), kMinScore);
-    EXPECT_THAT(result, testing::IsNull()) << result->low_resolution_score;
+
+    const std::unique_ptr<FastCorrelativeScanMatcher::Result>
+        low_resolution_result = fast_correlative_scan_matcher->Match(
+            transform::Rigid3d::Identity(), transform::Rigid3d::Identity(),
+            CreateConstantData({Eigen::Vector3f(42.f, 42.f, 42.f)}), kMinScore);
+    EXPECT_THAT(low_resolution_result, testing::IsNull())
+        << low_resolution_result->low_resolution_score;
   }
 }
 
@@ -177,10 +180,13 @@ TEST_F(FastCorrelativeScanMatcherTest, CorrectPoseForMatchFullSubmap) {
               transform::IsNearly(result->pose_estimate.cast<float>(), 0.05f))
       << "Actual: " << transform::ToProto(result->pose_estimate).DebugString()
       << "\nExpected: " << transform::ToProto(expected_pose).DebugString();
-  result = fast_correlative_scan_matcher->MatchFullSubmap(
-      Eigen::Quaterniond::Identity(), Eigen::Quaterniond::Identity(),
-      CreateConstantData({Eigen::Vector3f(42.f, 42.f, 42.f)}), kMinScore);
-  EXPECT_THAT(result, testing::IsNull()) << result->low_resolution_score;
+
+  const std::unique_ptr<FastCorrelativeScanMatcher::Result>
+      low_resolution_result = fast_correlative_scan_matcher->MatchFullSubmap(
+          Eigen::Quaterniond::Identity(), Eigen::Quaterniond::Identity(),
+          CreateConstantData({Eigen::Vector3f(42.f, 42.f, 42.f)}), kMinScore);
+  EXPECT_THAT(low_resolution_result, testing::IsNull())
+      << low_resolution_result->low_resolution_score;
 }
 
 }  // namespace

--- a/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher_test.cc
+++ b/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher_test.cc
@@ -140,26 +140,22 @@ TEST_F(FastCorrelativeScanMatcherTest, CorrectPoseForMatch) {
     std::unique_ptr<FastCorrelativeScanMatcher> fast_correlative_scan_matcher(
         GetFastCorrelativeScanMatcher(options_, expected_pose));
 
-    float score = 0.f;
-    transform::Rigid3d pose_estimate;
-    float rotational_score = 0.f;
-    float low_resolution_score = 0.f;
-    EXPECT_TRUE(fast_correlative_scan_matcher->Match(
-        transform::Rigid3d::Identity(), transform::Rigid3d::Identity(),
-        CreateConstantData(point_cloud_), kMinScore, &score, &pose_estimate,
-        &rotational_score, &low_resolution_score));
-    EXPECT_LT(kMinScore, score);
-    EXPECT_LT(0.09f, rotational_score);
-    EXPECT_LT(0.14f, low_resolution_score);
+    std::unique_ptr<FastCorrelativeScanMatcher::Result> result =
+        fast_correlative_scan_matcher->Match(
+            transform::Rigid3d::Identity(), transform::Rigid3d::Identity(),
+            CreateConstantData(point_cloud_), kMinScore);
+    EXPECT_THAT(result, testing::NotNull());
+    EXPECT_LT(kMinScore, result->score);
+    EXPECT_LT(0.09f, result->rotational_score);
+    EXPECT_LT(0.14f, result->low_resolution_score);
     EXPECT_THAT(expected_pose,
-                transform::IsNearly(pose_estimate.cast<float>(), 0.05f))
-        << "Actual: " << transform::ToProto(pose_estimate).DebugString()
+                transform::IsNearly(result->pose_estimate.cast<float>(), 0.05f))
+        << "Actual: " << transform::ToProto(result->pose_estimate).DebugString()
         << "\nExpected: " << transform::ToProto(expected_pose).DebugString();
-    EXPECT_FALSE(fast_correlative_scan_matcher->Match(
+    result = fast_correlative_scan_matcher->Match(
         transform::Rigid3d::Identity(), transform::Rigid3d::Identity(),
-        CreateConstantData({Eigen::Vector3f(42.f, 42.f, 42.f)}), kMinScore,
-        &score, &pose_estimate, &rotational_score, &low_resolution_score))
-        << low_resolution_score;
+        CreateConstantData({Eigen::Vector3f(42.f, 42.f, 42.f)}), kMinScore);
+    EXPECT_THAT(result, testing::IsNull()) << result->low_resolution_score;
   }
 }
 
@@ -169,26 +165,22 @@ TEST_F(FastCorrelativeScanMatcherTest, CorrectPoseForMatchFullSubmap) {
   std::unique_ptr<FastCorrelativeScanMatcher> fast_correlative_scan_matcher(
       GetFastCorrelativeScanMatcher(options_, expected_pose));
 
-  float score = 0.f;
-  transform::Rigid3d pose_estimate;
-  float rotational_score = 0.f;
-  float low_resolution_score = 0.f;
-  EXPECT_TRUE(fast_correlative_scan_matcher->MatchFullSubmap(
-      Eigen::Quaterniond::Identity(), Eigen::Quaterniond::Identity(),
-      CreateConstantData(point_cloud_), kMinScore, &score, &pose_estimate,
-      &rotational_score, &low_resolution_score));
-  EXPECT_LT(kMinScore, score);
-  EXPECT_LT(0.09f, rotational_score);
-  EXPECT_LT(0.14f, low_resolution_score);
+  std::unique_ptr<FastCorrelativeScanMatcher::Result> result =
+      fast_correlative_scan_matcher->MatchFullSubmap(
+          Eigen::Quaterniond::Identity(), Eigen::Quaterniond::Identity(),
+          CreateConstantData(point_cloud_), kMinScore);
+  EXPECT_THAT(result, testing::NotNull());
+  EXPECT_LT(kMinScore, result->score);
+  EXPECT_LT(0.09f, result->rotational_score);
+  EXPECT_LT(0.14f, result->low_resolution_score);
   EXPECT_THAT(expected_pose,
-              transform::IsNearly(pose_estimate.cast<float>(), 0.05f))
-      << "Actual: " << transform::ToProto(pose_estimate).DebugString()
+              transform::IsNearly(result->pose_estimate.cast<float>(), 0.05f))
+      << "Actual: " << transform::ToProto(result->pose_estimate).DebugString()
       << "\nExpected: " << transform::ToProto(expected_pose).DebugString();
-  EXPECT_FALSE(fast_correlative_scan_matcher->MatchFullSubmap(
+  result = fast_correlative_scan_matcher->MatchFullSubmap(
       Eigen::Quaterniond::Identity(), Eigen::Quaterniond::Identity(),
-      CreateConstantData({Eigen::Vector3f(42.f, 42.f, 42.f)}), kMinScore,
-      &score, &pose_estimate, &rotational_score, &low_resolution_score))
-      << low_resolution_score;
+      CreateConstantData({Eigen::Vector3f(42.f, 42.f, 42.f)}), kMinScore);
+  EXPECT_THAT(result, testing::IsNull()) << result->low_resolution_score;
 }
 
 }  // namespace

--- a/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher_test.cc
+++ b/cartographer/mapping_3d/scan_matching/fast_correlative_scan_matcher_test.cc
@@ -168,7 +168,7 @@ TEST_F(FastCorrelativeScanMatcherTest, CorrectPoseForMatchFullSubmap) {
   std::unique_ptr<FastCorrelativeScanMatcher> fast_correlative_scan_matcher(
       GetFastCorrelativeScanMatcher(options_, expected_pose));
 
-  std::unique_ptr<FastCorrelativeScanMatcher::Result> result =
+  const std::unique_ptr<FastCorrelativeScanMatcher::Result> result =
       fast_correlative_scan_matcher->MatchFullSubmap(
           Eigen::Quaterniond::Identity(), Eigen::Quaterniond::Identity(),
           CreateConstantData(point_cloud_), kMinScore);


### PR DESCRIPTION
Match methods use unique_ptr to output an optional result rather than writing into multiple pointer arguments.