### PR TITLE
Does not work.

### DIFF
--- a/cartographer_grpc/framework/rpc.cc
+++ b/cartographer_grpc/framework/rpc.cc
@@ -49,11 +49,11 @@ Rpc::Rpc(int method_index,
       execution_context_(execution_context),
       rpc_handler_info_(rpc_handler_info),
       service_(service),
-      new_connection_event_{Event::NEW_CONNECTION, this, false},
+      /*new_connection_event_{Event::NEW_CONNECTION, this, false},
       read_event_{Event::READ, this, false},
       write_event_{Event::WRITE, this, false},
       finish_event_{Event::FINISH, this, false},
-      done_event_{Event::DONE, this, false},
+      done_event_{Event::DONE, this, false},*/
       handler_(rpc_handler_info_.rpc_handler_factory(this, execution_context)) {
   InitializeReadersAndWriters(rpc_handler_info_.rpc_type);
 
@@ -78,30 +78,30 @@ void Rpc::OnReadsDone() { handler_->OnReadsDone(); }
 
 void Rpc::RequestNextMethodInvocation() {
   // Ask gRPC to notify us when the connection terminates.
-  done_event_.pending = true;
-  server_context_.AsyncNotifyWhenDone(&done_event_);
+  done_event_pending_ = true;
+  server_context_.AsyncNotifyWhenDone(new RpcEvent(Event::DONE, this));
 
   // Make sure after terminating the connection, gRPC notifies us with this
   // event.
-  new_connection_event_.pending = true;
+  new_connection_event_pending_ = true;
   switch (rpc_handler_info_.rpc_type) {
     case ::grpc::internal::RpcMethod::BIDI_STREAMING:
       service_->RequestAsyncBidiStreaming(
           method_index_, &server_context_, streaming_interface(),
           server_completion_queue_, server_completion_queue_,
-          &new_connection_event_);
+          new RpcEvent(Event::NEW_CONNECTION, this));
       break;
     case ::grpc::internal::RpcMethod::CLIENT_STREAMING:
       service_->RequestAsyncClientStreaming(
           method_index_, &server_context_, streaming_interface(),
           server_completion_queue_, server_completion_queue_,
-          &new_connection_event_);
+          new RpcEvent(Event::NEW_CONNECTION, this));
       break;
     case ::grpc::internal::RpcMethod::NORMAL_RPC:
       service_->RequestAsyncUnary(
           method_index_, &server_context_, request_.get(),
           streaming_interface(), server_completion_queue_,
-          server_completion_queue_, &new_connection_event_);
+          server_completion_queue_, new RpcEvent(Event::NEW_CONNECTION, this));
       break;
     default:
       LOG(FATAL) << "RPC type not implemented.";
@@ -113,8 +113,8 @@ void Rpc::RequestStreamingReadIfNeeded() {
   switch (rpc_handler_info_.rpc_type) {
     case ::grpc::internal::RpcMethod::BIDI_STREAMING:
     case ::grpc::internal::RpcMethod::CLIENT_STREAMING:
-      read_event_.pending = true;
-      async_reader_interface()->Read(request_.get(), &read_event_);
+      read_event_pending_ = true;
+      async_reader_interface()->Read(request_.get(), new RpcEvent(Event::READ, this));
       break;
     case ::grpc::internal::RpcMethod::NORMAL_RPC:
       // For NORMAL_RPC we don't have to do anything here, since gRPC
@@ -149,21 +149,21 @@ void Rpc::Write(std::unique_ptr<::google::protobuf::Message> message) {
 
 void Rpc::SendFinish(std::unique_ptr<::google::protobuf::Message> message,
                      ::grpc::Status status) {
-  finish_event_.pending = true;
+  finish_event_pending_ = true;
   switch (rpc_handler_info_.rpc_type) {
     case ::grpc::internal::RpcMethod::BIDI_STREAMING:
       CHECK(!message);
-      server_async_reader_writer_->Finish(status, &finish_event_);
+      server_async_reader_writer_->Finish(status, new RpcEvent(Event::FINISH, this));
       break;
     case ::grpc::internal::RpcMethod::CLIENT_STREAMING:
       response_ = std::move(message);
       SendUnaryFinish(server_async_reader_.get(), status, response_.get(),
-                      &finish_event_);
+                      new RpcEvent(Event::FINISH, this));
       break;
     case ::grpc::internal::RpcMethod::NORMAL_RPC:
       response_ = std::move(message);
       SendUnaryFinish(server_async_response_writer_.get(), status,
-                      response_.get(), &finish_event_);
+                      response_.get(), new RpcEvent(Event::FINISH, this));
       break;
     default:
       LOG(FATAL) << "RPC type not implemented.";
@@ -188,20 +188,20 @@ void Rpc::Finish(::grpc::Status status) {
 }
 
 void Rpc::PerformWriteIfNeeded() {
-  if (send_queue_.empty() || write_event_.pending) {
+  if (send_queue_.empty() || write_event_pending_) {
     return;
   }
 
   // Make sure not other send operations are in-flight.
-  CHECK(!finish_event_.pending);
+  CHECK(!finish_event_pending_);
 
   SendItem send_item = std::move(send_queue_.front());
   send_queue_.pop();
   response_ = std::move(send_item.msg);
 
   if (response_) {
-    write_event_.pending = true;
-    async_writer_interface()->Write(*response_.get(), &write_event_);
+    write_event_pending_ = true;
+    async_writer_interface()->Write(*response_.get(), new RpcEvent(Event::WRITE, this));
   } else {
     CHECK(send_queue_.empty());
     SendFinish(nullptr /* message */, send_item.status);
@@ -253,6 +253,7 @@ Rpc::async_writer_interface() {
   LOG(FATAL) << "Never reached.";
 }
 
+/*
 Rpc::RpcEvent* Rpc::GetRpcEvent(Event event) {
   switch (event) {
     case Event::DONE:
@@ -267,6 +268,30 @@ Rpc::RpcEvent* Rpc::GetRpcEvent(Event event) {
       return &write_event_;
   }
   LOG(FATAL) << "Never reached.";
+}
+*/
+
+void Rpc::SetEventState(Event event, bool pending) {
+  switch (event) {
+    case Event::DONE:
+      done_event_pending_ = pending;
+    case Event::FINISH:
+      finish_event_pending_ = pending;
+    case Event::NEW_CONNECTION:
+      new_connection_event_pending_ = pending;
+    case Event::READ:
+      read_event_pending_ = pending;
+    case Event::WRITE:
+      write_event_pending_ = pending;
+  }
+}
+
+bool Rpc::IsNoEventPending() {
+  return !done_event_pending_ && !read_event_pending_ && !write_event_pending_ && !finish_event_pending_;
+ /* !rpc->GetRpcEvent(Rpc::Event::DONE)->pending &&
+      !rpc->GetRpcEvent(Rpc::Event::READ)->pending &&
+      !rpc->GetRpcEvent(Rpc::Event::WRITE)->pending &&
+      !rpc->GetRpcEvent(Rpc::Event::FINISH)->pending*/
 }
 
 ActiveRpcs::ActiveRpcs() : lock_() {}

--- a/cartographer_grpc/framework/service.cc
+++ b/cartographer_grpc/framework/service.cc
@@ -52,7 +52,8 @@ void Service::StartServing(
 void Service::StopServing() { shutting_down_ = true; }
 
 void Service::HandleEvent(Rpc::Event event, Rpc* rpc, bool ok) {
-  rpc->GetRpcEvent(event)->pending = false;
+  rpc->SetEventState(event, false);
+      //GetRpcEvent(event)->pending = false;
   switch (event) {
     case Rpc::Event::NEW_CONNECTION:
       HandleNewConnection(rpc, ok);
@@ -131,10 +132,7 @@ void Service::HandleFinish(Rpc* rpc, bool ok) {
 void Service::HandleDone(Rpc* rpc, bool ok) { RemoveIfNotPending(rpc); }
 
 void Service::RemoveIfNotPending(Rpc* rpc) {
-  if (!rpc->GetRpcEvent(Rpc::Event::DONE)->pending &&
-      !rpc->GetRpcEvent(Rpc::Event::READ)->pending &&
-      !rpc->GetRpcEvent(Rpc::Event::WRITE)->pending &&
-      !rpc->GetRpcEvent(Rpc::Event::FINISH)->pending) {
+  if (rpc->IsNoEventPending()) {
     active_rpcs_.Remove(rpc);
   }
 }


### PR DESCRIPTION
Fails with

> 
> [ RUN      ] ServerTest.ProcessRpcStreamTest
> pure virtual method called
> terminate called without an active exception
> I1213 13:09:27.617507 200451 server.cc:99] Shutting down server.
> [New Thread 0x7ffff487c700 (LWP 200460)]
> [New Thread 0x7ffff5a89700 (LWP 200459)]
> [New Thread 0x7ffff5288700 (LWP 200458)]
> 
> Program received signal SIGABRT, Aborted.
> [Switching to Thread 0x7ffff487c700 (LWP 200460)]
> 0x00007ffff6e7fc37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
> 56      ../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.
> (gdb) bt
> #0  0x00007ffff6e7fc37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
> #1  0x00007ffff6e83028 in __GI_abort () at abort.c:89
> #2  0x00007ffff7488535 in __gnu_cxx::__verbose_terminate_handler () at ../../../../src/libstdc++-v3/libsupc++/vterminate.cc:95
> #3  0x00007ffff74866d6 in __cxxabiv1::__terminate (handler=<optimized out>) at ../../../../src/libstdc++-v3/libsupc++/eh_terminate.cc:38
> #4  0x00007ffff7486703 in std::terminate () at ../../../../src/libstdc++-v3/libsupc++/eh_terminate.cc:48
> #5  0x00007ffff74871bf in __cxxabiv1::__cxa_pure_virtual () at ../../../../src/libstdc++-v3/libsupc++/pure.cc:50
> #6  0x00007ffff7998ed3 in grpc::CompletionQueue::AsyncNextInternal(void**, bool*, gpr_timespec) () from /usr/local/lib/libgrpc++.so.1
> #7  0x00000000005751ff in Next (ok=0x7ffff487bd70, tag=0x7ffff487bd80, this=0x98da50) at /usr/local/include/grpc++/impl/codegen/completion_queue.h:170
> #8  cartographer_grpc::framework::Server::RunCompletionQueue (completion_queue=0x98da50)
>     at /usr/local/google/home/cschuet/catkin_ws/src/cartographer/cartographer_grpc/framework/server.cc:67
> #9  0x00007ffff74d9a60 in std::(anonymous namespace)::execute_native_thread_routine (__p=<optimized out>) at ../../../../../src/libstdc++-v3/src/c++11/thread.cc:84
> #10 0x00007ffff7bc4184 in start_thread (arg=0x7ffff487c700) at pthread_create.c:312
> #11 0x00007ffff6f46ffd in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:111
> 