### PR TITLE
Build cartographer_grpc with Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,3 +23,7 @@ cartographer_repositories()
 load("@com_github_nelhage_boost//:boost/boost.bzl", "boost_deps")
 
 boost_deps()
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -207,6 +207,28 @@ def cartographer_repositories():
       ],
   )
 
+  _maybe(native.http_archive,
+      name = "com_github_grpc_grpc",
+      sha256 = "2fdde7d64e6fb1a397bf2aa23aeddcdcf276652d9e48270e94eb0dc94d7c1345",
+      strip_prefix = "grpc-20e7074e4101b4fdbae1764caa952301b38957c4",
+      urls = [
+          "https://mirror.bazel.build/github.com/grpc/grpc/archive/20e7074e4101b4fdbae1764caa952301b38957c4.tar.gz",
+          "https://github.com/grpc/grpc/archive/20e7074e4101b4fdbae1764caa952301b38957c4.tar.gz",
+      ],
+  )
+
+  # TODO(rodrigoq): remove these binds once grpc#14140 has been merged, as well
+  # as removing `use_external` in cartographer_grpc/BUILD.bazel.
+  # https://github.com/grpc/grpc/pull/14140
+  native.bind(
+      name = "grpc_cpp_plugin",
+      actual = "@com_github_grpc_grpc//:grpc_cpp_plugin",
+  )
+  native.bind(
+      name = "grpc++_codegen_proto",
+      actual = "@com_github_grpc_grpc//:grpc++_codegen_proto",
+  )
+
 
 def _maybe(repo_rule, name, **kwargs):
   if name not in native.existing_rules():

--- a/cartographer_grpc/BUILD.bazel
+++ b/cartographer_grpc/BUILD.bazel
@@ -1,0 +1,133 @@
+# Copyright 2018 The Cartographer Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Top-level proto and C++ targets for Cartographer's gRPC server.
+
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "protos",
+    srcs = glob(
+        [
+            "**/*.proto",
+        ],
+        exclude = [
+            "**/*_service.proto",
+        ],
+    ),
+    deps = [
+        "//cartographer:protos",
+        "@com_google_protobuf//:empty_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "cc_protos",
+    deps = [":protos"],
+)
+
+# TODO(rodrigoq): This special rule name is required by cc_grpc_library. This
+# makes :protos look like it was created by
+#   cc_grpc_library(proto_only=True, ...)
+proto_library(
+    name = "_cc_protos_only",
+    deps = [
+        ":protos",
+        "//cartographer:protos",
+        "@com_google_protobuf//:empty_proto",
+    ],
+)
+
+# TODO(rodrigoq): this doesn't work when it is in an external repository. If
+# you want to use it, you can vendor cartographer in your main workspace.
+cc_grpc_library(
+    name = "proto_map_builder_service_grpc_cc",
+    srcs = ["proto/map_builder_service.proto"],
+    generate_mock = False,
+    proto_only = False,
+    use_external = True,
+    well_known_protos = True,
+    deps = [
+        ":cc_protos",
+    ],
+)
+
+cc_library(
+    name = "cartographer_grpc",
+    srcs = glob(
+        [
+            "**/*.cc",
+        ],
+        exclude = [
+            "**/*_main.cc",
+            "**/*_test.cc",
+        ],
+    ),
+    hdrs = glob([
+        "**/*.h",
+    ]),
+    includes = ["."],
+    deps = [
+        ":cc_protos",
+        ":proto_map_builder_service_grpc_cc",
+        "//cartographer",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_glog//:glog",
+        "@com_google_protobuf//:cc_wkt_protos",
+    ],
+)
+
+cc_binary(
+    name = "map_builder_server_main",
+    srcs = ["map_builder_server_main.cc"],
+    deps = [
+        ":cartographer_grpc",
+        "@com_github_gflags_gflags//:gflags",
+        "@com_google_glog//:glog",
+    ],
+)
+
+# TODO(rodrigoq): these tests need to read the configuration files, but they're
+# not able to find them.
+EXCLUDED_TESTS = [
+    "client_server_test.cc",
+]
+
+# This service is only used by the tests.
+cc_grpc_library(
+    name = "framework_proto_math_service_grpc_cc",
+    srcs = ["framework/proto/math_service.proto"],
+    generate_mock = False,
+    proto_only = False,
+    use_external = True,
+    well_known_protos = True,
+    deps = [
+        ":cc_protos",
+    ],
+)
+
+[cc_test(
+    name = src.replace("/", "_").replace(".cc", ""),
+    srcs = [src],
+    deps = [
+        ":cartographer_grpc",
+        ":framework_proto_math_service_grpc_cc",
+        "@com_google_googletest//:gtest_main",
+    ],
+) for src in glob(
+    ["**/*_test.cc"],
+    exclude = EXCLUDED_TESTS,
+)]


### PR DESCRIPTION
This doesn't work when cartographer is an external workspace, due to a
limitation in cc_grpc_library. However, the //cartographer target will
still work it is external, and cartographer_grpc users can vendor the
repository.
