### PR TITLE
Collate_by_trajectory option

### DIFF
--- a/cartographer/mapping/map_builder.h
+++ b/cartographer/mapping/map_builder.h
@@ -27,7 +27,7 @@
 #include "cartographer/mapping/proto/map_builder_options.pb.h"
 #include "cartographer/mapping_2d/pose_graph.h"
 #include "cartographer/mapping_3d/pose_graph.h"
-#include "cartographer/sensor/collator.h"
+#include "cartographer/sensor/collator_interface.h"
 
 namespace cartographer {
 namespace mapping {
@@ -39,7 +39,7 @@ proto::MapBuilderOptions CreateMapBuilderOptions(
 // and a PoseGraph for loop closure.
 class MapBuilder : public MapBuilderInterface {
  public:
-  MapBuilder(const proto::MapBuilderOptions& options);
+  explicit MapBuilder(const proto::MapBuilderOptions& options);
   ~MapBuilder() override;
 
   MapBuilder(const MapBuilder&) = delete;
@@ -76,7 +76,7 @@ class MapBuilder : public MapBuilderInterface {
   std::unique_ptr<mapping_3d::PoseGraph> pose_graph_3d_;
   mapping::PoseGraph* pose_graph_;
 
-  sensor::Collator sensor_collator_;
+  std::unique_ptr<sensor::CollatorInterface> sensor_collator_;
   std::vector<std::unique_ptr<mapping::TrajectoryBuilderInterface>>
       trajectory_builders_;
 };

--- a/cartographer/mapping/proto/map_builder_options.proto
+++ b/cartographer/mapping/proto/map_builder_options.proto
@@ -25,4 +25,6 @@ message MapBuilderOptions {
   // Number of threads to use for background computations.
   int32 num_background_threads = 3;
   PoseGraphOptions pose_graph_options = 4;
+  // Sort sensor input independently for each trajectory.
+  bool collate_by_trajectory = 5;
 }

--- a/cartographer_grpc/map_builder_server_main.cc
+++ b/cartographer_grpc/map_builder_server_main.cc
@@ -34,6 +34,10 @@ void Run(const std::string& configuration_directory,
   proto::MapBuilderServerOptions map_builder_server_options =
       LoadMapBuilderServerOptions(configuration_directory,
                                   configuration_basename);
+  // TODO(gaschler): Remove this override when parameter is imported from lua
+  // config.
+  map_builder_server_options.mutable_map_builder_options()
+      ->set_collate_by_trajectory(true);
   auto map_builder =
       cartographer::common::make_unique<cartographer::mapping::MapBuilder>(
           map_builder_server_options.map_builder_options());


### PR DESCRIPTION
Adds an option to create a MapBuilder using TrajectoryCollator
(instead of Collator).

[RFC=0008](https://github.com/googlecartographer/rfcs/blob/master/text/0008-collator-interface.md)
