### PR TITLE
Fix typo in CMake install script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ file(GLOB_RECURSE hdrs "*.h.in")
 foreach(HDR ${hdrs})
   file(RELATIVE_PATH REL_FIL ${PROJECT_SOURCE_DIR} ${HDR})
   get_filename_component(DIR ${REL_FIL} DIRECTORY)
-  get_filename_component(FIL_WE ${REL_FIL} NAME_WE)
+  get_filename_component(FILE_WE ${REL_FIL} NAME_WE)
   install(
     FILES
       ${PROJECT_BINARY_DIR}/${DIR}/${FILE_WE}


### PR DESCRIPTION
Fixes a typo in CMake scripts when installing generated header files.