### PR TITLE
Move ceres_pose.* to mapping/pose_graph.

### DIFF
--- a/cartographer/mapping/pose_graph/ceres_pose.cc
+++ b/cartographer/mapping/pose_graph/ceres_pose.cc
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-#include "cartographer/mapping_3d/ceres_pose.h"
+#include "cartographer/mapping/pose_graph/ceres_pose.h"
 
 namespace cartographer {
-namespace mapping_3d {
+namespace mapping {
+namespace pose_graph {
 
 CeresPose::CeresPose(
     const transform::Rigid3d& rigid,
@@ -42,5 +43,6 @@ const transform::Rigid3d CeresPose::ToRigid() const {
       Eigen::Quaterniond(rotation[0], rotation[1], rotation[2], rotation[3]));
 }
 
-}  // namespace mapping_3d
+}  // namespace pose_graph
+}  // namespace mapping
 }  // namespace cartographer

--- a/cartographer/mapping/pose_graph/ceres_pose.h
+++ b/cartographer/mapping/pose_graph/ceres_pose.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef CARTOGRAPHER_MAPPING_3D_CERES_POSE_H_
-#define CARTOGRAPHER_MAPPING_3D_CERES_POSE_H_
+#ifndef CARTOGRAPHER_MAPPING_POSE_GRAPH_CERES_POSE_H_
+#define CARTOGRAPHER_MAPPING_POSE_GRAPH_CERES_POSE_H_
 
 #include <array>
 #include <memory>
@@ -25,7 +25,8 @@
 #include "ceres/ceres.h"
 
 namespace cartographer {
-namespace mapping_3d {
+namespace mapping {
+namespace pose_graph {
 
 class CeresPose {
  public:
@@ -49,7 +50,8 @@ class CeresPose {
   std::shared_ptr<Data> data_;
 };
 
-}  // namespace mapping_3d
+}  // namespace pose_graph
+}  // namespace mapping
 }  // namespace cartographer
 
-#endif  // CARTOGRAPHER_MAPPING_3D_CERES_POSE_H_
+#endif  // CARTOGRAPHER_MAPPING_POSE_GRAPH_CERES_POSE_H_

--- a/cartographer/mapping_3d/pose_graph/optimization_problem.cc
+++ b/cartographer/mapping_3d/pose_graph/optimization_problem.cc
@@ -32,7 +32,7 @@
 #include "cartographer/common/time.h"
 #include "cartographer/internal/mapping_3d/acceleration_cost_function.h"
 #include "cartographer/internal/mapping_3d/rotation_cost_function.h"
-#include "cartographer/mapping_3d/ceres_pose.h"
+#include "cartographer/mapping/pose_graph/ceres_pose.h"
 #include "cartographer/mapping_3d/imu_integration.h"
 #include "cartographer/mapping_3d/pose_graph/spa_cost_function.h"
 #include "cartographer/mapping_3d/rotation_parameterization.h"
@@ -46,8 +46,9 @@
 namespace cartographer {
 namespace mapping_3d {
 namespace pose_graph {
-
 namespace {
+
+using ::cartographer::mapping::pose_graph::CeresPose;
 
 // For odometry.
 std::unique_ptr<transform::Rigid3d> Interpolate(

--- a/cartographer/mapping_3d/scan_matching/ceres_scan_matcher.cc
+++ b/cartographer/mapping_3d/scan_matching/ceres_scan_matcher.cc
@@ -23,7 +23,7 @@
 #include "cartographer/common/ceres_solver_options.h"
 #include "cartographer/common/make_unique.h"
 #include "cartographer/internal/mapping_3d/scan_matching/occupied_space_cost_function.h"
-#include "cartographer/mapping_3d/ceres_pose.h"
+#include "cartographer/mapping/pose_graph/ceres_pose.h"
 #include "cartographer/mapping_3d/rotation_parameterization.h"
 #include "cartographer/mapping_3d/scan_matching/rotation_delta_cost_functor.h"
 #include "cartographer/mapping_3d/scan_matching/translation_delta_cost_functor.h"
@@ -75,7 +75,7 @@ void CeresScanMatcher::Match(const Eigen::Vector3d& target_translation,
                              transform::Rigid3d* const pose_estimate,
                              ceres::Solver::Summary* const summary) {
   ceres::Problem problem;
-  CeresPose ceres_pose(
+  mapping::pose_graph::CeresPose ceres_pose(
       initial_pose_estimate, nullptr /* translation_parameterization */,
       options_.only_optimize_yaw()
           ? std::unique_ptr<ceres::LocalParameterization>(


### PR DESCRIPTION
Landmarks live in 3D in both 2D and 3D versions of the pose graph. CeresPose is needed to parametrize optimization variables in 3D.

[RFC=0011](https://github.com/googlecartographer/rfcs/blob/master/text/0011-landmarks.md)