### PR TITLE
 Create AutoDiffCostFunction in cost functions.

### DIFF
--- a/cartographer/internal/mapping_2d/scan_matching/occupied_space_cost_function.h
+++ b/cartographer/internal/mapping_2d/scan_matching/occupied_space_cost_function.h
@@ -37,7 +37,8 @@ class OccupiedSpaceCostFunction {
       const double scaling_factor, const sensor::PointCloud& point_cloud,
       const ProbabilityGrid& probability_grid) {
     return new ceres::AutoDiffCostFunction<OccupiedSpaceCostFunction,
-                                           ceres::DYNAMIC, 3>(
+                                           ceres::DYNAMIC /* residuals */,
+                                           3 /* pose variables */>(
         new OccupiedSpaceCostFunction(scaling_factor, point_cloud,
                                       probability_grid),
         point_cloud.size());

--- a/cartographer/internal/mapping_2d/scan_matching/occupied_space_cost_function.h
+++ b/cartographer/internal/mapping_2d/scan_matching/occupied_space_cost_function.h
@@ -33,16 +33,15 @@ namespace scan_matching {
 // at pixels with lower values.
 class OccupiedSpaceCostFunction {
  public:
-  OccupiedSpaceCostFunction(const double scaling_factor,
-                            const sensor::PointCloud& point_cloud,
-                            const ProbabilityGrid& probability_grid)
-      : scaling_factor_(scaling_factor),
-        point_cloud_(point_cloud),
-        probability_grid_(probability_grid) {}
-
-  OccupiedSpaceCostFunction(const OccupiedSpaceCostFunction&) = delete;
-  OccupiedSpaceCostFunction& operator=(const OccupiedSpaceCostFunction&) =
-      delete;
+  static ceres::CostFunction* CreateAutoDiffCostFunction(
+      const double scaling_factor, const sensor::PointCloud& point_cloud,
+      const ProbabilityGrid& probability_grid) {
+    return new ceres::AutoDiffCostFunction<OccupiedSpaceCostFunction,
+                                           ceres::DYNAMIC, 3>(
+        new OccupiedSpaceCostFunction(scaling_factor, point_cloud,
+                                      probability_grid),
+        point_cloud.size());
+  }
 
   template <typename T>
   bool operator()(const T* const pose, T* residual) const {
@@ -104,6 +103,17 @@ class OccupiedSpaceCostFunction {
    private:
     const ProbabilityGrid& probability_grid_;
   };
+
+  OccupiedSpaceCostFunction(const double scaling_factor,
+                            const sensor::PointCloud& point_cloud,
+                            const ProbabilityGrid& probability_grid)
+      : scaling_factor_(scaling_factor),
+        point_cloud_(point_cloud),
+        probability_grid_(probability_grid) {}
+
+  OccupiedSpaceCostFunction(const OccupiedSpaceCostFunction&) = delete;
+  OccupiedSpaceCostFunction& operator=(const OccupiedSpaceCostFunction&) =
+      delete;
 
   const double scaling_factor_;
   const sensor::PointCloud& point_cloud_;

--- a/cartographer/internal/mapping_3d/rotation_cost_function.h
+++ b/cartographer/internal/mapping_3d/rotation_cost_function.h
@@ -26,13 +26,14 @@ namespace mapping_3d {
 // Penalizes differences between IMU data and optimized orientations.
 class RotationCostFunction {
  public:
-  RotationCostFunction(const double scaling_factor,
-                       const Eigen::Quaterniond& delta_rotation_imu_frame)
-      : scaling_factor_(scaling_factor),
-        delta_rotation_imu_frame_(delta_rotation_imu_frame) {}
-
-  RotationCostFunction(const RotationCostFunction&) = delete;
-  RotationCostFunction& operator=(const RotationCostFunction&) = delete;
+  static ceres::CostFunction* CreateAutoDiffCostFunction(
+      const double scaling_factor,
+      const Eigen::Quaterniond& delta_rotation_imu_frame) {
+    return new ceres::AutoDiffCostFunction<
+        RotationCostFunction, 3 /* residuals */, 4 /* rotation variables */,
+        4 /* rotation variables */, 4 /* rotation variables */
+        >(new RotationCostFunction(scaling_factor, delta_rotation_imu_frame));
+  }
 
   template <typename T>
   bool operator()(const T* const start_rotation, const T* const end_rotation,
@@ -54,6 +55,14 @@ class RotationCostFunction {
   }
 
  private:
+  RotationCostFunction(const double scaling_factor,
+                       const Eigen::Quaterniond& delta_rotation_imu_frame)
+      : scaling_factor_(scaling_factor),
+        delta_rotation_imu_frame_(delta_rotation_imu_frame) {}
+
+  RotationCostFunction(const RotationCostFunction&) = delete;
+  RotationCostFunction& operator=(const RotationCostFunction&) = delete;
+
   const double scaling_factor_;
   const Eigen::Quaterniond delta_rotation_imu_frame_;
 };

--- a/cartographer/mapping_2d/pose_graph/optimization_problem.cc
+++ b/cartographer/mapping_2d/pose_graph/optimization_problem.cc
@@ -152,8 +152,7 @@ void OptimizationProblem::Solve(const std::vector<Constraint>& constraints,
   // Add cost functions for intra- and inter-submap constraints.
   for (const Constraint& constraint : constraints) {
     problem.AddResidualBlock(
-        new ceres::AutoDiffCostFunction<SpaCostFunction, 3, 3, 3>(
-            new SpaCostFunction(constraint.pose)),
+        SpaCostFunction::CreateAutoDiffCostFunction(constraint.pose),
         // Only loop closure constraints should have a loss function.
         constraint.tag == Constraint::INTER_SUBMAP
             ? new ceres::HuberLoss(options_.huber_scale())
@@ -187,10 +186,9 @@ void OptimizationProblem::Solve(const std::vector<Constraint>& constraints,
       const transform::Rigid3d relative_pose =
           ComputeRelativePose(trajectory_id, first_node_data, second_node_data);
       problem.AddResidualBlock(
-          new ceres::AutoDiffCostFunction<SpaCostFunction, 3, 3, 3>(
-              new SpaCostFunction(Constraint::Pose{
-                  relative_pose, options_.consecutive_node_translation_weight(),
-                  options_.consecutive_node_rotation_weight()})),
+          SpaCostFunction::CreateAutoDiffCostFunction(Constraint::Pose{
+              relative_pose, options_.consecutive_node_translation_weight(),
+              options_.consecutive_node_rotation_weight()}),
           nullptr /* loss function */, C_nodes.at(first_node_id).data(),
           C_nodes.at(second_node_id).data());
     }

--- a/cartographer/mapping_2d/pose_graph/spa_cost_function.h
+++ b/cartographer/mapping_2d/pose_graph/spa_cost_function.h
@@ -38,7 +38,9 @@ class SpaCostFunction {
 
   static ceres::CostFunction* CreateAutoDiffCostFunction(
       const Constraint::Pose& pose) {
-    return new ceres::AutoDiffCostFunction<SpaCostFunction, 3, 3, 3>(
+    return new ceres::AutoDiffCostFunction<SpaCostFunction, 3 /* residuals */,
+                                           3 /* pose variables */,
+                                           3 /* pose variables */>(
         new SpaCostFunction(pose));
   }
 

--- a/cartographer/mapping_2d/pose_graph/spa_cost_function.h
+++ b/cartographer/mapping_2d/pose_graph/spa_cost_function.h
@@ -36,7 +36,11 @@ class SpaCostFunction {
  public:
   using Constraint = mapping::PoseGraph::Constraint;
 
-  explicit SpaCostFunction(const Constraint::Pose& pose) : pose_(pose) {}
+  static ceres::CostFunction* CreateAutoDiffCostFunction(
+      const Constraint::Pose& pose) {
+    return new ceres::AutoDiffCostFunction<SpaCostFunction, 3, 3, 3>(
+        new SpaCostFunction(pose));
+  }
 
   // Computes the error between the node-to-submap alignment 'zbar_ij' and the
   // difference of submap pose 'c_i' and node pose 'c_j' which are both in an
@@ -78,6 +82,8 @@ class SpaCostFunction {
   }
 
  private:
+  explicit SpaCostFunction(const Constraint::Pose& pose) : pose_(pose) {}
+
   const Constraint::Pose pose_;
 };
 

--- a/cartographer/mapping_2d/pose_graph/spa_cost_function.h
+++ b/cartographer/mapping_2d/pose_graph/spa_cost_function.h
@@ -44,6 +44,15 @@ class SpaCostFunction {
         new SpaCostFunction(pose));
   }
 
+  template <typename T>
+  bool operator()(const T* const c_i, const T* const c_j, T* e) const {
+    ComputeScaledError(pose_, c_i, c_j, e);
+    return true;
+  }
+
+ private:
+  explicit SpaCostFunction(const Constraint::Pose& pose) : pose_(pose) {}
+
   // Computes the error between the node-to-submap alignment 'zbar_ij' and the
   // difference of submap pose 'c_i' and node pose 'c_j' which are both in an
   // arbitrary common frame.
@@ -76,15 +85,6 @@ class SpaCostFunction {
     e[1] = e_ij[1] * T(pose.translation_weight);
     e[2] = e_ij[2] * T(pose.rotation_weight);
   }
-
-  template <typename T>
-  bool operator()(const T* const c_i, const T* const c_j, T* e) const {
-    ComputeScaledError(pose_, c_i, c_j, e);
-    return true;
-  }
-
- private:
-  explicit SpaCostFunction(const Constraint::Pose& pose) : pose_(pose) {}
 
   const Constraint::Pose pose_;
 };

--- a/cartographer/mapping_2d/scan_matching/ceres_scan_matcher.cc
+++ b/cartographer/mapping_2d/scan_matching/ceres_scan_matcher.cc
@@ -71,25 +71,20 @@ void CeresScanMatcher::Match(const Eigen::Vector2d& target_translation,
   ceres::Problem problem;
   CHECK_GT(options_.occupied_space_weight(), 0.);
   problem.AddResidualBlock(
-      new ceres::AutoDiffCostFunction<OccupiedSpaceCostFunction, ceres::DYNAMIC,
-                                      3>(
-          new OccupiedSpaceCostFunction(
-              options_.occupied_space_weight() /
-                  std::sqrt(static_cast<double>(point_cloud.size())),
-              point_cloud, probability_grid),
-          point_cloud.size()),
+      OccupiedSpaceCostFunction::CreateAutoDiffCostFunction(
+          options_.occupied_space_weight() /
+              std::sqrt(static_cast<double>(point_cloud.size())),
+          point_cloud, probability_grid),
       nullptr, ceres_pose_estimate);
   CHECK_GT(options_.translation_weight(), 0.);
   problem.AddResidualBlock(
-      new ceres::AutoDiffCostFunction<TranslationDeltaCostFunctor, 2, 3>(
-          new TranslationDeltaCostFunctor(options_.translation_weight(),
-                                          target_translation)),
+      TranslationDeltaCostFunctor::CreateAutoDiffCostFunction(
+          options_.translation_weight(), target_translation),
       nullptr, ceres_pose_estimate);
   CHECK_GT(options_.rotation_weight(), 0.);
   problem.AddResidualBlock(
-      new ceres::AutoDiffCostFunction<RotationDeltaCostFunctor, 1, 3>(
-          new RotationDeltaCostFunctor(options_.rotation_weight(),
-                                       ceres_pose_estimate[2])),
+      RotationDeltaCostFunctor::CreateAutoDiffCostFunction(
+          options_.rotation_weight(), ceres_pose_estimate[2]),
       nullptr, ceres_pose_estimate);
 
   ceres::Solve(ceres_solver_options_, &problem, summary);

--- a/cartographer/mapping_2d/scan_matching/ceres_scan_matcher.cc
+++ b/cartographer/mapping_2d/scan_matching/ceres_scan_matcher.cc
@@ -75,17 +75,17 @@ void CeresScanMatcher::Match(const Eigen::Vector2d& target_translation,
           options_.occupied_space_weight() /
               std::sqrt(static_cast<double>(point_cloud.size())),
           point_cloud, probability_grid),
-      nullptr, ceres_pose_estimate);
+      nullptr /* loss function */, ceres_pose_estimate);
   CHECK_GT(options_.translation_weight(), 0.);
   problem.AddResidualBlock(
       TranslationDeltaCostFunctor::CreateAutoDiffCostFunction(
           options_.translation_weight(), target_translation),
-      nullptr, ceres_pose_estimate);
+      nullptr /* loss function */, ceres_pose_estimate);
   CHECK_GT(options_.rotation_weight(), 0.);
   problem.AddResidualBlock(
       RotationDeltaCostFunctor::CreateAutoDiffCostFunction(
           options_.rotation_weight(), ceres_pose_estimate[2]),
-      nullptr, ceres_pose_estimate);
+      nullptr /* loss function */, ceres_pose_estimate);
 
   ceres::Solve(ceres_solver_options_, &problem, summary);
 

--- a/cartographer/mapping_2d/scan_matching/rotation_delta_cost_functor.h
+++ b/cartographer/mapping_2d/scan_matching/rotation_delta_cost_functor.h
@@ -27,13 +27,11 @@ namespace scan_matching {
 // the solution's distance from 'target_angle'.
 class RotationDeltaCostFunctor {
  public:
-  // Constructs a new RotationDeltaCostFunctor for the given 'angle'.
-  explicit RotationDeltaCostFunctor(const double scaling_factor,
-                                    const double target_angle)
-      : scaling_factor_(scaling_factor), angle_(target_angle) {}
-
-  RotationDeltaCostFunctor(const RotationDeltaCostFunctor&) = delete;
-  RotationDeltaCostFunctor& operator=(const RotationDeltaCostFunctor&) = delete;
+  static ceres::CostFunction* CreateAutoDiffCostFunction(
+      const double scaling_factor, const double target_angle) {
+    return new ceres::AutoDiffCostFunction<RotationDeltaCostFunctor, 1, 3>(
+        new RotationDeltaCostFunctor(scaling_factor, target_angle));
+  }
 
   template <typename T>
   bool operator()(const T* const pose, T* residual) const {
@@ -42,6 +40,14 @@ class RotationDeltaCostFunctor {
   }
 
  private:
+  // Constructs a new RotationDeltaCostFunctor for the given 'angle'.
+  explicit RotationDeltaCostFunctor(const double scaling_factor,
+                                    const double target_angle)
+      : scaling_factor_(scaling_factor), angle_(target_angle) {}
+
+  RotationDeltaCostFunctor(const RotationDeltaCostFunctor&) = delete;
+  RotationDeltaCostFunctor& operator=(const RotationDeltaCostFunctor&) = delete;
+
   const double scaling_factor_;
   const double angle_;
 };

--- a/cartographer/mapping_2d/scan_matching/rotation_delta_cost_functor.h
+++ b/cartographer/mapping_2d/scan_matching/rotation_delta_cost_functor.h
@@ -29,7 +29,8 @@ class RotationDeltaCostFunctor {
  public:
   static ceres::CostFunction* CreateAutoDiffCostFunction(
       const double scaling_factor, const double target_angle) {
-    return new ceres::AutoDiffCostFunction<RotationDeltaCostFunctor, 1, 3>(
+    return new ceres::AutoDiffCostFunction<
+        RotationDeltaCostFunctor, 1 /* residuals */, 3 /* pose variables */>(
         new RotationDeltaCostFunctor(scaling_factor, target_angle));
   }
 

--- a/cartographer/mapping_2d/scan_matching/rotation_delta_cost_functor.h
+++ b/cartographer/mapping_2d/scan_matching/rotation_delta_cost_functor.h
@@ -41,7 +41,6 @@ class RotationDeltaCostFunctor {
   }
 
  private:
-  // Constructs a new RotationDeltaCostFunctor for the given 'angle'.
   explicit RotationDeltaCostFunctor(const double scaling_factor,
                                     const double target_angle)
       : scaling_factor_(scaling_factor), angle_(target_angle) {}

--- a/cartographer/mapping_2d/scan_matching/translation_delta_cost_functor.h
+++ b/cartographer/mapping_2d/scan_matching/translation_delta_cost_functor.h
@@ -27,6 +27,20 @@ namespace scan_matching {
 // Cost increases with the solution's distance from 'target_translation'.
 class TranslationDeltaCostFunctor {
  public:
+  static ceres::CostFunction* CreateAutoDiffCostFunction(
+      const double scaling_factor, const Eigen::Vector2d& target_translation) {
+    return new ceres::AutoDiffCostFunction<TranslationDeltaCostFunctor, 2, 3>(
+        new TranslationDeltaCostFunctor(scaling_factor, target_translation));
+  }
+
+  template <typename T>
+  bool operator()(const T* const pose, T* residual) const {
+    residual[0] = scaling_factor_ * (pose[0] - x_);
+    residual[1] = scaling_factor_ * (pose[1] - y_);
+    return true;
+  }
+
+ private:
   // Constructs a new TranslationDeltaCostFunctor from the given
   // 'target_translation' (x, y).
   explicit TranslationDeltaCostFunctor(
@@ -39,14 +53,6 @@ class TranslationDeltaCostFunctor {
   TranslationDeltaCostFunctor& operator=(const TranslationDeltaCostFunctor&) =
       delete;
 
-  template <typename T>
-  bool operator()(const T* const pose, T* residual) const {
-    residual[0] = scaling_factor_ * (pose[0] - x_);
-    residual[1] = scaling_factor_ * (pose[1] - y_);
-    return true;
-  }
-
- private:
   const double scaling_factor_;
   const double x_;
   const double y_;

--- a/cartographer/mapping_2d/scan_matching/translation_delta_cost_functor.h
+++ b/cartographer/mapping_2d/scan_matching/translation_delta_cost_functor.h
@@ -29,7 +29,8 @@ class TranslationDeltaCostFunctor {
  public:
   static ceres::CostFunction* CreateAutoDiffCostFunction(
       const double scaling_factor, const Eigen::Vector2d& target_translation) {
-    return new ceres::AutoDiffCostFunction<TranslationDeltaCostFunctor, 2, 3>(
+    return new ceres::AutoDiffCostFunction<
+        TranslationDeltaCostFunctor, 2 /* residuals */, 3 /* pose variables */>(
         new TranslationDeltaCostFunctor(scaling_factor, target_translation));
   }
 

--- a/cartographer/mapping_3d/pose_graph/optimization_problem.cc
+++ b/cartographer/mapping_3d/pose_graph/optimization_problem.cc
@@ -300,13 +300,12 @@ void OptimizationProblem::Solve(const std::vector<Constraint>& constraints,
                result_to_first_center.delta_rotation) *
               result_center_to_center.delta_velocity;
           problem.AddResidualBlock(
-              new ceres::AutoDiffCostFunction<AccelerationCostFunction, 3, 4, 3,
-                                              3, 3, 1, 4>(
-                  new AccelerationCostFunction(
-                      options_.acceleration_weight(), delta_velocity,
-                      common::ToSeconds(first_duration),
-                      common::ToSeconds(second_duration))),
-              nullptr, C_nodes.at(second_node_id).rotation(),
+              AccelerationCostFunction::CreateAutoDiffCostFunction(
+                  options_.acceleration_weight(), delta_velocity,
+                  common::ToSeconds(first_duration),
+                  common::ToSeconds(second_duration)),
+              nullptr /* loss function */,
+              C_nodes.at(second_node_id).rotation(),
               C_nodes.at(first_node_id).translation(),
               C_nodes.at(second_node_id).translation(),
               C_nodes.at(third_node_id).translation(),
@@ -314,10 +313,9 @@ void OptimizationProblem::Solve(const std::vector<Constraint>& constraints,
               trajectory_data.imu_calibration.data());
         }
         problem.AddResidualBlock(
-            new ceres::AutoDiffCostFunction<RotationCostFunction, 3, 4, 4, 4>(
-                new RotationCostFunction(options_.rotation_weight(),
-                                         result.delta_rotation)),
-            nullptr, C_nodes.at(first_node_id).rotation(),
+            RotationCostFunction::CreateAutoDiffCostFunction(
+                options_.rotation_weight(), result.delta_rotation),
+            nullptr /* loss function */, C_nodes.at(first_node_id).rotation(),
             C_nodes.at(second_node_id).rotation(),
             trajectory_data.imu_calibration.data());
       }

--- a/cartographer/mapping_3d/scan_matching/rotation_delta_cost_functor.h
+++ b/cartographer/mapping_3d/scan_matching/rotation_delta_cost_functor.h
@@ -30,18 +30,13 @@ namespace scan_matching {
 // Cost increases with the solution's distance from 'target_rotation'.
 class RotationDeltaCostFunctor {
  public:
-  // Constructs a new RotationDeltaCostFunctor from the given 'target_rotation'.
-  explicit RotationDeltaCostFunctor(const double scaling_factor,
-                                    const Eigen::Quaterniond& target_rotation)
-      : scaling_factor_(scaling_factor) {
-    target_rotation_inverse_[0] = target_rotation.w();
-    target_rotation_inverse_[1] = -target_rotation.x();
-    target_rotation_inverse_[2] = -target_rotation.y();
-    target_rotation_inverse_[3] = -target_rotation.z();
+  static ceres::CostFunction* CreateAutoDiffCostFunction(
+      const double scaling_factor, const Eigen::Quaterniond& target_rotation) {
+    return new ceres::AutoDiffCostFunction<RotationDeltaCostFunctor,
+                                           3 /* residuals */,
+                                           4 /* rotation variables */>(
+        new RotationDeltaCostFunctor(scaling_factor, target_rotation));
   }
-
-  RotationDeltaCostFunctor(const RotationDeltaCostFunctor&) = delete;
-  RotationDeltaCostFunctor& operator=(const RotationDeltaCostFunctor&) = delete;
 
   template <typename T>
   bool operator()(const T* const rotation_quaternion, T* residual) const {
@@ -60,6 +55,19 @@ class RotationDeltaCostFunctor {
   }
 
  private:
+  // Constructs a new RotationDeltaCostFunctor from the given 'target_rotation'.
+  explicit RotationDeltaCostFunctor(const double scaling_factor,
+                                    const Eigen::Quaterniond& target_rotation)
+      : scaling_factor_(scaling_factor) {
+    target_rotation_inverse_[0] = target_rotation.w();
+    target_rotation_inverse_[1] = -target_rotation.x();
+    target_rotation_inverse_[2] = -target_rotation.y();
+    target_rotation_inverse_[3] = -target_rotation.z();
+  }
+
+  RotationDeltaCostFunctor(const RotationDeltaCostFunctor&) = delete;
+  RotationDeltaCostFunctor& operator=(const RotationDeltaCostFunctor&) = delete;
+
   const double scaling_factor_;
   double target_rotation_inverse_[4];
 };

--- a/cartographer/mapping_3d/scan_matching/translation_delta_cost_functor.h
+++ b/cartographer/mapping_3d/scan_matching/translation_delta_cost_functor.h
@@ -27,6 +27,23 @@ namespace scan_matching {
 // Cost increases with the solution's distance from 'target_translation'.
 class TranslationDeltaCostFunctor {
  public:
+  static ceres::CostFunction* CreateAutoDiffCostFunction(
+      const double scaling_factor, const Eigen::Vector3d& target_translation) {
+    return new ceres::AutoDiffCostFunction<TranslationDeltaCostFunctor,
+                                           3 /* residuals */,
+                                           3 /* translation variables */>(
+        new TranslationDeltaCostFunctor(scaling_factor, target_translation));
+  }
+
+  template <typename T>
+  bool operator()(const T* const translation, T* residual) const {
+    residual[0] = scaling_factor_ * (translation[0] - x_);
+    residual[1] = scaling_factor_ * (translation[1] - y_);
+    residual[2] = scaling_factor_ * (translation[2] - z_);
+    return true;
+  }
+
+ private:
   // Constructs a new TranslationDeltaCostFunctor from the given
   // 'target_translation'.
   explicit TranslationDeltaCostFunctor(
@@ -40,15 +57,6 @@ class TranslationDeltaCostFunctor {
   TranslationDeltaCostFunctor& operator=(const TranslationDeltaCostFunctor&) =
       delete;
 
-  template <typename T>
-  bool operator()(const T* const translation, T* residual) const {
-    residual[0] = scaling_factor_ * (translation[0] - x_);
-    residual[1] = scaling_factor_ * (translation[1] - y_);
-    residual[2] = scaling_factor_ * (translation[2] - z_);
-    return true;
-  }
-
- private:
   const double scaling_factor_;
   const double x_;
   const double y_;


### PR DESCRIPTION
Creating a ceres::AutoDiffCostFunction requires specifying numbers
of residuals and variables, so it is safer to implement this within
the cost functions, which know best.