### PR TITLE
Fix RpcEvent lifetime

### DIFF
--- a/cartographer_grpc/framework/event_queue_thread.h
+++ b/cartographer_grpc/framework/event_queue_thread.h
@@ -26,8 +26,6 @@
 namespace cartographer_grpc {
 namespace framework {
 
-using EventQueue = cartographer::common::BlockingQueue<Rpc::RpcEvent*>;
-
 class EventQueueThread {
  public:
   using EventQueueRunner = std::function<void(EventQueue*)>;

--- a/cartographer_grpc/framework/rpc.cc
+++ b/cartographer_grpc/framework/rpc.cc
@@ -153,18 +153,14 @@ void Rpc::RequestStreamingReadIfNeeded() {
 
 void Rpc::Write(std::unique_ptr<::google::protobuf::Message> message) {
   EnqueueMessage(SendItem{std::move(message), ::grpc::Status::OK});
-  event_queue_->Push(
-      UniqueEventPtr(
-          new InternalRpcEvent(Event::WRITE_NEEDED, weak_ptr_factory_(this))
-          ));
+  event_queue_->Push(UniqueEventPtr(
+      new InternalRpcEvent(Event::WRITE_NEEDED, weak_ptr_factory_(this))));
 }
 
 void Rpc::Finish(::grpc::Status status) {
   EnqueueMessage(SendItem{nullptr /* message */, status});
-  event_queue_->Push(
-      UniqueEventPtr(
-      new InternalRpcEvent(Event::WRITE_NEEDED, weak_ptr_factory_(this))
-  ));
+  event_queue_->Push(UniqueEventPtr(
+      new InternalRpcEvent(Event::WRITE_NEEDED, weak_ptr_factory_(this))));
 }
 
 void Rpc::HandleSendQueue() {

--- a/cartographer_grpc/framework/rpc.cc
+++ b/cartographer_grpc/framework/rpc.cc
@@ -99,7 +99,7 @@ void Rpc::RequestNextMethodInvocation() {
   SetRpcEventState(Event::DONE, true);
   // TODO(gaschler): Asan reports direct leak of this new from both calls
   // StartServing and HandleNewConnection.
-  server_context_.AsyncNotifyWhenDone(&done_event_);
+  server_context_.AsyncNotifyWhenDone(GetRpcEvent(Event::DONE));
 
   // Make sure after terminating the connection, gRPC notifies us with this
   // event.

--- a/cartographer_grpc/framework/rpc.cc
+++ b/cartographer_grpc/framework/rpc.cc
@@ -52,11 +52,13 @@ Rpc::Rpc(int method_index,
       rpc_handler_info_(rpc_handler_info),
       service_(service),
       weak_ptr_factory_(weak_ptr_factory),
-      new_connection_event_{Event::NEW_CONNECTION, this, false},
-      read_event_{Event::READ, this, false},
-      write_event_{Event::WRITE, this, false},
-      finish_event_{Event::FINISH, this, false},
-      done_event_{Event::DONE, this, false},
+      new_connection_event_{Event::NEW_CONNECTION, weak_ptr_factory(this),
+                            false, false},
+      read_event_{Event::READ, weak_ptr_factory(this), false, false},
+      write_needed_event_{Event::WRITE_NEEDED, weak_ptr_factory(this), false, false},
+      write_event_{Event::WRITE, weak_ptr_factory(this), false, false},
+      finish_event_{Event::FINISH, weak_ptr_factory(this), false, false},
+      done_event_{Event::DONE, weak_ptr_factory(this), false, false},
       handler_(rpc_handler_info_.rpc_handler_factory(this, execution_context)) {
   InitializeReadersAndWriters(rpc_handler_info_.rpc_type);
 
@@ -238,6 +240,10 @@ Rpc::RpcEvent* Rpc::GetRpcEvent(Event event) {
       return &done_event_;
   }
   LOG(FATAL) << "Never reached.";
+}
+
+bool* Rpc::GetRpcEventState(Event event) {
+  return &GetRpcEvent(event)->pending;
 }
 
 void Rpc::EnqueueMessage(SendItem&& send_item) {

--- a/cartographer_grpc/framework/rpc.h
+++ b/cartographer_grpc/framework/rpc.h
@@ -75,6 +75,7 @@ class Rpc {
   void SetEventQueue(EventQueue* event_queue) { event_queue_ = event_queue; }
   EventQueue* event_queue() { return event_queue_; }
   std::weak_ptr<Rpc> GetWeakPtr();
+  RpcEvent* GetRpcEvent(Event event);
 
  private:
   struct SendItem {
@@ -119,6 +120,11 @@ class Rpc {
   bool write_event_pending_ = false;
   bool finish_event_pending_ = false;
   bool done_event_pending_ = false;
+  RpcEvent new_connection_event_;
+  RpcEvent read_event_;
+  RpcEvent write_event_;
+  RpcEvent finish_event_;
+  RpcEvent done_event_;
 
   std::unique_ptr<google::protobuf::Message> request_;
   std::unique_ptr<google::protobuf::Message> response_;

--- a/cartographer_grpc/framework/rpc.h
+++ b/cartographer_grpc/framework/rpc.h
@@ -54,6 +54,7 @@ class Rpc {
     const Event event;
     std::weak_ptr<Rpc> rpc;
     bool ok;
+    bool pending;
   };
   Rpc(int method_index, ::grpc::ServerCompletionQueue* server_completion_queue,
       EventQueue* event_queue, ExecutionContext* execution_context,
@@ -110,18 +111,9 @@ class Rpc {
   WeakPtrFactory weak_ptr_factory_;
   ::grpc::ServerContext server_context_;
 
-  // These state variables indicate whether the corresponding event is currently
-  // pending completion, e.g. 'read_event_pending_ = true' means that a read has
-  // been requested but hasn't completed yet. 'read_event_pending_ = false'
-  // indicates that the read has completed and currently no read is in-flight.
-  bool new_connection_event_pending_ = false;
-  bool read_event_pending_ = false;
-  bool write_needed_event_pending_ = false;
-  bool write_event_pending_ = false;
-  bool finish_event_pending_ = false;
-  bool done_event_pending_ = false;
   RpcEvent new_connection_event_;
   RpcEvent read_event_;
+  RpcEvent write_needed_event_;
   RpcEvent write_event_;
   RpcEvent finish_event_;
   RpcEvent done_event_;

--- a/cartographer_grpc/framework/rpc.h
+++ b/cartographer_grpc/framework/rpc.h
@@ -61,6 +61,9 @@ class Rpc {
    public:
     enum Action { DELETE = 0, DO_NOT_DELETE };
 
+    // The default action 'DELETE' is used implicitly, for instance for a
+    // new UniqueEventPtr or a UniqueEventPtr that is created by
+    // 'return nullptr'.
     EventDeleter() : action_(DELETE) {}
     explicit EventDeleter(Action action) : action_(action) {}
     void operator()(EventBase* e) {

--- a/cartographer_grpc/framework/rpc.h
+++ b/cartographer_grpc/framework/rpc.h
@@ -101,13 +101,11 @@ class Rpc {
   void Write(std::unique_ptr<::google::protobuf::Message> message);
   void Finish(::grpc::Status status);
   Service* service() { return service_; }
-  void SetRpcEventState(Event event, bool pending);
   bool IsRpcEventPending(Event event);
   bool IsAnyEventPending();
   void SetEventQueue(EventQueue* event_queue) { event_queue_ = event_queue; }
   EventQueue* event_queue() { return event_queue_; }
   std::weak_ptr<Rpc> GetWeakPtr();
-  RawRpcEvent* GetRpcEvent(Event event);
 
  private:
   struct SendItem {
@@ -119,7 +117,9 @@ class Rpc {
   Rpc& operator=(const Rpc&) = delete;
   void InitializeReadersAndWriters(
       ::grpc::internal::RpcMethod::RpcType rpc_type);
+  RawRpcEvent* GetRpcEvent(Event event);
   bool* GetRpcEventState(Event event);
+  void SetRpcEventState(Event event, bool pending);
   void EnqueueMessage(SendItem&& send_item);
   void PerformFinish(std::unique_ptr<::google::protobuf::Message> message,
                      ::grpc::Status status);

--- a/cartographer_grpc/framework/rpc.h
+++ b/cartographer_grpc/framework/rpc.h
@@ -50,6 +50,7 @@ class Rpc {
     FINISH,
     DONE
   };
+
   struct RpcEvent {
     explicit RpcEvent(Event event) : event(event), ok(false) {}
     virtual ~RpcEvent(){};
@@ -59,6 +60,7 @@ class Rpc {
     const Event event;
     bool ok;
   };
+
   struct RawRpcEvent : public RpcEvent {
     RawRpcEvent(Event event, Rpc* rpc)
         : RpcEvent(event), rpc_ptr(rpc), pending(false) {}
@@ -68,6 +70,7 @@ class Rpc {
     Rpc* rpc_ptr;
     bool pending;
   };
+
   struct WeakRpcEvent : public RpcEvent {
     WeakRpcEvent(Event event, std::weak_ptr<Rpc> rpc)
         : RpcEvent(event), rpc(rpc) {

--- a/cartographer_grpc/framework/rpc.h
+++ b/cartographer_grpc/framework/rpc.h
@@ -57,7 +57,6 @@ class Rpc {
     const Event event;
   };
 
-
   class EventDeleter {
    public:
     EventDeleter() : needs_deletion_(true) {}

--- a/cartographer_grpc/framework/server.cc
+++ b/cartographer_grpc/framework/server.cc
@@ -95,14 +95,14 @@ EventQueue* Server::SelectNextEventQueueRoundRobin() {
 
 void Server::RunEventQueue(EventQueue* event_queue) {
   while (!shutting_down_) {
-    Rpc::EventBase* rpc_event = event_queue->PopWithTimeout(kPopEventTimeout);
+    Rpc::UniqueEventPtr rpc_event = event_queue->PopWithTimeout(kPopEventTimeout);
     if (rpc_event) {
       rpc_event->Handle();
     }
   }
 
   // Finish processing the rest of the items.
-  while (Rpc::EventBase* rpc_event =
+  while (Rpc::UniqueEventPtr rpc_event =
              event_queue->PopWithTimeout(kPopEventTimeout)) {
     rpc_event->Handle();
   }

--- a/cartographer_grpc/framework/server.cc
+++ b/cartographer_grpc/framework/server.cc
@@ -86,8 +86,6 @@ void Server::RunCompletionQueue(
   }
 }
 
-void Server::ProcessRpcEvent(Rpc::RpcEvent* rpc_event) { rpc_event->Handle(); }
-
 EventQueue* Server::SelectNextEventQueueRoundRobin() {
   cartographer::common::MutexLocker locker(&current_event_queue_id_lock_);
   current_event_queue_id_ =
@@ -99,14 +97,14 @@ void Server::RunEventQueue(EventQueue* event_queue) {
   while (!shutting_down_) {
     Rpc::RpcEvent* rpc_event = event_queue->PopWithTimeout(kPopEventTimeout);
     if (rpc_event) {
-      ProcessRpcEvent(rpc_event);
+      rpc_event->Handle();
     }
   }
 
   // Finish processing the rest of the items.
   while (Rpc::RpcEvent* rpc_event =
              event_queue->PopWithTimeout(kPopEventTimeout)) {
-    ProcessRpcEvent(rpc_event);
+    rpc_event->Handle();
   }
 }
 

--- a/cartographer_grpc/framework/server.cc
+++ b/cartographer_grpc/framework/server.cc
@@ -80,7 +80,7 @@ void Server::RunCompletionQueue(
   bool ok;
   void* tag;
   while (completion_queue->Next(&tag, &ok)) {
-    auto* rpc_event = static_cast<Rpc::RpcEvent*>(tag);
+    auto* rpc_event = static_cast<Rpc::CompletionQueueRpcEvent*>(tag);
     rpc_event->ok = ok;
     rpc_event->PushToEventQueue();
   }
@@ -95,14 +95,14 @@ EventQueue* Server::SelectNextEventQueueRoundRobin() {
 
 void Server::RunEventQueue(EventQueue* event_queue) {
   while (!shutting_down_) {
-    Rpc::RpcEvent* rpc_event = event_queue->PopWithTimeout(kPopEventTimeout);
+    Rpc::EventBase* rpc_event = event_queue->PopWithTimeout(kPopEventTimeout);
     if (rpc_event) {
       rpc_event->Handle();
     }
   }
 
   // Finish processing the rest of the items.
-  while (Rpc::RpcEvent* rpc_event =
+  while (Rpc::EventBase* rpc_event =
              event_queue->PopWithTimeout(kPopEventTimeout)) {
     rpc_event->Handle();
   }

--- a/cartographer_grpc/framework/server.cc
+++ b/cartographer_grpc/framework/server.cc
@@ -95,7 +95,8 @@ EventQueue* Server::SelectNextEventQueueRoundRobin() {
 
 void Server::RunEventQueue(EventQueue* event_queue) {
   while (!shutting_down_) {
-    Rpc::UniqueEventPtr rpc_event = event_queue->PopWithTimeout(kPopEventTimeout);
+    Rpc::UniqueEventPtr rpc_event =
+        event_queue->PopWithTimeout(kPopEventTimeout);
     if (rpc_event) {
       rpc_event->Handle();
     }

--- a/cartographer_grpc/framework/server.h
+++ b/cartographer_grpc/framework/server.h
@@ -113,7 +113,6 @@ class Server {
       const std::map<std::string, RpcHandlerInfo>& rpc_handler_infos);
   void RunCompletionQueue(::grpc::ServerCompletionQueue* completion_queue);
   void RunEventQueue(EventQueue* event_queue);
-  void ProcessRpcEvent(Rpc::RpcEvent* rpc_event);
   EventQueue* SelectNextEventQueueRoundRobin();
 
   Options options_;

--- a/cartographer_grpc/framework/server.h
+++ b/cartographer_grpc/framework/server.h
@@ -112,8 +112,8 @@ class Server {
       const std::string& service_name,
       const std::map<std::string, RpcHandlerInfo>& rpc_handler_infos);
   void RunCompletionQueue(::grpc::ServerCompletionQueue* completion_queue);
-  void RunEventQueue(EventQueue* event_queue);
-  EventQueue* SelectNextEventQueueRoundRobin();
+  void RunEventQueue(Rpc::EventQueue* event_queue);
+  Rpc::EventQueue* SelectNextEventQueueRoundRobin();
 
   Options options_;
 

--- a/cartographer_grpc/framework/service.cc
+++ b/cartographer_grpc/framework/service.cc
@@ -58,7 +58,6 @@ void Service::StartServing(
 void Service::StopServing() { shutting_down_ = true; }
 
 void Service::HandleEvent(Rpc::Event event, Rpc* rpc, bool ok) {
-  rpc->SetRpcEventState(event, false);
   switch (event) {
     case Rpc::Event::NEW_CONNECTION:
       HandleNewConnection(rpc, ok);


### PR DESCRIPTION
Fixes #788.

Uses two different types of events whether the event goes through the CompletionQueue or not.
CompletionQueueRpcEvent is again a member of Rpc.

