### PR TITLE
Landmark-sided observations

### DIFF
--- a/cartographer/mapping/2d/pose_graph/landmark_cost_function_2d.h
+++ b/cartographer/mapping/2d/pose_graph/landmark_cost_function_2d.h
@@ -89,10 +89,15 @@ class LandmarkCostFunction2D {
                          T(interpolation_parameter_));
 
     const std::array<T, 6> error = ScaleError(
-        ComputeUnscaledError(landmark_to_tracking_transform_,
-                             interpolated_pose_rotation.data(),
-                             interpolated_pose_translation.data(),
-                             landmark_rotation, landmark_translation),
+        observed_from_tracking_
+            ? ComputeUnscaledError(landmark_to_tracking_transform_,
+                                   interpolated_pose_rotation.data(),
+                                   interpolated_pose_translation.data(),
+                                   landmark_rotation, landmark_translation)
+            : ComputeUnscaledError(landmark_to_tracking_transform_,
+                                   landmark_rotation, landmark_translation,
+                                   interpolated_pose_rotation.data(),
+                                   interpolated_pose_translation.data()),
         T(translation_weight_), T(rotation_weight_));
     std::copy(std::begin(error), std::end(error), e);
     return true;
@@ -110,7 +115,8 @@ class LandmarkCostFunction2D {
         rotation_weight_(observation.rotation_weight),
         interpolation_parameter_(
             common::ToSeconds(observation.time - prev_node.time) /
-            common::ToSeconds(next_node.time - prev_node.time)) {}
+            common::ToSeconds(next_node.time - prev_node.time)),
+        observed_from_tracking_(observation.observed_from_tracking) {}
 
   const transform::Rigid3d landmark_to_tracking_transform_;
   const Eigen::Quaterniond prev_node_gravity_alignment_;
@@ -118,6 +124,7 @@ class LandmarkCostFunction2D {
   const double translation_weight_;
   const double rotation_weight_;
   const double interpolation_parameter_;
+  const bool observed_from_tracking_;
 };
 
 }  // namespace pose_graph

--- a/cartographer/mapping/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/2d/pose_graph_2d.cc
@@ -181,7 +181,8 @@ void PoseGraph2D::AddLandmarkData(int trajectory_id,
           PoseGraph::LandmarkNode::LandmarkObservation{
               trajectory_id, landmark_data.time,
               observation.landmark_to_tracking_transform,
-              observation.translation_weight, observation.rotation_weight});
+              observation.translation_weight, observation.rotation_weight,
+              observation.observed_from_tracking});
     }
   });
 }

--- a/cartographer/mapping/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/2d/pose_graph_2d.cc
@@ -298,6 +298,7 @@ void PoseGraph2D::DispatchOptimization() {
     HandleWorkQueue();
   }
 }
+
 common::Time PoseGraph2D::GetLatestNodeTime(const NodeId& node_id,
                                             const SubmapId& submap_id) const {
   common::Time time = trajectory_nodes_.at(node_id).constant_data->time;

--- a/cartographer/mapping/3d/pose_graph/landmark_cost_function_3d.h
+++ b/cartographer/mapping/3d/pose_graph/landmark_cost_function_3d.h
@@ -74,10 +74,15 @@ class LandmarkCostFunction3D {
         prev_node_rotation, next_node_rotation, T(interpolation_parameter_));
 
     const std::array<T, 6> error = ScaleError(
-        ComputeUnscaledError(landmark_to_tracking_transform_,
-                             interpolated_pose_rotation.data(),
-                             interpolated_pose_translation.data(),
-                             landmark_rotation, landmark_translation),
+        observed_from_tracking_
+            ? ComputeUnscaledError(landmark_to_tracking_transform_,
+                                   interpolated_pose_rotation.data(),
+                                   interpolated_pose_translation.data(),
+                                   landmark_rotation, landmark_translation)
+            : ComputeUnscaledError(landmark_to_tracking_transform_,
+                                   landmark_rotation, landmark_translation,
+                                   interpolated_pose_rotation.data(),
+                                   interpolated_pose_translation.data()),
         T(translation_weight_), T(rotation_weight_));
     std::copy(std::begin(error), std::end(error), e);
     return true;
@@ -93,12 +98,14 @@ class LandmarkCostFunction3D {
         rotation_weight_(observation.rotation_weight),
         interpolation_parameter_(
             common::ToSeconds(observation.time - prev_node.time) /
-            common::ToSeconds(next_node.time - prev_node.time)) {}
+            common::ToSeconds(next_node.time - prev_node.time)),
+        observed_from_tracking_(observation.observed_from_tracking) {}
 
   const transform::Rigid3d landmark_to_tracking_transform_;
   const double translation_weight_;
   const double rotation_weight_;
   const double interpolation_parameter_;
+  const bool observed_from_tracking_;
 };
 
 }  // namespace pose_graph

