### PR TITLE
Gracefully handle time-overlapping point clouds.

### DIFF
--- a/cartographer/internal/mapping_2d/local_trajectory_builder_2d.cc
+++ b/cartographer/internal/mapping_2d/local_trajectory_builder_2d.cc
@@ -106,8 +106,18 @@ LocalTrajectoryBuilder2D::AddRangeData(
 
   std::vector<transform::Rigid3f> range_data_poses;
   range_data_poses.reserve(range_data.returns.size());
+  bool warned = false;
   for (const Eigen::Vector4f& hit : range_data.returns) {
-    const common::Time time_point = time + common::FromSeconds(hit[3]);
+    common::Time time_point = time + common::FromSeconds(hit[3]);
+    if (time_point < extrapolator_->GetLastExtrapolatedTime()) {
+      if (!warned) {
+        LOG(ERROR)
+            << "Timestamp of individual range data point jumps backwards from "
+            << extrapolator_->GetLastExtrapolatedTime() << " to " << time_point;
+        warned = true;
+      }
+      time_point = extrapolator_->GetLastExtrapolatedTime();
+    }
     range_data_poses.push_back(
         extrapolator_->ExtrapolatePose(time_point).cast<float>());
   }


### PR DESCRIPTION
Per-point relative times are usually computed by multiplying
a per-point time increment by the number of points.
So it is not uncommon for consecutive point clouds of a single
sensor to overlap in time.
When this happens, we act as if no backward jump in time happened
and warn once per input point cloud.

FIXES=#912