### PR TITLE
Move GetTrajectoryData() down to PoseGraphInterface

### DIFF
--- a/cartographer/mapping/pose_graph.h
+++ b/cartographer/mapping/pose_graph.h
@@ -125,9 +125,6 @@ class PoseGraph : public PoseGraphInterface {
   // Returns the odometry data.
   virtual sensor::MapByTime<sensor::OdometryData> GetOdometryData() = 0;
 
-  // Returns the trajectory data.
-  virtual std::map<int, TrajectoryData> GetTrajectoryData() = 0;
-
   // Returns the fixed frame pose data.
   virtual sensor::MapByTime<sensor::FixedFramePoseData>
   GetFixedFramePoseData() = 0;

--- a/cartographer/mapping/pose_graph_interface.h
+++ b/cartographer/mapping/pose_graph_interface.h
@@ -111,6 +111,9 @@ class PoseGraphInterface {
   // Checks if the given trajectory is finished.
   virtual bool IsTrajectoryFinished(int trajectory_id) = 0;
 
+  // Returns the trajectory data.
+  virtual std::map<int, TrajectoryData> GetTrajectoryData() = 0;
+
   // Returns the collection of constraints.
   virtual std::vector<Constraint> constraints() = 0;
 

--- a/cartographer_grpc/mapping/pose_graph_stub.cc
+++ b/cartographer_grpc/mapping/pose_graph_stub.cc
@@ -121,7 +121,8 @@ bool PoseGraphStub::IsTrajectoryFinished(int trajectory_id) {
   LOG(FATAL) << "Not implemented";
 }
 
-std::map<int, cartographer::mapping::PoseGraphInterface::TrajectoryData> PoseGraphStub::GetTrajectoryData() {
+std::map<int, cartographer::mapping::PoseGraphInterface::TrajectoryData>
+PoseGraphStub::GetTrajectoryData() {
   LOG(FATAL) << "Not implemented";
 }
 

--- a/cartographer_grpc/mapping/pose_graph_stub.cc
+++ b/cartographer_grpc/mapping/pose_graph_stub.cc
@@ -121,6 +121,10 @@ bool PoseGraphStub::IsTrajectoryFinished(int trajectory_id) {
   LOG(FATAL) << "Not implemented";
 }
 
+std::map<int, cartographer::mapping::PoseGraphInterface::TrajectoryData> PoseGraphStub::GetTrajectoryData() {
+  LOG(FATAL) << "Not implemented";
+}
+
 std::vector<cartographer::mapping::PoseGraphInterface::Constraint>
 PoseGraphStub::constraints() {
   google::protobuf::Empty request;

--- a/cartographer_grpc/mapping/pose_graph_stub.h
+++ b/cartographer_grpc/mapping/pose_graph_stub.h
@@ -46,7 +46,8 @@ class PoseGraphStub : public cartographer::mapping::PoseGraphInterface {
   std::map<std::string, cartographer::transform::Rigid3d> GetLandmarkPoses()
       override;
   bool IsTrajectoryFinished(int trajectory_id) override;
-  std::map<int, cartographer::mapping::PoseGraphInterface::TrajectoryData> GetTrajectoryData() override;
+  std::map<int, cartographer::mapping::PoseGraphInterface::TrajectoryData>
+  GetTrajectoryData() override;
   std::vector<Constraint> constraints() override;
   cartographer::mapping::proto::PoseGraph ToProto() override;
 

--- a/cartographer_grpc/mapping/pose_graph_stub.h
+++ b/cartographer_grpc/mapping/pose_graph_stub.h
@@ -46,6 +46,7 @@ class PoseGraphStub : public cartographer::mapping::PoseGraphInterface {
   std::map<std::string, cartographer::transform::Rigid3d> GetLandmarkPoses()
       override;
   bool IsTrajectoryFinished(int trajectory_id) override;
+  std::map<int, cartographer::mapping::PoseGraphInterface::TrajectoryData> GetTrajectoryData() override;
   std::vector<Constraint> constraints() override;
   cartographer::mapping::proto::PoseGraph ToProto() override;
 

--- a/cartographer_grpc/testing/mock_pose_graph.h
+++ b/cartographer_grpc/testing/mock_pose_graph.h
@@ -50,7 +50,10 @@ class MockPoseGraph : public cartographer::mapping::PoseGraphInterface {
   MOCK_METHOD0(GetLandmarkPoses,
                std::map<std::string, cartographer::transform::Rigid3d>());
   MOCK_METHOD1(IsTrajectoryFinished, bool(int));
-  MOCK_METHOD0(GetTrajectoryData, std::map<int, cartographer::mapping::PoseGraphInterface::TrajectoryData>());
+  MOCK_METHOD0(
+      GetTrajectoryData,
+      std::map<int,
+               cartographer::mapping::PoseGraphInterface::TrajectoryData>());
   MOCK_METHOD0(constraints, std::vector<Constraint>());
   MOCK_METHOD0(ToProto, cartographer::mapping::proto::PoseGraph());
 };

--- a/cartographer_grpc/testing/mock_pose_graph.h
+++ b/cartographer_grpc/testing/mock_pose_graph.h
@@ -50,6 +50,7 @@ class MockPoseGraph : public cartographer::mapping::PoseGraphInterface {
   MOCK_METHOD0(GetLandmarkPoses,
                std::map<std::string, cartographer::transform::Rigid3d>());
   MOCK_METHOD1(IsTrajectoryFinished, bool(int));
+  MOCK_METHOD0(GetTrajectoryData, std::map<int, cartographer::mapping::PoseGraphInterface::TrajectoryData>());
   MOCK_METHOD0(constraints, std::vector<Constraint>());
   MOCK_METHOD0(ToProto, cartographer::mapping::proto::PoseGraph());
 };


### PR DESCRIPTION
That way it is accessible to clients of PoseGraph, for example,
if you create a MapBuilder and want to extract reference information
for fixed frame poses.
