### PR TITLE
 Interface for MapBuilder

### DIFF
--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -134,10 +134,6 @@ void MapBuilder::FinishTrajectory(const int trajectory_id) {
   pose_graph_->FinishTrajectory(trajectory_id);
 }
 
-int MapBuilder::GetBlockingTrajectoryId() const {
-  return sensor_collator_.GetBlockingTrajectoryId();
-}
-
 std::string MapBuilder::SubmapToProto(
     const mapping::SubmapId& submap_id,
     proto::SubmapQuery::Response* const response) {

--- a/cartographer/mapping/map_builder.h
+++ b/cartographer/mapping/map_builder.h
@@ -77,11 +77,6 @@ class MapBuilder {
   // i.e. no further sensor data is expected.
   void FinishTrajectory(int trajectory_id);
 
-  // Must only be called if at least one unfinished trajectory exists. Returns
-  // the ID of the trajectory that needs more data before the MapBuilder is
-  // unblocked.
-  int GetBlockingTrajectoryId() const;
-
   // Fills the SubmapQuery::Response corresponding to 'submap_id'. Returns an
   // error string on failure, or an empty string on success.
   std::string SubmapToProto(const SubmapId& submap_id,

--- a/cartographer/mapping/map_builder_interface.h
+++ b/cartographer/mapping/map_builder_interface.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 The Cartographer Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CARTOGRAPHER_MAPPING_MAP_BUILDER_INTERFACE_H_
+#define CARTOGRAPHER_MAPPING_MAP_BUILDER_INTERFACE_H_
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "Eigen/Geometry"
+#include "cartographer/common/lua_parameter_dictionary.h"
+#include "cartographer/common/port.h"
+#include "cartographer/io/proto_stream.h"
+#include "cartographer/mapping/id.h"
+#include "cartographer/mapping/pose_graph.h"
+#include "cartographer/mapping/proto/submap_visualization.pb.h"
+#include "cartographer/mapping/proto/trajectory_builder_options.pb.h"
+#include "cartographer/mapping/submaps.h"
+#include "cartographer/mapping/trajectory_builder.h"
+
+namespace cartographer {
+namespace mapping {
+
+// This interface is used for both library and RPC implementations.
+// Implementations wire up the complete SLAM stack.
+class MapBuilderInterface {
+ public:
+  using LocalSlamResultCallback =
+      GlobalTrajectoryBuilderInterface::LocalSlamResultCallback;
+
+  MapBuilderInterface(){};
+  virtual ~MapBuilderInterface(){};
+
+  MapBuilderInterface(const MapBuilderInterface&) = delete;
+  MapBuilderInterface& operator=(const MapBuilderInterface&) = delete;
+
+  // Creates a new trajectory builder and returns its index.
+  virtual int AddTrajectoryBuilder(
+      const std::unordered_set<std::string>& expected_sensor_ids,
+      const proto::TrajectoryBuilderOptions& trajectory_options) = 0;
+
+  // Creates a new trajectory and returns its index. Querying the trajectory
+  // builder for it will return 'nullptr'.
+  virtual int AddTrajectoryForDeserialization() = 0;
+
+  // Returns the TrajectoryBuilder corresponding to the specified
+  // 'trajectory_id' or 'nullptr' if the trajectory has no corresponding
+  // builder.
+  virtual mapping::TrajectoryBuilder* GetTrajectoryBuilder(
+      int trajectory_id) const = 0;
+
+  // Marks the TrajectoryBuilder corresponding to 'trajectory_id' as finished,
+  // i.e. no further sensor data is expected.
+  virtual void FinishTrajectory(int trajectory_id) = 0;
+
+  // Fills the SubmapQuery::Response corresponding to 'submap_id'. Returns an
+  // error string on failure, or an empty string on success.
+  virtual std::string SubmapToProto(const SubmapId& submap_id,
+                                    proto::SubmapQuery::Response* response) = 0;
+
+  // Serializes the current state to a proto stream.
+  virtual void SerializeState(io::ProtoStreamWriter* writer) = 0;
+
+  // Loads submaps from a proto stream into a new frozen trajectory.
+  virtual void LoadMap(io::ProtoStreamReader* reader) = 0;
+
+  virtual int num_trajectory_builders() const = 0;
+
+  virtual mapping::PoseGraph* pose_graph() = 0;
+};
+
+}  // namespace mapping
+}  // namespace cartographer
+
+#endif  // CARTOGRAPHER_MAPPING_MAP_BUILDER_INTERFACE_H_


### PR DESCRIPTION
Defines an interface for MapBuilder that can be used to implement a gRPC stub.
[RFC=0002](https://github.com/googlecartographer/rfcs/blob/master/text/0002-cloud-based-mapping-1.md)