### PR TITLE
CMake bug fixes and performance improvements.

### DIFF
--- a/cmake/modules/FindLuaGoogle.cmake
+++ b/cmake/modules/FindLuaGoogle.cmake
@@ -70,7 +70,7 @@ unset(_lua_append_versions)
 
 # this is a function only to have all the variables inside go away automatically
 function(_lua_set_version_vars)
-    set(LUA_VERSIONS5 5.3 5.2 5.1 5.0)
+    set(LUA_VERSIONS5 5.3 5.2)
 
     if (Lua_FIND_VERSION_EXACT)
         if (Lua_FIND_VERSION_COUNT GREATER 1)
@@ -211,5 +211,10 @@ endif ()
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(Lua
                                   REQUIRED_VARS LUA_LIBRARIES LUA_INCLUDE_DIR
                                   VERSION_VAR LUA_VERSION_STRING)
-
 mark_as_advanced(LUA_INCLUDE_DIR LUA_LIBRARY LUA_MATH_LIBRARY)
+
+if (NOT LUA_FOUND)
+  MESSAGE(FATAL_ERROR "Did not find Lua >= 5.2.")
+endif ()
+
+

--- a/scripts/install_ceres.sh
+++ b/scripts/install_ceres.sh
@@ -17,9 +17,12 @@
 set -o errexit
 set -o verbose
 
+VERSION="1.13.0"
+
 # Build and install Ceres.
 git clone https://ceres-solver.googlesource.com/ceres-solver
 cd ceres-solver
+git checkout tags/${VERSION}
 mkdir build
 cd build
 cmake .. -G Ninja

--- a/scripts/install_proto3.sh
+++ b/scripts/install_proto3.sh
@@ -17,9 +17,12 @@
 set -o errexit
 set -o verbose
 
+VERSION="v3.4.1"
+
 # Build and install proto3.
 git clone https://github.com/google/protobuf.git
 cd protobuf
+git checkout tags/${VERSION}
 mkdir build
 cd build
 cmake -G Ninja \


### PR DESCRIPTION
- Pin versions of Ceres and protobuf (Fixes #341).
- Require Lua >= 5.2 (Fixes #629).
- No longer run ceres tests in CI. We implicitly test Ceres through Cartographer's tests and this saves ~4 minutes on CI.