### PR TITLE
Bazel: build with -Wno-sign-compare

### DIFF
--- a/cartographer/BUILD.bazel
+++ b/cartographer/BUILD.bazel
@@ -64,6 +64,7 @@ cc_library(
     ] + glob([
         "**/*.h",
     ]),
+    copts = ["-Wno-sign-compare"],
     includes = ["."],
     deps = [
         ":cc_protos",

--- a/cartographer_grpc/BUILD.bazel
+++ b/cartographer_grpc/BUILD.bazel
@@ -81,6 +81,7 @@ cc_library(
     hdrs = glob([
         "**/*.h",
     ]),
+    copts = ["-Wno-sign-compare"],
     includes = ["."],
     deps = [
         ":cc_protos",


### PR DESCRIPTION
This avoids warnings for code like:

```
  CHECK_EQ(local_to_cloud_trajectory_id_map_.count(local_trajectory_id), 0);
```
