### PR TITLE
Miscellaneous: rename odometer->odometry

### DIFF
--- a/cartographer/mapping/global_trajectory_builder.h
+++ b/cartographer/mapping/global_trajectory_builder.h
@@ -71,8 +71,8 @@ class GlobalTrajectoryBuilder
 
   void AddSensorData(const sensor::OdometryData& odometry_data) override {
     CHECK(odometry_data.pose.IsValid()) << odometry_data.pose;
-    local_trajectory_builder_.AddOdometerData(odometry_data);
-    sparse_pose_graph_->AddOdometerData(trajectory_id_, odometry_data);
+    local_trajectory_builder_.AddOdometryData(odometry_data);
+    sparse_pose_graph_->AddOdometryData(trajectory_id_, odometry_data);
   }
 
   void AddSensorData(

--- a/cartographer/mapping/sparse_pose_graph.h
+++ b/cartographer/mapping/sparse_pose_graph.h
@@ -88,7 +88,7 @@ class SparsePoseGraph {
                           const sensor::ImuData& imu_data) = 0;
 
   // Inserts an odometry measurement.
-  virtual void AddOdometerData(int trajectory_id,
+  virtual void AddOdometryData(int trajectory_id,
                                const sensor::OdometryData& odometry_data) = 0;
 
   // Finishes the given trajectory.

--- a/cartographer/mapping/trajectory_builder.h
+++ b/cartographer/mapping/trajectory_builder.h
@@ -69,7 +69,7 @@ class TrajectoryBuilder {
                                  time, linear_acceleration, angular_velocity}));
   }
 
-  void AddOdometerData(const string& sensor_id, common::Time time,
+  void AddOdometryData(const string& sensor_id, common::Time time,
                        const transform::Rigid3d& odometer_pose) {
     AddSensorData(sensor_id, sensor::MakeDispatchable(
                                  sensor::OdometryData{time, odometer_pose}));

--- a/cartographer/mapping/trajectory_builder.h
+++ b/cartographer/mapping/trajectory_builder.h
@@ -69,7 +69,7 @@ class TrajectoryBuilder {
                                  time, linear_acceleration, angular_velocity}));
   }
 
