### PR TITLE
Heap-allocate RpcEvents.

### DIFF
--- a/cartographer_grpc/framework/rpc.cc
+++ b/cartographer_grpc/framework/rpc.cc
@@ -49,11 +49,6 @@ Rpc::Rpc(int method_index,
       execution_context_(execution_context),
       rpc_handler_info_(rpc_handler_info),
       service_(service),
-      new_connection_event_pending_(false),
-      read_event_pending_(false),
-      write_event_pending_(false),
-      finish_event_pending_(false),
-      done_event_pending_(false),
       handler_(rpc_handler_info_.rpc_handler_factory(this, execution_context)) {
   InitializeReadersAndWriters(rpc_handler_info_.rpc_type);
 
@@ -256,7 +251,7 @@ Rpc::async_writer_interface() {
   LOG(FATAL) << "Never reached.";
 }
 
-bool* Rpc::GetEventState(Event event) {
+bool* Rpc::GetRpcEventState(Event event) {
   switch (event) {
     case Event::DONE:
       return &done_event_pending_;
@@ -273,16 +268,16 @@ bool* Rpc::GetEventState(Event event) {
 }
 
 void Rpc::SetRpcEventState(Event event, bool pending) {
-  *GetEventState(event) = pending;
+  *GetRpcEventState(event) = pending;
 }
 
-bool Rpc::IsRpcEventPending(Event event) { return *GetEventState(event); }
+bool Rpc::IsRpcEventPending(Event event) { return *GetRpcEventState(event); }
 
-bool Rpc::IsNoEventPending() {
-  return !IsRpcEventPending(Rpc::Event::DONE) &&
-         !IsRpcEventPending(Rpc::Event::READ) &&
-         !IsRpcEventPending(Rpc::Event::WRITE) &&
-         !IsRpcEventPending(Rpc::Event::FINISH);
+bool Rpc::IsAnyEventPending() {
+  return IsRpcEventPending(Rpc::Event::DONE) ||
+         IsRpcEventPending(Rpc::Event::READ) ||
+         IsRpcEventPending(Rpc::Event::WRITE) ||
+         IsRpcEventPending(Rpc::Event::FINISH);
 }
 
 ActiveRpcs::ActiveRpcs() : lock_() {}

--- a/cartographer_grpc/framework/rpc.cc
+++ b/cartographer_grpc/framework/rpc.cc
@@ -255,69 +255,29 @@ Rpc::async_writer_interface() {
   }
   LOG(FATAL) << "Never reached.";
 }
-/*
-Rpc::RpcEvent* Rpc::GetRpcEventInternal(Event event) {
+
+bool* Rpc::GetEventState(Event event) {
   switch (event) {
     case Event::DONE:
-      LOG(INFO) << "Accessing done";
-      return &done2_event_;
+      return &done_event_pending_;
     case Event::FINISH:
-      return &finish_event_;
+      return  &finish_event_pending_;
     case Event::NEW_CONNECTION:
-      return &new_connection_event_;
+      return  &new_connection_event_pending_;
     case Event::READ:
-      return &read_event_;
+      return &read_event_pending_;
     case Event::WRITE:
-      return &write_event_;
+      return &write_event_pending_;
   }
   LOG(FATAL) << "Never reached.";
-}*/
+}
 
 void Rpc::SetRpcEventState(Event event, bool pending) {
-  switch (event) {
-    case Event::DONE:
-      done_event_pending_ = pending;
-      break;
-      // return &done_event_;
-    case Event::FINISH:
-      finish_event_pending_ = pending;
-      break;
-      // return &finish_event_;
-    case Event::NEW_CONNECTION:
-      new_connection_event_pending_ = pending;
-      break;
-      // return &new_connection_event_;
-    case Event::READ:
-      read_event_pending_ = pending;
-      break;
-      // return &read_event_;
-    case Event::WRITE:
-      write_event_pending_ = pending;
-      break;
-      // return &write_event_;
-  }
+  *GetEventState(event) = pending;
 }
 
 bool Rpc::IsRpcEventPending(Event event) {
-  bool is_pending = false;
-  switch (event) {
-    case Event::DONE:
-      is_pending = done_event_pending_;
-      break;
-    case Event::FINISH:
-      is_pending = finish_event_pending_;
-      break;
-    case Event::NEW_CONNECTION:
-      is_pending = new_connection_event_pending_;
-      break;
-    case Event::READ:
-      is_pending = read_event_pending_;
-      break;
-    case Event::WRITE:
-      is_pending = write_event_pending_;
-      break;
-  }
-  return is_pending;
+  return *GetEventState(event);
 }
 
 bool Rpc::IsNoEventPending() {

--- a/cartographer_grpc/framework/rpc.cc
+++ b/cartographer_grpc/framework/rpc.cc
@@ -261,9 +261,9 @@ bool* Rpc::GetEventState(Event event) {
     case Event::DONE:
       return &done_event_pending_;
     case Event::FINISH:
-      return  &finish_event_pending_;
+      return &finish_event_pending_;
     case Event::NEW_CONNECTION:
-      return  &new_connection_event_pending_;
+      return &new_connection_event_pending_;
     case Event::READ:
       return &read_event_pending_;
     case Event::WRITE:
@@ -276,9 +276,7 @@ void Rpc::SetRpcEventState(Event event, bool pending) {
   *GetEventState(event) = pending;
 }
 
-bool Rpc::IsRpcEventPending(Event event) {
-  return *GetEventState(event);
-}
+bool Rpc::IsRpcEventPending(Event event) { return *GetEventState(event); }
 
 bool Rpc::IsNoEventPending() {
   return !IsRpcEventPending(Rpc::Event::DONE) &&

--- a/cartographer_grpc/framework/rpc.h
+++ b/cartographer_grpc/framework/rpc.h
@@ -41,11 +41,6 @@ class Rpc {
   struct RpcEvent {
     const Event event;
     Rpc* rpc;
-    // Indicates whether the event is pending completion. E.g. 'event = READ'
-    // and 'pending = true' means that a read has been requested but hasn't
-    // completed yet. While 'pending = false' indicates, that the read has
-    // completed and currently no read is in-flight.
-    bool pending;
   };
 
   Rpc(int method_index, ::grpc::ServerCompletionQueue* server_completion_queue,
@@ -60,9 +55,12 @@ class Rpc {
   void Write(std::unique_ptr<::google::protobuf::Message> message);
   void Finish(::grpc::Status status);
   Service* service() { return service_; }
-  RpcEvent* GetRpcEvent(Event event);
+  void SetRpcEventState(Event event, bool pending);
+  bool IsRpcEventPending(Event event);
+  bool IsNoEventPending();
 
  private:
+  // RpcEvent* GetRpcEventInternal(Event event);
   struct SendItem {
     std::unique_ptr<google::protobuf::Message> msg;
     ::grpc::Status status;
@@ -89,11 +87,15 @@ class Rpc {
   Service* service_;
   ::grpc::ServerContext server_context_;
 
-  RpcEvent new_connection_event_;
-  RpcEvent read_event_;
-  RpcEvent write_event_;
-  RpcEvent finish_event_;
-  RpcEvent done_event_;
+  // Indicates whether the event is pending completion. E.g. 'event = READ'
+  // and 'pending = true' means that a read has been requested but hasn't
+  // completed yet. While 'pending = false' indicates, that the read has
+  // completed and currently no read is in-flight.
+  bool new_connection_event_pending_;
+  bool read_event_pending_;
+  bool write_event_pending_;
+  bool finish_event_pending_;
+  bool done_event_pending_;
 
   std::unique_ptr<google::protobuf::Message> request_;
   std::unique_ptr<google::protobuf::Message> response_;

--- a/cartographer_grpc/framework/rpc.h
+++ b/cartographer_grpc/framework/rpc.h
@@ -60,7 +60,6 @@ class Rpc {
   bool IsNoEventPending();
 
  private:
-  // RpcEvent* GetRpcEventInternal(Event event);
   struct SendItem {
     std::unique_ptr<google::protobuf::Message> msg;
     ::grpc::Status status;
@@ -72,6 +71,7 @@ class Rpc {
       ::grpc::internal::RpcMethod::RpcType rpc_type);
   void SendFinish(std::unique_ptr<::google::protobuf::Message> message,
                   ::grpc::Status status);
+  bool* GetEventState(Event event);
 
   ::grpc::internal::AsyncReaderInterface<::google::protobuf::Message>*
   async_reader_interface();

--- a/cartographer_grpc/framework/rpc.h
+++ b/cartographer_grpc/framework/rpc.h
@@ -57,7 +57,7 @@ class Rpc {
   Service* service() { return service_; }
   void SetRpcEventState(Event event, bool pending);
   bool IsRpcEventPending(Event event);
-  bool IsNoEventPending();
+  bool IsAnyEventPending();
 
  private:
   struct SendItem {
@@ -71,7 +71,7 @@ class Rpc {
       ::grpc::internal::RpcMethod::RpcType rpc_type);
   void SendFinish(std::unique_ptr<::google::protobuf::Message> message,
                   ::grpc::Status status);
-  bool* GetEventState(Event event);
+  bool* GetRpcEventState(Event event);
 
   ::grpc::internal::AsyncReaderInterface<::google::protobuf::Message>*
   async_reader_interface();
@@ -89,14 +89,13 @@ class Rpc {
 
   // These state variables indicate whether the corresponding event is currently
   // pending completion, e.g. 'read_event_pending_ = true' means that a read has
-  // been requested but hasn't completed yet. While
-  // 'read_event_pending_ = false' indicates, that the read has completed and
-  // currently no read is in-flight.
-  bool new_connection_event_pending_;
-  bool read_event_pending_;
-  bool write_event_pending_;
-  bool finish_event_pending_;
-  bool done_event_pending_;
+  // been requested but hasn't completed yet. 'read_event_pending_ = false'
+  // indicates that the read has completed and currently no read is in-flight.
+  bool new_connection_event_pending_ = false;
+  bool read_event_pending_ = false;
+  bool write_event_pending_ = false;
+  bool finish_event_pending_ = false;
+  bool done_event_pending_ = false;
 
   std::unique_ptr<google::protobuf::Message> request_;
   std::unique_ptr<google::protobuf::Message> response_;

--- a/cartographer_grpc/framework/rpc.h
+++ b/cartographer_grpc/framework/rpc.h
@@ -87,10 +87,11 @@ class Rpc {
   Service* service_;
   ::grpc::ServerContext server_context_;
 
-  // Indicates whether the event is pending completion. E.g. 'event = READ'
-  // and 'pending = true' means that a read has been requested but hasn't
-  // completed yet. While 'pending = false' indicates, that the read has
-  // completed and currently no read is in-flight.
+  // These state variables indicate whether the corresponding event is currently
+  // pending completion, e.g. 'read_event_pending_ = true' means that a read has
+  // been requested but hasn't completed yet. While
+  // 'read_event_pending_ = false' indicates, that the read has completed and
+  // currently no read is in-flight.
   bool new_connection_event_pending_;
   bool read_event_pending_;
   bool write_event_pending_;

--- a/cartographer_grpc/framework/server.cc
+++ b/cartographer_grpc/framework/server.cc
@@ -68,6 +68,7 @@ void Server::RunCompletionQueue(
     auto* rpc_event = static_cast<Rpc::RpcEvent*>(tag);
     rpc_event->rpc->service()->HandleEvent(rpc_event->event, rpc_event->rpc,
                                            ok);
+    delete rpc_event;
   }
 }
 

--- a/cartographer_grpc/framework/service.cc
+++ b/cartographer_grpc/framework/service.cc
@@ -131,7 +131,7 @@ void Service::HandleFinish(Rpc* rpc, bool ok) {
 void Service::HandleDone(Rpc* rpc, bool ok) { RemoveIfNotPending(rpc); }
 
 void Service::RemoveIfNotPending(Rpc* rpc) {
-  if (rpc->IsNoEventPending()) {
+  if (!rpc->IsAnyEventPending()) {
     active_rpcs_.Remove(rpc);
   }
 }

--- a/cartographer_grpc/framework/service.cc
+++ b/cartographer_grpc/framework/service.cc
@@ -52,7 +52,7 @@ void Service::StartServing(
 void Service::StopServing() { shutting_down_ = true; }
 
 void Service::HandleEvent(Rpc::Event event, Rpc* rpc, bool ok) {
-  rpc->GetRpcEvent(event)->pending = false;
+  rpc->SetRpcEventState(event, false);
   switch (event) {
     case Rpc::Event::NEW_CONNECTION:
       HandleNewConnection(rpc, ok);
@@ -131,10 +131,7 @@ void Service::HandleFinish(Rpc* rpc, bool ok) {
 void Service::HandleDone(Rpc* rpc, bool ok) { RemoveIfNotPending(rpc); }
 
 void Service::RemoveIfNotPending(Rpc* rpc) {
-  if (!rpc->GetRpcEvent(Rpc::Event::DONE)->pending &&
-      !rpc->GetRpcEvent(Rpc::Event::READ)->pending &&
-      !rpc->GetRpcEvent(Rpc::Event::WRITE)->pending &&
-      !rpc->GetRpcEvent(Rpc::Event::FINISH)->pending) {
+  if (rpc->IsNoEventPending()) {
     active_rpcs_.Remove(rpc);
   }
 }


### PR DESCRIPTION
Replace Rpc's RpcEvent members with heap-allocated RpcEvents.

[RFC=0002](https://github.com/googlecartographer/rfcs/blob/master/text/0002-cloud-based-mapping-1.md)