### PR TITLE
Introduce framework::Client

### DIFF
--- a/cartographer_grpc/framework/client.h
+++ b/cartographer_grpc/framework/client.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018 The Cartographer Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CARTOGRAPHER_GRPC_FRAMEWORK_CLIENT_H
+#define CARTOGRAPHER_GRPC_FRAMEWORK_CLIENT_H
+
+#include "grpc++/grpc++.h"
+#include "grpc++/impl/codegen/client_unary_call.h"
+#include "grpc++/impl/codegen/sync_stream.h"
+
+namespace cartographer_grpc {
+namespace framework {
+
+template <typename RpcHandlerType>
+class Client {
+ public:
+  Client(std::shared_ptr<grpc::Channel> channel)
+      : channel_(channel),
+        rpc_method_name_(
+            RpcHandlerInterface::Instantiate<RpcHandlerType>()->method_name()),
+        rpc_method_(rpc_method_name_.c_str(),
+                    RpcType<typename RpcHandlerType::IncomingType,
+                            typename RpcHandlerType::OutgoingType>::value,
+                    channel_) {
+    switch (rpc_method_.method_type()) {
+      case grpc::internal::RpcMethod::NORMAL_RPC:
+        break;
+      case grpc::internal::RpcMethod::CLIENT_STREAMING:
+        break;
+      default:
+        LOG(FATAL) << "Not implemented.";
+    }
+  }
+
+  bool Write(const typename RpcHandlerType::RequestType& request) {
+    switch (rpc_method_.method_type()) {
+      case grpc::internal::RpcMethod::NORMAL_RPC:
+        return MakeBlockingUnaryCall(request, &response_).ok();
+      case grpc::internal::RpcMethod::CLIENT_STREAMING:
+        InstantiateClientWriterIfNeeded();
+        return client_writer_->Write(request);
+      default:
+        LOG(FATAL) << "Not implemented.";
+    }
+  }
+
+  bool WritesDone() {
+    switch (rpc_method_.method_type()) {
+      case grpc::internal::RpcMethod::CLIENT_STREAMING:
+        InstantiateClientWriterIfNeeded();
+        return client_writer_->WritesDone();
+      default:
+        LOG(FATAL) << "Not implemented.";
+    }
+  }
+
+  grpc::Status Finish() {
+    switch (rpc_method_.method_type()) {
+      case grpc::internal::RpcMethod::CLIENT_STREAMING:
+        InstantiateClientWriterIfNeeded();
+        return client_writer_->Finish();
+      default:
+        LOG(FATAL) << "Not implemented.";
+    }
+  }
+
+  const typename RpcHandlerType::ResponseType& response() {
+    CHECK(rpc_method_.method_type() == grpc::internal::RpcMethod::NORMAL_RPC ||
+          rpc_method_.method_type() ==
+              grpc::internal::RpcMethod::CLIENT_STREAMING);
+    return response_;
+  }
+
+ private:
+  void InstantiateClientWriterIfNeeded() {
+    CHECK_EQ(rpc_method_.method_type(),
+             grpc::internal::RpcMethod::CLIENT_STREAMING);
+    if (!client_writer_) {
+      client_writer_.reset(
+          grpc::internal::ClientWriterFactory<
+              typename RpcHandlerType::RequestType>::Create(channel_.get(),
+                                                            rpc_method_,
+                                                            &client_context_,
+                                                            &response_));
+    }
+  }
+
+  grpc::Status MakeBlockingUnaryCall(
+      const typename RpcHandlerType::RequestType& request,
+      typename RpcHandlerType::ResponseType* response) {
+    CHECK_EQ(rpc_method_.method_type(), grpc::internal::RpcMethod::NORMAL_RPC);
+    return ::grpc::internal::BlockingUnaryCall(
+        channel_.get(), rpc_method_, &client_context_, request, response);
+  }
+
+  std::shared_ptr<grpc::Channel> channel_;
+  grpc::ClientContext client_context_;
+  const std::string rpc_method_name_;
+  const ::grpc::internal::RpcMethod rpc_method_;
+
+  std::unique_ptr<grpc::ClientWriter<typename RpcHandlerType::RequestType>>
+      client_writer_;
+  std::unique_ptr < grpc::ClientReaderWriter
+      typename RpcHandlerType::ResponseType response_;
+};
+
+}  // namespace framework
+}  // namespace cartographer_grpc
+
+#endif  // CARTOGRAPHER_GRPC_FRAMEWORK_CLIENT_H

