### PR TITLE
Rename sparse_pose_graph options.

### DIFF
--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -46,8 +46,8 @@ proto::MapBuilderOptions CreateMapBuilderOptions(
       parameter_dictionary->GetBool("use_trajectory_builder_3d"));
   options.set_num_background_threads(
       parameter_dictionary->GetNonNegativeInt("num_background_threads"));
-  *options.mutable_sparse_pose_graph_options() = CreateSparsePoseGraphOptions(
-      parameter_dictionary->GetDictionary("sparse_pose_graph").get());
+  *options.mutable_pose_graph_options() = CreatePoseGraphOptions(
+      parameter_dictionary->GetDictionary("pose_graph").get());
   CHECK_NE(options.use_trajectory_builder_2d(),
            options.use_trajectory_builder_3d());
   return options;
@@ -61,12 +61,12 @@ MapBuilder::MapBuilder(
       local_slam_result_callback_(local_slam_result_callback) {
   if (options.use_trajectory_builder_2d()) {
     pose_graph_2d_ = common::make_unique<mapping_2d::PoseGraph>(
-        options_.sparse_pose_graph_options(), &thread_pool_);
+        options_.pose_graph_options(), &thread_pool_);
     pose_graph_ = pose_graph_2d_.get();
   }
   if (options.use_trajectory_builder_3d()) {
     pose_graph_3d_ = common::make_unique<mapping_3d::PoseGraph>(
-        options_.sparse_pose_graph_options(), &thread_pool_);
+        options_.pose_graph_options(), &thread_pool_);
     pose_graph_ = pose_graph_3d_.get();
   }
 }

--- a/cartographer/mapping/pose_graph.cc
+++ b/cartographer/mapping/pose_graph.cc
@@ -68,9 +68,9 @@ std::vector<PoseGraph::Constraint> FromProto(
   return constraints;
 }
 
