### PR TITLE
ExtrapolatePose uses fewer transforms.

### DIFF
--- a/cartographer/mapping/pose_extrapolator.cc
+++ b/cartographer/mapping/pose_extrapolator.cc
@@ -133,10 +133,12 @@ transform::Rigid3d PoseExtrapolator::ExtrapolatePose(const common::Time time) {
   // TODO(whess): Keep the last extrapolated pose.
   const TimedPose& newest_timed_pose = timed_pose_queue_.back();
   CHECK_GE(time, newest_timed_pose.time);
-  return transform::Rigid3d::Translation(ExtrapolateTranslation(time)) *
-         newest_timed_pose.pose *
-         transform::Rigid3d::Rotation(
-             ExtrapolateRotation(time, extrapolation_imu_tracker_.get()));
+  const Eigen::Vector3d translation =
+      ExtrapolateTranslation(time) + newest_timed_pose.pose.translation();
+  const Eigen::Quaterniond rotation =
+      newest_timed_pose.pose.rotation() *
+      ExtrapolateRotation(time, extrapolation_imu_tracker_.get());
+  return transform::Rigid3d(translation, rotation);
 }
 
 Eigen::Quaterniond PoseExtrapolator::EstimateGravityOrientation(


### PR DESCRIPTION
ExtrapolatePose avoids conversion to Rigid3d and computes translation
and rotation directly, which is faster.
Per-point unwarping will call this function for every point, so we
optimize it.