### PR TITLE
Make clang compile without warnings.

### DIFF
--- a/cartographer/mapping/pose_graph/cost_helpers.h
+++ b/cartographer/mapping/pose_graph/cost_helpers.h
@@ -31,8 +31,9 @@ namespace pose_graph {
 //
 // 'start' and 'end' poses have the format [x, y, rotation].
 template <typename T>
-std::array<T, 3> ComputeUnscaledError(const transform::Rigid2d& relative_pose,
-                                      const T* const start, const T* const end);
+static std::array<T, 3> ComputeUnscaledError(
+    const transform::Rigid2d& relative_pose, const T* const start,
+    const T* const end);
 template <typename T>
 std::array<T, 3> ScaleError(std::array<T, 3> error, T translation_weight,
                             T rotation_weight);
@@ -43,11 +44,10 @@ std::array<T, 3> ScaleError(std::array<T, 3> error, T translation_weight,
 // 'start' and 'end' translation has the format [x, y, z].
 // 'start' and 'end' rotation are quaternions in the format [w, n_1, n_2, n_3].
 template <typename T>
-std::array<T, 6> ComputeUnscaledError(const transform::Rigid3d& relative_pose,
-                                      const T* const start_rotation,
-                                      const T* const start_translation,
-                                      const T* const end_rotation,
-                                      const T* const end_translation);
+static std::array<T, 6> ComputeUnscaledError(
+    const transform::Rigid3d& relative_pose, const T* const start_rotation,
+    const T* const start_translation, const T* const end_rotation,
+    const T* const end_translation);
 
 template <typename T>
 std::array<T, 6> ScaleError(std::array<T, 6> error, T translation_weight,

--- a/cartographer/mapping/pose_graph/cost_helpers_impl.h
+++ b/cartographer/mapping/pose_graph/cost_helpers_impl.h
@@ -101,7 +101,8 @@ std::array<T, 4> SlerpQuaternions(const T* const start, const T* const end,
   // as the arccosine of their dot product.
   const T cos_theta = start[0] * end[0] + start[1] * end[1] +
                       start[2] * end[2] + start[3] * end[3];
-  const T abs_cos_theta = abs(cos_theta);
+  // Avoid using ::abs which would cast to integer.
+  const T abs_cos_theta = ceres::abs(cos_theta);
   // If numerical error brings 'cos_theta' outside [-1 + epsilon, 1 - epsilon]
   // interval, then the quaternions are likely to be collinear.
   T prev_scale = T(1.) - factor;

--- a/cartographer_grpc/framework/server.h
+++ b/cartographer_grpc/framework/server.h
@@ -35,7 +35,7 @@ namespace cartographer_grpc {
 namespace framework {
 
 class Server {
- private:
+ protected:
   // All options that configure server behaviour such as number of threads,
   // ports etc.
   struct Options {

--- a/cartographer_grpc/testing/mock_map_builder_context.h
+++ b/cartographer_grpc/testing/mock_map_builder_context.h
@@ -69,7 +69,7 @@ class MockMapBuilderContext : public MapBuilderContextInterface {
   void EnqueueLocalSlamResultData(
       int trajectory_id, const std::string &sensor_id,
       std::unique_ptr<cartographer::mapping::LocalSlamResultData>
-          local_slam_result_data) {
+          local_slam_result_data) override {
     DoEnqueueLocalSlamResultData(trajectory_id, sensor_id,
                                  local_slam_result_data.get());
   }


### PR DESCRIPTION
Rule out accidental usage of integer-only ::abs.
Correct static, override and protected annotations.