--- a/cartographer_grpc/framework/client.h
+++ b/cartographer_grpc/framework/client.h
@@ -138,9 +138,7 @@ class Client {
             typename RpcHandlerType::ResponseType>::Create(channel_.get(),
                                                            rpc_method_,
                                                            &client_context_,
-                                                           request
-
-                                                           ));
+                                                           request));
   }
 
   grpc::Status MakeBlockingUnaryCall(

--- a/cartographer_grpc/framework/rpc_handler_interface.h
+++ b/cartographer_grpc/framework/rpc_handler_interface.h
@@ -17,6 +17,7 @@
 #ifndef CARTOGRAPHER_GRPC_FRAMEWORK_RPC_HANDLER_INTERFACE_H_H
 #define CARTOGRAPHER_GRPC_FRAMEWORK_RPC_HANDLER_INTERFACE_H_H
 
+#include "cartographer/common/make_unique.h"
 #include "cartographer_grpc/framework/execution_context.h"
 #include "google/protobuf/message.h"
 #include "grpc++/grpc++.h"
@@ -40,6 +41,10 @@ class RpcHandlerInterface {
       const ::google::protobuf::Message* request) = 0;
   virtual void OnReadsDone(){};
   virtual void OnFinish(){};
+  template <class RpcHandlerType>
+  static std::unique_ptr<RpcHandlerType> Instantiate() {
+    return cartographer::common::make_unique<RpcHandlerType>();
+  }
 };
 
 using RpcHandlerFactory = std::function<std::unique_ptr<RpcHandlerInterface>(

--- a/cartographer_grpc/framework/server.h
+++ b/cartographer_grpc/framework/server.h
@@ -57,7 +57,8 @@ class Server {
 
     template <typename RpcHandlerType>
     void RegisterHandler() {
-      std::string method_full_name = GetMethodFullName<RpcHandlerType>();
+      std::string method_full_name =
+          RpcHandlerInterface::Instantiate<RpcHandlerType>()->method_name();
       std::string service_full_name;
       std::string method_name;
       std::tie(service_full_name, method_name) =
@@ -83,11 +84,6 @@ class Server {
    private:
     using ServiceInfo = std::map<std::string, RpcHandlerInfo>;
 
-    template <typename RpcHandlerType>
-    std::string GetMethodFullName() {
-      auto handler = cartographer::common::make_unique<const RpcHandlerType>();
-      return handler->method_name();
-    }
     std::tuple<std::string /* service_full_name */,
                std::string /* method_name */>
     ParseMethodFullName(const std::string& method_full_name);

--- a/cartographer_grpc/framework/server_test.cc
+++ b/cartographer_grpc/framework/server_test.cc
@@ -166,6 +166,13 @@ class ServerTest : public ::testing::Test {
 };
 
 TEST_F(ServerTest, StartAndStopServerTest) {
+  auto* pool = google::protobuf::DescriptorPool::generated_pool();
+  CHECK(pool->FindMessageTypeByName(
+      "cartographer_grpc.framework.proto.GetSumRequest"));
+  CHECK(pool->FindServiceByName("cartographer_grpc.framework.proto.Math"));
+  CHECK(
+      pool->FindMethodByName("cartographer_grpc.framework.proto.Math.GetSum"));
+
   server_->Start();
   server_->Shutdown();
 }

--- a/cartographer_grpc/framework/server_test.cc
+++ b/cartographer_grpc/framework/server_test.cc
@@ -236,7 +236,6 @@ TEST_F(ServerTest, WriteFromOtherThread) {
   });
 
   Client<GetEchoHandler> client(client_channel_);
-  proto::GetEchoResponse result;
   proto::GetEchoRequest request;
   request.set_input(13);
   EXPECT_TRUE(client.Write(request));

--- a/cartographer_grpc/framework/server_test.cc
+++ b/cartographer_grpc/framework/server_test.cc
@@ -264,19 +264,6 @@ TEST_F(ServerTest, ProcessServerStreamingRpcTest) {
   EXPECT_FALSE(client.Read(&response));
   EXPECT_TRUE(client.Finish().ok());
 
-  /*
-  proto::GetSequenceRequest request;
-  request.set_input(12);
-  auto reader = stub_->GetSequence(&client_context_, request);
-
-  proto::GetSequenceResponse response;
-  for (int i = 0; i < 12; ++i) {
-    EXPECT_TRUE(reader->Read(&response));
-    EXPECT_EQ(response.output(), i);
-  }
-  EXPECT_FALSE(reader->Read(&response));
-  EXPECT_TRUE(reader->Finish().ok());
-*/
   server_->Shutdown();
 }
 

--- a/cartographer_grpc/framework/server_test.cc
+++ b/cartographer_grpc/framework/server_test.cc
@@ -157,7 +157,6 @@ class ServerTest : public ::testing::Test {
 
     client_channel_ =
         grpc::CreateChannel(kServerAddress, grpc::InsecureChannelCredentials());
-    stub_ = proto::Math::NewStub(client_channel_);
   }
 
   std::unique_ptr<Server> server_;

--- a/cartographer_grpc/framework/server_test.cc
+++ b/cartographer_grpc/framework/server_test.cc
@@ -166,13 +166,6 @@ class ServerTest : public ::testing::Test {
 };
 
 TEST_F(ServerTest, StartAndStopServerTest) {
-  auto* pool = google::protobuf::DescriptorPool::generated_pool();
-  CHECK(pool->FindMessageTypeByName(
-      "cartographer_grpc.framework.proto.GetSumRequest"));
-  CHECK(pool->FindServiceByName("cartographer_grpc.framework.proto.Math"));
-  CHECK(
-      pool->FindMethodByName("cartographer_grpc.framework.proto.Math.GetSum"));
-
   server_->Start();
   server_->Shutdown();
 }

--- a/cartographer_grpc/framework/server_test.cc
+++ b/cartographer_grpc/framework/server_test.cc
@@ -162,8 +162,6 @@ class ServerTest : public ::testing::Test {
 
   std::unique_ptr<Server> server_;
   std::shared_ptr<grpc::Channel> client_channel_;
-  std::unique_ptr<proto::Math::Stub> stub_;
-  grpc::ClientContext client_context_;
 };
 
 TEST_F(ServerTest, StartAndStopServerTest) {


### PR DESCRIPTION
Introduces a framework::Client class that makes it more convenient to call gRPC methods.

[RFC=0002](https://github.com/googlecartographer/rfcs/blob/master/text/0002-cloud-based-mapping-1.md)