-proto::SparsePoseGraphOptions CreateSparsePoseGraphOptions(
+proto::PoseGraphOptions CreatePoseGraphOptions(
     common::LuaParameterDictionary* const parameter_dictionary) {
-  proto::SparsePoseGraphOptions options;
+  proto::PoseGraphOptions options;
   options.set_optimize_every_n_scans(
       parameter_dictionary->GetInt("optimize_every_n_scans"));
   *options.mutable_constraint_builder_options() =

--- a/cartographer/mapping/pose_graph.h
+++ b/cartographer/mapping/pose_graph.h
@@ -27,8 +27,8 @@
 #include "cartographer/mapping/id.h"
 #include "cartographer/mapping/pose_graph_trimmer.h"
 #include "cartographer/mapping/proto/pose_graph.pb.h"
+#include "cartographer/mapping/proto/pose_graph_options.pb.h"
 #include "cartographer/mapping/proto/serialization.pb.h"
-#include "cartographer/mapping/proto/sparse_pose_graph_options.pb.h"
 #include "cartographer/mapping/submaps.h"
 #include "cartographer/mapping/trajectory_node.h"
 #include "cartographer/sensor/imu_data.h"
@@ -39,7 +39,7 @@
 namespace cartographer {
 namespace mapping {
 
-proto::SparsePoseGraphOptions CreateSparsePoseGraphOptions(
+proto::PoseGraphOptions CreatePoseGraphOptions(
     common::LuaParameterDictionary* const parameter_dictionary);
 
 class PoseGraph {

--- a/cartographer/mapping/proto/map_builder_options.proto
+++ b/cartographer/mapping/proto/map_builder_options.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-import "cartographer/mapping/proto/sparse_pose_graph_options.proto";
+import "cartographer/mapping/proto/pose_graph_options.proto";
 
 package cartographer.mapping.proto;
 
@@ -24,5 +24,5 @@ message MapBuilderOptions {
 
   // Number of threads to use for background computations.
   int32 num_background_threads = 3;
-  SparsePoseGraphOptions sparse_pose_graph_options = 4;
+  PoseGraphOptions pose_graph_options = 4;
 }

--- a/cartographer/mapping/proto/pose_graph_options.proto
+++ b/cartographer/mapping/proto/pose_graph_options.proto
@@ -19,7 +19,7 @@ package cartographer.mapping.proto;
 import "cartographer/mapping/pose_graph/proto/constraint_builder_options.proto";
 import "cartographer/mapping/pose_graph/proto/optimization_problem_options.proto";
 
-message SparsePoseGraphOptions {
+message PoseGraphOptions {
   // Online loop closure: If positive, will run the loop closure while the map
   // is built.
   int32 optimize_every_n_scans = 1;

--- a/cartographer/mapping_2d/pose_graph.cc
+++ b/cartographer/mapping_2d/pose_graph.cc
@@ -39,7 +39,7 @@
 namespace cartographer {
 namespace mapping_2d {
 
-PoseGraph::PoseGraph(const mapping::proto::SparsePoseGraphOptions& options,
+PoseGraph::PoseGraph(const mapping::proto::PoseGraphOptions& options,
                      common::ThreadPool* thread_pool)
     : options_(options),
       optimization_problem_(options_.optimization_problem_options()),

--- a/cartographer/mapping_2d/pose_graph.h
+++ b/cartographer/mapping_2d/pose_graph.h
@@ -58,7 +58,7 @@ namespace mapping_2d {
 // All constraints are between a submap i and a node j.
 class PoseGraph : public mapping::PoseGraph {
  public:
-  PoseGraph(const mapping::proto::SparsePoseGraphOptions& options,
+  PoseGraph(const mapping::proto::PoseGraphOptions& options,
             common::ThreadPool* thread_pool);
   ~PoseGraph() override;
 
@@ -190,7 +190,7 @@ class PoseGraph : public mapping::PoseGraph {
   void UpdateTrajectoryConnectivity(const Constraint& constraint)
       REQUIRES(mutex_);
 
-  const mapping::proto::SparsePoseGraphOptions options_;
+  const mapping::proto::PoseGraphOptions options_;
   common::Mutex mutex_;
 
   // If it exists, further work items must be added to this queue, and will be

--- a/cartographer/mapping_2d/pose_graph_test.cc
+++ b/cartographer/mapping_2d/pose_graph_test.cc
@@ -133,7 +133,7 @@ class PoseGraphTest : public ::testing::Test {
             global_constraint_search_after_n_seconds = 10.0,
           })text");
       pose_graph_ = common::make_unique<PoseGraph>(
-          mapping::CreateSparsePoseGraphOptions(parameter_dictionary.get()),
+          mapping::CreatePoseGraphOptions(parameter_dictionary.get()),
           &thread_pool_);
     }
 

--- a/cartographer/mapping_3d/pose_graph.cc
+++ b/cartographer/mapping_3d/pose_graph.cc
@@ -38,7 +38,7 @@
 namespace cartographer {
 namespace mapping_3d {
 
-PoseGraph::PoseGraph(const mapping::proto::SparsePoseGraphOptions& options,
+PoseGraph::PoseGraph(const mapping::proto::PoseGraphOptions& options,
                      common::ThreadPool* thread_pool)
     : options_(options),
       optimization_problem_(options_.optimization_problem_options(),

--- a/cartographer/mapping_3d/pose_graph.h
+++ b/cartographer/mapping_3d/pose_graph.h
@@ -58,7 +58,7 @@ namespace mapping_3d {
 // All constraints are between a submap i and a node j.
 class PoseGraph : public mapping::PoseGraph {
  public:
-  PoseGraph(const mapping::proto::SparsePoseGraphOptions& options,
+  PoseGraph(const mapping::proto::PoseGraphOptions& options,
             common::ThreadPool* thread_pool);
   ~PoseGraph() override;
 
@@ -194,7 +194,7 @@ class PoseGraph : public mapping::PoseGraph {
   void UpdateTrajectoryConnectivity(const Constraint& constraint)
       REQUIRES(mutex_);
 
-  const mapping::proto::SparsePoseGraphOptions options_;
+  const mapping::proto::PoseGraphOptions options_;
   common::Mutex mutex_;
 
   // If it exists, further work items must be added to this queue, and will be

--- a/configuration_files/map_builder.lua
+++ b/configuration_files/map_builder.lua
@@ -12,11 +12,11 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-include "sparse_pose_graph.lua"
+include "pose_graph.lua"
 
 MAP_BUILDER = {
   use_trajectory_builder_2d = false,
   use_trajectory_builder_3d = false,
   num_background_threads = 4,
-  sparse_pose_graph = SPARSE_POSE_GRAPH,
+  pose_graph = POSE_GRAPH,
 }

--- a/configuration_files/pose_graph.lua
+++ b/configuration_files/pose_graph.lua
@@ -12,7 +12,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-SPARSE_POSE_GRAPH = {
+POSE_GRAPH = {
   optimize_every_n_scans = 90,
   constraint_builder = {
     sampling_ratio = 0.3,

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -117,12 +117,12 @@ bool use_trajectory_builder_3d
 int32 num_background_threads
   Number of threads to use for background computations.
 
-cartographer.mapping.proto.SparsePoseGraphOptions sparse_pose_graph_options
+cartographer.mapping.proto.PoseGraphOptions pose_graph_options
   Not yet documented.
 
 
-cartographer.mapping.proto.SparsePoseGraphOptions
-=================================================
+cartographer.mapping.proto.PoseGraphOptions
+===========================================
 
 int32 optimize_every_n_scans
   Online loop closure: If positive, will run the loop closure while the map


### PR DESCRIPTION
The default pose graph configuration is now included as "pose_graph.lua"
and available as POSE_GRAPH.

[RFC=0001](https://github.com/googlecartographer/rfcs/blob/master/text/0001-renaming-sparse-pose-graph.md)