### PR TITLE
Allow FixedRatioSampler to drop all data.

### DIFF
--- a/cartographer/common/fixed_ratio_sampler.cc
+++ b/cartographer/common/fixed_ratio_sampler.cc
@@ -22,7 +22,8 @@ namespace cartographer {
 namespace common {
 
 FixedRatioSampler::FixedRatioSampler(const double ratio) : ratio_(ratio) {
-  CHECK_GT(ratio, 0.);
+  CHECK_GE(ratio, 0.);
+  LOG_IF(WARNING, ratio == 0.) << "FixedRatioSampler is dropping all data.";
   CHECK_LE(ratio, 1.);
 }
 

--- a/cartographer/common/fixed_ratio_sampler_test.cc
+++ b/cartographer/common/fixed_ratio_sampler_test.cc
@@ -29,8 +29,14 @@ TEST(FixedRatioSamplerTest, AlwaysTrue) {
   }
 }
 
+TEST(FixedRatioSamplerTest, AlwaysFalse) {
+  FixedRatioSampler fixed_ratio_sampler(0.);
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_FALSE(fixed_ratio_sampler.Pulse());
+  }
+}
+
 TEST(FixedRatioSamplerTest, NonSensicalRatio) {
-  EXPECT_DEATH(FixedRatioSampler(0.), "ratio");
   EXPECT_DEATH(FixedRatioSampler(2.), "ratio");
   EXPECT_DEATH(FixedRatioSampler(-0.1), "ratio");
 }


### PR DESCRIPTION
This is useful to disable loop closure by setting
constraint_builder.sampling_ratio = 0.