### PR TITLE
WIP: Refactor worker dispatch logic

### DIFF
--- a/cartographer/mapping_2d/pose_graph.h
+++ b/cartographer/mapping_2d/pose_graph.h
@@ -172,6 +172,9 @@ class PoseGraph : public mapping::PoseGraph {
   // all computations have finished.
   void WaitForAllComputations() EXCLUDES(mutex_);
 
+  // Dispatches a worker thread
+  void DispatchWorker();
+
   // Runs the optimization. Callers have to make sure, that there is only one
   // optimization being run at a time.
   void RunOptimization() EXCLUDES(mutex_);


### PR DESCRIPTION
As discussed in #563

@cschuet  This is the rough logic how I get CHECK failure in constraint builder. This is how I reproduced. 

* start localization trajectory
* A few seconds later, finish it and start the new pure localization trajectory.
* Then, kill cartographer_node.

```
[/cartographer_node  INFO 1512404436.214935386, 1498225483.460233338]: I1204 17:20:36.000000 30475 submaps.cc:190] Added submap 1
[/cartographer_node  INFO 1512404436.215024605, 1498225483.460233338]: I1204 17:20:36.000000 30475 map_builder_bridge.cc:102] Added trajectory with ID '1'.
[/cartographer_node  INFO 1512404436.486713140, 1498225483.732305270]: I1204 17:20:36.000000 30475 ordered_multi_queue.cc:172] All sensor data for trajectory 1 is available starting at '636338222837143499'.
[/cartographer_node  INFO 1512404436.486774292, 1498225483.732305270]: I1204 17:20:36.000000 30475 local_trajectory_builder.cc:227] Extrapolator not yet initialized.
[/rviz  INFO 1512404442.862798002, 1498225490.109016016]: Setting pose: -0.975 3.187 0.065 [frame=map]
[/cartographer_node  INFO 1512404442.870230131, 1498225490.119075553]: I1204 17:20:42.000000 30475 node.cc:396] Shutdown the subscriber of [scan_1]
[/cartographer_node  INFO 1512404442.873909440, 1498225490.119075553]: I1204 17:20:42.000000 30475 node.cc:396] Shutdown the subscriber of [scan_2]
[/cartographer_node  INFO 1512404442.874931825, 1498225490.119075553]: I1204 17:20:42.000000 30475 node.cc:396] Shutdown the subscriber of [odom]
[/cartographer_node  INFO 1512404442.874972135, 1498225490.119075553]: I1204 17:20:42.000000 30475 map_builder_bridge.cc:124] Finishing trajectory with ID '1'...
[/cartographer_node  INFO 1512404442.883320257, 1498225490.129132641]: I1204 17:20:42.000000 30475 submaps.cc:190] Added submap 1
[/cartographer_node  INFO 1512404442.883375739, 1498225490.129132641]: I1204 17:20:42.000000 30475 map_builder_bridge.cc:102] Added trajectory with ID '2'.
[/cartographer_initialpose_handler  INFO 1512404442.906812873, 1498225490.149516327]: I1204 17:20:42.000000 30492 initialpose_to_start_trajectory.cc:171] Started trajectory 2
[/cartographer_node  INFO 1512404443.107188172, 1498225490.351897728]: I1204 17:20:43.000000 30475 ordered_multi_queue.cc:172] All sensor data for trajectory 2 is available starting at '636338222903340143'.
[/cartographer_node  INFO 1512404443.115571745, 1498225490.362315504]: I1204 17:20:43.000000 30475 local_trajectory_builder.cc:227] Extrapolator not yet initialized.
Optimizing: Done.
F1204 17:20:45.663755 30475 constraint_builder.cc:112] Check failed: when_done_ == nullptr 
 [PAUSED ]  Bag Time: 1498225492.195133   Duration: 8.998239 / 681.610451               
*** Check failure stack trace: ***
    @     0x7fb7895615cd  google::LogMessage::Fail()
    @     0x7fb789563433  google::LogMessage::SendToLog()
    @     0x7fb78956115b  google::LogMessage::Flush()
    @     0x7fb789563e1e  google::LogMessageFatal::~LogMessageFatal()
    @           0x5c952b  cartographer::mapping_2d::pose_graph::ConstraintBuilder::WhenDone()
    @           0x530a3c  cartographer::mapping_2d::PoseGraph::WaitForAllComputations()
    @           0x539785  cartographer::mapping_2d::PoseGraph::RunFinalOptimization()
    @           0x4f1cb9  cartographer_ros::MapBuilderBridge::RunFinalOptimization()
    @           0x4cfad6  cartographer_ros::Node::RunFinalOptimization()
    @           0x4ca291  cartographer_ros::(anonymous namespace)::Run()
    @           0x4c8774  main
    @     0x7fb786893830  __libc_start_main
    @           0x4c9e39  _start
    @              (nil)  (unknown)
```
