### PR TITLE
Fix unused lambda capture warning

### DIFF
--- a/cartographer/io/submap_painter.cc
+++ b/cartographer/io/submap_painter.cc
@@ -73,7 +73,7 @@ PaintSubmapSlicesResult PaintSubmapSlices(
 
     CairoPaintSubmapSlices(
         1. / resolution, submaps, cr.get(),
-        [&update_bounding_box, &bounding_box](const SubmapSlice& submap_slice) {
+        [&update_bounding_box](const SubmapSlice& submap_slice) {
           update_bounding_box(0, 0);
           update_bounding_box(submap_slice.width, 0);
           update_bounding_box(0, submap_slice.height);


### PR DESCRIPTION
- [ X] Keep your PR rebased to master.
- [ X] Keep your PR under 200 lines of code and address a single concern.
- [ X] Add unit test(s) and documentation (these do not count toward your 200 lines).
- [ X] Adhere to the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
- [ X] Run `clang-format -style=Google` on your code (this alone is not enough to ensure you've followed the style guide).
- [ X] Run `ninja test` or `catkin_make_isolated --install --use-ninja --pkg cartographer --make-args test` as appropriate.
