### PR TITLE
Add licenses() declarations to BUILD files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,8 @@
 # and mapping (SLAM) in 2D and 3D across multiple platforms and sensor
 # configurations.
 
+licenses(["notice"])  # Apache 2.0
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(["LICENSE"])

--- a/bazel/third_party/BUILD.bazel
+++ b/bazel/third_party/BUILD.bazel
@@ -14,6 +14,8 @@
 
 # Bazel build support for third-party packages.
 
+licenses(["notice"])  # Apache 2.0
+
 exports_files(
     glob(["*.BUILD"]),
     visibility = ["//visibility:public"],

--- a/cartographer_grpc/BUILD.bazel
+++ b/cartographer_grpc/BUILD.bazel
@@ -16,6 +16,8 @@
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
+licenses(["notice"])  # Apache 2.0
+
 package(default_visibility = ["//visibility:public"])
 
 proto_library(


### PR DESCRIPTION
These were in some, but not all, of the existing BUILD files. They make
it easier to vendor cartographer, as Bazel complains if a BUILD file in
//third_party is missing a licenses() declaration.
