### PR TITLE
Do not install global_trajectory_builder.h.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,8 +210,12 @@ install(
 )
 
 # Install source headers.
-file(GLOB_RECURSE hdrs "*.h")
-foreach(HDR ${hdrs})
+file(GLOB_RECURSE HDRS "*.h")
+file(GLOB_RECURSE INTERNAL_HDRS "cartographer/internal/*.h")
+list(REMOVE_ITEM HDRS ${INTERNAL_HDRS})  # Do not install internal headers.
+file(GLOB_RECURSE INTERNAL_HDRS "cartographer_grpc/internal/*.h")
+list_remove_item(HDRS INTERNAL_HDRS)
+foreach(HDR ${HDRS})
   file(RELATIVE_PATH REL_FIL ${PROJECT_SOURCE_DIR} ${HDR})
   get_filename_component(INSTALL_DIR ${REL_FIL} DIRECTORY)
   install(
@@ -223,8 +227,8 @@ foreach(HDR ${hdrs})
 endforeach()
 
 # Install generated headers.
-file(GLOB_RECURSE hdrs "*.h.in")
-foreach(HDR ${hdrs})
+file(GLOB_RECURSE HDRS "*.h.in")
+foreach(HDR ${HDRS})
   file(RELATIVE_PATH REL_FIL ${PROJECT_SOURCE_DIR} ${HDR})
   get_filename_component(DIR ${REL_FIL} DIRECTORY)
   get_filename_component(FILE_WE ${REL_FIL} NAME_WE)

--- a/cartographer/internal/mapping/global_trajectory_builder.h
+++ b/cartographer/internal/mapping/global_trajectory_builder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef CARTOGRAPHER_MAPPING_GLOBAL_TRAJECTORY_BUILDER_H_
-#define CARTOGRAPHER_MAPPING_GLOBAL_TRAJECTORY_BUILDER_H_
+#ifndef CARTOGRAPHER_INTERNAL_MAPPING_GLOBAL_TRAJECTORY_BUILDER_H_
+#define CARTOGRAPHER_INTERNAL_MAPPING_GLOBAL_TRAJECTORY_BUILDER_H_
 
 #include "cartographer/mapping/global_trajectory_builder_interface.h"
 
@@ -94,4 +94,4 @@ class GlobalTrajectoryBuilder
 }  // namespace mapping
 }  // namespace cartographer
 
-#endif  // CARTOGRAPHER_MAPPING_GLOBAL_TRAJECTORY_BUILDER_H_
+#endif  // CARTOGRAPHER_INTERNAL_MAPPING_GLOBAL_TRAJECTORY_BUILDER_H_

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -24,8 +24,8 @@
 
 #include "cartographer/common/make_unique.h"
 #include "cartographer/common/time.h"
+#include "cartographer/internal/mapping/global_trajectory_builder.h"
 #include "cartographer/mapping/collated_trajectory_builder.h"
-#include "cartographer/mapping/global_trajectory_builder.h"
 #include "cartographer/mapping_2d/local_trajectory_builder.h"
 #include "cartographer/mapping_3d/local_trajectory_builder.h"
 #include "cartographer/sensor/range_data.h"


### PR DESCRIPTION
This moves the global_trajectory_builder.h header under
cartographer/internal and changes the CMakeLists.txt to
not install internal headers.

[RFC=0003](https://github.com/googlecartographer/rfcs/blob/master/text/0003-internal-headers.md)