### PR TITLE
Move LocalSlamResultCallback to AddTrajectory.

### DIFF
--- a/cartographer/mapping/map_builder.h
+++ b/cartographer/mapping/map_builder.h
@@ -38,8 +38,7 @@ proto::MapBuilderOptions CreateMapBuilderOptions(
 // and a PoseGraph for loop closure.
 class MapBuilder : public MapBuilderInterface {
  public:
-  MapBuilder(const proto::MapBuilderOptions& options,
-             const LocalSlamResultCallback& local_slam_result_callback);
+  MapBuilder(const proto::MapBuilderOptions& options);
   ~MapBuilder() override;
 
   MapBuilder(const MapBuilder&) = delete;
@@ -47,7 +46,8 @@ class MapBuilder : public MapBuilderInterface {
 
   int AddTrajectoryBuilder(
       const std::unordered_set<std::string>& expected_sensor_ids,
-      const proto::TrajectoryBuilderOptions& trajectory_options) override;
+      const proto::TrajectoryBuilderOptions& trajectory_options,
+      LocalSlamResultCallback local_slam_result_callback) override;
 
   int AddTrajectoryForDeserialization() override;
 
@@ -74,8 +74,6 @@ class MapBuilder : public MapBuilderInterface {
   std::unique_ptr<mapping_2d::PoseGraph> pose_graph_2d_;
   std::unique_ptr<mapping_3d::PoseGraph> pose_graph_3d_;
   mapping::PoseGraph* pose_graph_;
-
-  LocalSlamResultCallback local_slam_result_callback_;
 
   sensor::Collator sensor_collator_;
   std::vector<std::unique_ptr<mapping::TrajectoryBuilder>> trajectory_builders_;

--- a/cartographer/mapping/map_builder_interface.h
+++ b/cartographer/mapping/map_builder_interface.h
@@ -51,7 +51,8 @@ class MapBuilderInterface {
   // Creates a new trajectory builder and returns its index.
   virtual int AddTrajectoryBuilder(
       const std::unordered_set<std::string>& expected_sensor_ids,
-      const proto::TrajectoryBuilderOptions& trajectory_options) = 0;
+      const proto::TrajectoryBuilderOptions& trajectory_options,
+      LocalSlamResultCallback local_slam_result_callback) = 0;
 
   // Creates a new trajectory and returns its index. Querying the trajectory
   // builder for it will return 'nullptr'.


### PR DESCRIPTION
This is necessary so that MapBuilderBridge can create MapBuilder without specifying the callback until it is needed, which makes gRPC implementation easier [RFC=0002](https://github.com/googlecartographer/rfcs/blob/master/text/0002-cloud-based-mapping-1.md).