--- a/cartographer/mapping/3d/pose_graph/landmark_cost_function_3d_test.cc
+++ b/cartographer/mapping/3d/pose_graph/landmark_cost_function_3d_test.cc
@@ -39,7 +39,7 @@ TEST(LandmarkCostFunction3DTest, SmokeTest) {
   OptimizationProblem3D::NodeData next_node;
   next_node.time = common::FromUniversal(10);
 
-  std::unique_ptr<ceres::CostFunction> cost_function(
+  std::unique_ptr<ceres::CostFunction> cost_function_observation_from_tracking(
       LandmarkCostFunction3D::CreateAutoDiffCostFunction(
           LandmarkObservation{
               0 /* trajectory ID */,
@@ -47,6 +47,18 @@ TEST(LandmarkCostFunction3DTest, SmokeTest) {
               transform::Rigid3d::Translation(Eigen::Vector3d(1., 1., 1.)),
               1. /* translation_weight */,
               2. /* rotation_weight */,
+              true
+          },
+          prev_node, next_node));
+  std::unique_ptr<ceres::CostFunction> cost_function_observation_from_landmark(
+      LandmarkCostFunction::CreateAutoDiffCostFunction(
+          LandmarkObservation{
+              0 /* trajectory ID */,
+              common::FromUniversal(5) /* time */,
+              transform::Rigid3d::Translation(Eigen::Vector3d(-1., -1., -1.)),
+              1. /* translation_weight */,
+              2. /* rotation_weight */,
+              false
           },
           prev_node, next_node));
 
@@ -65,9 +77,14 @@ TEST(LandmarkCostFunction3DTest, SmokeTest) {
   std::array<std::array<double, 21>, 6> jacobians;
   std::array<double*, 6> jacobians_ptrs;
   for (int i = 0; i < 6; ++i) jacobians_ptrs[i] = jacobians[i].data();
-  cost_function->Evaluate(parameter_blocks.data(), residuals.data(),
-                          jacobians_ptrs.data());
+
+  cost_function_observation_from_tracking->Evaluate(
+      parameter_blocks.data(), residuals.data(), jacobians_ptrs.data());
   EXPECT_THAT(residuals, ElementsAre(DoubleEq(1.), DoubleEq(0.), DoubleEq(0.),
+                                     DoubleEq(0.), DoubleEq(0.), DoubleEq(0.)));
+  cost_function_observation_from_landmark->Evaluate(
+      parameter_blocks.data(), residuals.data(), jacobians_ptrs.data());
+  EXPECT_THAT(residuals, ElementsAre(DoubleEq(-1.), DoubleEq(0.), DoubleEq(0.),
                                      DoubleEq(0.), DoubleEq(0.), DoubleEq(0.)));
 }
 

--- a/cartographer/mapping/3d/pose_graph/landmark_cost_function_3d_test.cc
+++ b/cartographer/mapping/3d/pose_graph/landmark_cost_function_3d_test.cc
@@ -51,7 +51,7 @@ TEST(LandmarkCostFunction3DTest, SmokeTest) {
           },
           prev_node, next_node));
   std::unique_ptr<ceres::CostFunction> cost_function_observation_from_landmark(
-      LandmarkCostFunction::CreateAutoDiffCostFunction(
+      LandmarkCostFunction3D::CreateAutoDiffCostFunction(
           LandmarkObservation{
               0 /* trajectory ID */,
               common::FromUniversal(5) /* time */,

--- a/cartographer/mapping/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/3d/pose_graph_3d.cc
@@ -184,7 +184,8 @@ void PoseGraph3D::AddLandmarkData(int trajectory_id,
           PoseGraph::LandmarkNode::LandmarkObservation{
               trajectory_id, landmark_data.time,
               observation.landmark_to_tracking_transform,
-              observation.translation_weight, observation.rotation_weight});
+              observation.translation_weight, observation.rotation_weight,
+              observation.observed_from_tracking});
     }
   });
 }

