### PR TITLE
Check ifstream::good() in proto_stream.cc

### DIFF
--- a/cartographer/io/proto_stream.cc
+++ b/cartographer/io/proto_stream.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/io/proto_stream.h"
+#include "glog/logging.h"
 
 namespace cartographer {
 namespace io {
@@ -44,6 +45,7 @@ bool ReadSizeAsLittleEndian(std::istream* in, uint64* size) {
 
 ProtoStreamWriter::ProtoStreamWriter(const std::string& filename)
     : out_(filename, std::ios::out | std::ios::binary) {
+  CHECK(out_.good()) << "Failed to open proto stream '" << filename << "'.";
   WriteSizeAsLittleEndian(kMagic, &out_);
 }
 
@@ -71,6 +73,7 @@ ProtoStreamReader::ProtoStreamReader(const std::string& filename)
   if (!ReadSizeAsLittleEndian(&in_, &magic) || magic != kMagic) {
     in_.setstate(std::ios::failbit);
   }
+  CHECK(in_.good()) << "Failed to open proto stream '" << filename << "'.";
 }
 
 bool ProtoStreamReader::Read(std::string* decompressed_data) {

--- a/cartographer/io/proto_stream.cc
+++ b/cartographer/io/proto_stream.cc
@@ -45,7 +45,6 @@ bool ReadSizeAsLittleEndian(std::istream* in, uint64* size) {
 
 ProtoStreamWriter::ProtoStreamWriter(const std::string& filename)
     : out_(filename, std::ios::out | std::ios::binary) {
-  CHECK(out_.good()) << "Failed to open proto stream '" << filename << "'.";
   WriteSizeAsLittleEndian(kMagic, &out_);
 }
 


### PR DESCRIPTION
Check for basic stream errors before doing more involved read actions.
The log message in this case is also more descriptive than
`Check failed: reader->ReadProto(&pose_graph)`.