-  void AddOdometryData(const string& sensor_id, common::Time time,
+  void AddOdometerData(const string& sensor_id, common::Time time,
                        const transform::Rigid3d& odometer_pose) {
     AddSensorData(sensor_id, sensor::MakeDispatchable(
                                  sensor::OdometryData{time, odometer_pose}));

--- a/cartographer/mapping_2d/local_trajectory_builder.cc
+++ b/cartographer/mapping_2d/local_trajectory_builder.cc
@@ -213,7 +213,7 @@ void LocalTrajectoryBuilder::AddImuData(const sensor::ImuData& imu_data) {
 }
 
 void LocalTrajectoryBuilder::AddOdometryData(
-    const sensor::OdometryData &odometry_data) {
+    const sensor::OdometryData& odometry_data) {
   if (extrapolator_ == nullptr) {
     // Until we've initialized the extrapolator we cannot add odometry data.
     LOG(INFO) << "Extrapolator not yet initialized.";

--- a/cartographer/mapping_2d/local_trajectory_builder.cc
+++ b/cartographer/mapping_2d/local_trajectory_builder.cc
@@ -212,8 +212,8 @@ void LocalTrajectoryBuilder::AddImuData(const sensor::ImuData& imu_data) {
   extrapolator_->AddImuData(imu_data);
 }
 
-void LocalTrajectoryBuilder::AddOdometerData(
-    const sensor::OdometryData& odometry_data) {
+void LocalTrajectoryBuilder::AddOdometryData(
+    const sensor::OdometryData &odometry_data) {
   if (extrapolator_ == nullptr) {
     // Until we've initialized the extrapolator we cannot add odometry data.
     LOG(INFO) << "Extrapolator not yet initialized.";

--- a/cartographer/mapping_2d/local_trajectory_builder.h
+++ b/cartographer/mapping_2d/local_trajectory_builder.h
@@ -68,7 +68,7 @@ class LocalTrajectoryBuilder {
   std::unique_ptr<MatchingResult> AddRangeData(
       common::Time, const sensor::TimedRangeData& range_data);
   void AddImuData(const sensor::ImuData& imu_data);
-  void AddOdometryData(const sensor::OdometryData &odometry_data);
+  void AddOdometryData(const sensor::OdometryData& odometry_data);
 
  private:
   std::unique_ptr<MatchingResult> AddAccumulatedRangeData(

--- a/cartographer/mapping_2d/local_trajectory_builder.h
+++ b/cartographer/mapping_2d/local_trajectory_builder.h
@@ -68,7 +68,7 @@ class LocalTrajectoryBuilder {
   std::unique_ptr<MatchingResult> AddRangeData(
       common::Time, const sensor::TimedRangeData& range_data);
   void AddImuData(const sensor::ImuData& imu_data);
-  void AddOdometerData(const sensor::OdometryData& odometry_data);
+  void AddOdometryData(const sensor::OdometryData &odometry_data);
 
  private:
   std::unique_ptr<MatchingResult> AddAccumulatedRangeData(

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -160,8 +160,8 @@ void SparsePoseGraph::AddImuData(const int trajectory_id,
   });
 }
 
-void SparsePoseGraph::AddOdometerData(
-    const int trajectory_id, const sensor::OdometryData& odometry_data) {
+void SparsePoseGraph::AddOdometryData(
+    int trajectory_id, const sensor::OdometryData &odometry_data) {
   common::MutexLocker locker(&mutex_);
   AddWorkItem([=]() REQUIRES(mutex_) {
     optimization_problem_.AddOdometerData(trajectory_id, odometry_data);

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -161,7 +161,7 @@ void SparsePoseGraph::AddImuData(const int trajectory_id,
 }
 
 void SparsePoseGraph::AddOdometryData(
-    int trajectory_id, const sensor::OdometryData &odometry_data) {
+    const int trajectory_id, const sensor::OdometryData& odometry_data) {
   common::MutexLocker locker(&mutex_);
   AddWorkItem([=]() REQUIRES(mutex_) {
     optimization_problem_.AddOdometerData(trajectory_id, odometry_data);

--- a/cartographer/mapping_2d/sparse_pose_graph.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph.cc
@@ -164,7 +164,7 @@ void SparsePoseGraph::AddOdometryData(
     const int trajectory_id, const sensor::OdometryData& odometry_data) {
   common::MutexLocker locker(&mutex_);
   AddWorkItem([=]() REQUIRES(mutex_) {
-    optimization_problem_.AddOdometerData(trajectory_id, odometry_data);
+    optimization_problem_.AddOdometryData(trajectory_id, odometry_data);
   });
 }
 

--- a/cartographer/mapping_2d/sparse_pose_graph.h
+++ b/cartographer/mapping_2d/sparse_pose_graph.h
@@ -78,7 +78,7 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
 
   void AddImuData(int trajectory_id, const sensor::ImuData& imu_data) override
       EXCLUDES(mutex_);
-  void AddOdometerData(int trajectory_id,
+  void AddOdometryData(int trajectory_id,
                        const sensor::OdometryData& odometry_data) override
       EXCLUDES(mutex_);
   void AddFixedFramePoseData(

--- a/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
+++ b/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.cc
@@ -66,7 +66,7 @@ void OptimizationProblem::AddImuData(const int trajectory_id,
   imu_data_.Append(trajectory_id, imu_data);
 }
 
-void OptimizationProblem::AddOdometerData(
+void OptimizationProblem::AddOdometryData(
     const int trajectory_id, const sensor::OdometryData& odometry_data) {
   odometry_data_.Append(trajectory_id, odometry_data);
 }

--- a/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.h
+++ b/cartographer/mapping_2d/sparse_pose_graph/optimization_problem.h
@@ -64,7 +64,7 @@ class OptimizationProblem {
   OptimizationProblem& operator=(const OptimizationProblem&) = delete;
 
   void AddImuData(int trajectory_id, const sensor::ImuData& imu_data);
-  void AddOdometerData(int trajectory_id,
+  void AddOdometryData(int trajectory_id,
                        const sensor::OdometryData& odometry_data);
   void AddTrajectoryNode(int trajectory_id, common::Time time,
                          const transform::Rigid2d& initial_pose,

--- a/cartographer/mapping_3d/local_trajectory_builder.cc
+++ b/cartographer/mapping_3d/local_trajectory_builder.cc
@@ -175,8 +175,8 @@ LocalTrajectoryBuilder::AddAccumulatedRangeData(
       std::move(insertion_result)});
 }
 
-void LocalTrajectoryBuilder::AddOdometerData(
-    const sensor::OdometryData& odometry_data) {
+void LocalTrajectoryBuilder::AddOdometryData(
+    const sensor::OdometryData &odometry_data) {
   if (extrapolator_ == nullptr) {
     // Until we've initialized the extrapolator we cannot add odometry data.
     LOG(INFO) << "Extrapolator not yet initialized.";

--- a/cartographer/mapping_3d/local_trajectory_builder.cc
+++ b/cartographer/mapping_3d/local_trajectory_builder.cc
@@ -176,7 +176,7 @@ LocalTrajectoryBuilder::AddAccumulatedRangeData(
 }
 
 void LocalTrajectoryBuilder::AddOdometryData(
-    const sensor::OdometryData &odometry_data) {
+    const sensor::OdometryData& odometry_data) {
   if (extrapolator_ == nullptr) {
     // Until we've initialized the extrapolator we cannot add odometry data.
     LOG(INFO) << "Extrapolator not yet initialized.";

--- a/cartographer/mapping_3d/local_trajectory_builder.h
+++ b/cartographer/mapping_3d/local_trajectory_builder.h
@@ -64,7 +64,7 @@ class LocalTrajectoryBuilder {
   // otherwise 'nullptr'.
   std::unique_ptr<MatchingResult> AddRangeData(
       common::Time time, const sensor::TimedRangeData& range_data);
-  void AddOdometryData(const sensor::OdometryData &odometry_data);
+  void AddOdometryData(const sensor::OdometryData& odometry_data);
   const mapping::PoseEstimate& pose_estimate() const;
 
  private:

--- a/cartographer/mapping_3d/local_trajectory_builder.h
+++ b/cartographer/mapping_3d/local_trajectory_builder.h
@@ -64,7 +64,7 @@ class LocalTrajectoryBuilder {
   // otherwise 'nullptr'.
   std::unique_ptr<MatchingResult> AddRangeData(
       common::Time time, const sensor::TimedRangeData& range_data);
-  void AddOdometerData(const sensor::OdometryData& odometry_data);
+  void AddOdometryData(const sensor::OdometryData &odometry_data);
   const mapping::PoseEstimate& pose_estimate() const;
 
  private:

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -157,8 +157,8 @@ void SparsePoseGraph::AddImuData(const int trajectory_id,
   });
 }
 
-void SparsePoseGraph::AddOdometerData(
-    const int trajectory_id, const sensor::OdometryData& odometry_data) {
+void SparsePoseGraph::AddOdometryData(
+    int trajectory_id, const sensor::OdometryData &odometry_data) {
   common::MutexLocker locker(&mutex_);
   AddWorkItem([=]() REQUIRES(mutex_) {
     optimization_problem_.AddOdometerData(trajectory_id, odometry_data);

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -158,7 +158,7 @@ void SparsePoseGraph::AddImuData(const int trajectory_id,
 }
 
 void SparsePoseGraph::AddOdometryData(
-    int trajectory_id, const sensor::OdometryData &odometry_data) {
+    const int trajectory_id, const sensor::OdometryData& odometry_data) {
   common::MutexLocker locker(&mutex_);
   AddWorkItem([=]() REQUIRES(mutex_) {
     optimization_problem_.AddOdometerData(trajectory_id, odometry_data);

--- a/cartographer/mapping_3d/sparse_pose_graph.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph.cc
@@ -161,7 +161,7 @@ void SparsePoseGraph::AddOdometryData(
     const int trajectory_id, const sensor::OdometryData& odometry_data) {
   common::MutexLocker locker(&mutex_);
   AddWorkItem([=]() REQUIRES(mutex_) {
-    optimization_problem_.AddOdometerData(trajectory_id, odometry_data);
+    optimization_problem_.AddOdometryData(trajectory_id, odometry_data);
   });
 }
 

--- a/cartographer/mapping_3d/sparse_pose_graph.h
+++ b/cartographer/mapping_3d/sparse_pose_graph.h
@@ -78,7 +78,7 @@ class SparsePoseGraph : public mapping::SparsePoseGraph {
 
   void AddImuData(int trajectory_id, const sensor::ImuData& imu_data) override
       EXCLUDES(mutex_);
-  void AddOdometerData(int trajectory_id,
+  void AddOdometryData(int trajectory_id,
                        const sensor::OdometryData& odometry_data) override
       EXCLUDES(mutex_);
   void AddFixedFramePoseData(

--- a/cartographer/mapping_3d/sparse_pose_graph/optimization_problem.cc
+++ b/cartographer/mapping_3d/sparse_pose_graph/optimization_problem.cc
@@ -86,7 +86,7 @@ void OptimizationProblem::AddImuData(const int trajectory_id,
   imu_data_.Append(trajectory_id, imu_data);
 }
 
-void OptimizationProblem::AddOdometerData(
+void OptimizationProblem::AddOdometryData(
     const int trajectory_id, const sensor::OdometryData& odometry_data) {
   odometry_data_.Append(trajectory_id, odometry_data);
 }

--- a/cartographer/mapping_3d/sparse_pose_graph/optimization_problem.h
+++ b/cartographer/mapping_3d/sparse_pose_graph/optimization_problem.h
@@ -67,7 +67,7 @@ class OptimizationProblem {
   OptimizationProblem& operator=(const OptimizationProblem&) = delete;
 
   void AddImuData(int trajectory_id, const sensor::ImuData& imu_data);
-  void AddOdometerData(int trajectory_id,
+  void AddOdometryData(int trajectory_id,
                        const sensor::OdometryData& odometry_data);
   void AddFixedFramePoseData(
       int trajectory_id,


### PR DESCRIPTION
Since we're adding `sensor::OdometryData`, I think that the function should be called `AddOdometryData`.