--- a/cartographer/mapping/pose_graph_interface.h
+++ b/cartographer/mapping/pose_graph_interface.h
@@ -58,6 +58,7 @@ class PoseGraphInterface {
       transform::Rigid3d landmark_to_tracking_transform;
       double translation_weight;
       double rotation_weight;
+      bool observed_from_tracking;
     };
     std::vector<LandmarkObservation> landmark_observations;
     common::optional<transform::Rigid3d> global_landmark_pose;

--- a/cartographer/sensor/landmark_data.cc
+++ b/cartographer/sensor/landmark_data.cc
@@ -31,6 +31,7 @@ proto::LandmarkData ToProto(const LandmarkData& landmark_data) {
         transform::ToProto(observation.landmark_to_tracking_transform);
     item->set_translation_weight(observation.translation_weight);
     item->set_rotation_weight(observation.rotation_weight);
+    item->set_observed_from_tracking(observation.observed_from_tracking);
   }
   return proto;
 }
@@ -44,6 +45,7 @@ LandmarkData FromProto(const proto::LandmarkData& proto) {
         transform::ToRigid3(item.landmark_to_tracking_transform()),
         item.translation_weight(),
         item.rotation_weight(),
+        item.observed_from_tracking()
     });
   }
   return landmark_data;

--- a/cartographer/sensor/landmark_data.h
+++ b/cartographer/sensor/landmark_data.h
@@ -34,6 +34,8 @@ struct LandmarkObservation {
   transform::Rigid3d landmark_to_tracking_transform;
   double translation_weight;
   double rotation_weight;
+  // Set to false if the observation was made from the landmark frame.
+  bool observed_from_tracking;
 };
 
 struct LandmarkData {

--- a/cartographer/sensor/landmark_data_test.cc
+++ b/cartographer/sensor/landmark_data_test.cc
@@ -52,6 +52,7 @@ class LandmarkDataTest : public ::testing::Test {
                                     Eigen::Quaterniond(1., 1., -1., -1.)),
                  1.f,
                  3.f,
+                 true
              },
              {
                  "ID2",
@@ -59,6 +60,7 @@ class LandmarkDataTest : public ::testing::Test {
                                     Eigen::Quaterniond(2., 2., -2., -2.)),
                  2.f,
                  4.f,
+                 false
              }}) {}
   std::vector<LandmarkObservation> observations_;
 };

--- a/cartographer/sensor/proto/sensor.proto
+++ b/cartographer/sensor/proto/sensor.proto
@@ -66,6 +66,7 @@ message LandmarkData {
     transform.proto.Rigid3d landmark_to_tracking_transform = 2;
     double translation_weight = 3;
     double rotation_weight = 4;
+    bool observed_from_tracking = 5;
   }
   int64 timestamp = 1;
   repeated LandmarkObservation landmark_observations = 2;


### PR DESCRIPTION
[RFC=0011](https://github.com/googlecartographer/rfcs/blob/master/text/0011-landmarks.md)
Enable adding landmark-sided observations of the tracking frame.