### PR TITLE
WIP: Allow serialization of selected trajectory IDs.

### DIFF
--- a/cartographer/mapping/map_builder.h
+++ b/cartographer/mapping/map_builder.h
@@ -61,7 +61,8 @@ class MapBuilder : public MapBuilderInterface {
   std::string SubmapToProto(const SubmapId& submap_id,
                             proto::SubmapQuery::Response* response) override;
 
-  void SerializeState(io::ProtoStreamWriterInterface* writer) override;
+  void SerializeState(io::ProtoStreamWriterInterface* writer,
+                      const std::set<int> trajectory_ids = {}) override;
 
   void LoadState(io::ProtoStreamReaderInterface* reader,
                  bool load_frozen_state) override;

--- a/cartographer/mapping/map_builder_interface.h
+++ b/cartographer/mapping/map_builder_interface.h
@@ -78,7 +78,8 @@ class MapBuilderInterface {
                                     proto::SubmapQuery::Response* response) = 0;
 
   // Serializes the current state to a proto stream.
-  virtual void SerializeState(io::ProtoStreamWriterInterface* writer) = 0;
+  virtual void SerializeState(io::ProtoStreamWriterInterface* writer,
+  const std::set<int> trajectory_ids = {}) = 0;
 
   // Loads the SLAM state from a proto stream.
   virtual void LoadState(io::ProtoStreamReaderInterface* reader,

--- a/cartographer/mapping/map_builder_interface.h
+++ b/cartographer/mapping/map_builder_interface.h
@@ -79,7 +79,7 @@ class MapBuilderInterface {
 
   // Serializes the current state to a proto stream.
   virtual void SerializeState(io::ProtoStreamWriterInterface* writer,
-  const std::set<int> trajectory_ids = {}) = 0;
+                              const std::set<int> trajectory_ids = {}) = 0;
 
   // Loads the SLAM state from a proto stream.
   virtual void LoadState(io::ProtoStreamReaderInterface* reader,

--- a/cartographer_grpc/client/map_builder_stub.cc
+++ b/cartographer_grpc/client/map_builder_stub.cc
@@ -98,7 +98,8 @@ std::string MapBuilderStub::SubmapToProto(
 }
 
 void MapBuilderStub::SerializeState(
-    cartographer::io::ProtoStreamWriterInterface* writer) {
+    cartographer::io::ProtoStreamWriterInterface* writer,
+    const std::set<int> trajectory_ids) {
   google::protobuf::Empty request;
   framework::Client<handlers::WriteStateHandler> client(client_channel_);
   CHECK(client.Write(request));

--- a/cartographer_grpc/client/map_builder_stub.h
+++ b/cartographer_grpc/client/map_builder_stub.h
@@ -48,8 +48,8 @@ class MapBuilderStub : public cartographer::mapping::MapBuilderInterface {
   std::string SubmapToProto(
       const cartographer::mapping::SubmapId& submap_id,
       cartographer::mapping::proto::SubmapQuery::Response* response) override;
-  void SerializeState(
-      cartographer::io::ProtoStreamWriterInterface* writer) override;
+  void SerializeState(cartographer::io::ProtoStreamWriterInterface* writer,
+                      const std::set<int> trajectory_ids = {}) override;
   void LoadState(cartographer::io::ProtoStreamReaderInterface* reader,
                  bool load_frozen_state) override;
   int num_trajectory_builders() const override;

--- a/cartographer_grpc/handlers/add_fixed_frame_pose_data_handler_test.cc
+++ b/cartographer_grpc/handlers/add_fixed_frame_pose_data_handler_test.cc
@@ -30,20 +30,10 @@ using ::testing::Pointee;
 using ::testing::Truly;
 
 const std::string kMessage = R"PROTO(
-  sensor_metadata {
-    trajectory_id: 1
-    sensor_id: "sensor_id"
-  }
+  sensor_metadata { trajectory_id: 1 sensor_id: "sensor_id" }
   fixed_frame_pose_data {
     timestamp: 2
-    pose {
-      translation {
-        x: 3 y: 4 z: 5
-      }
-      rotation {
-        w: 6 x: 7 y: 8 z: 9
-      }
-    }
+    pose { translation { x: 3 y: 4 z: 5 } rotation { w: 6 x: 7 y: 8 z: 9 } }
   })PROTO";
 
 using AddFixedFramePoseDataHandlerTest =

--- a/cartographer_grpc/handlers/add_imu_data_handler_test.cc
+++ b/cartographer_grpc/handlers/add_imu_data_handler_test.cc
@@ -30,18 +30,11 @@ using ::testing::Pointee;
 using ::testing::Truly;
 
 const std::string kMessage = R"PROTO(
-  sensor_metadata {
-    trajectory_id: 1
-    sensor_id: "sensor_id"
-  }
+  sensor_metadata { trajectory_id: 1 sensor_id: "sensor_id" }
   imu_data {
     timestamp: 2
-    linear_acceleration {
-      x: 3 y: 4 z: 5
-    }
-    angular_velocity {
-      x: 6 y: 7 z: 8
-    }
+    linear_acceleration { x: 3 y: 4 z: 5 }
+    angular_velocity { x: 6 y: 7 z: 8 }
   })PROTO";
 
 using AddImuDataHandlerTest = testing::HandlerTest<AddImuDataHandler>;

--- a/cartographer_grpc/handlers/add_landmark_data_handler_test.cc
+++ b/cartographer_grpc/handlers/add_landmark_data_handler_test.cc
@@ -30,21 +30,14 @@ using ::testing::Pointee;
 using ::testing::Truly;
 
 const std::string kMessage = R"PROTO(
-  sensor_metadata {
-    trajectory_id: 1
-    sensor_id: "sensor_id"
-  }
+  sensor_metadata { trajectory_id: 1 sensor_id: "sensor_id" }
   landmark_data {
     timestamp: 2
     landmark_observations {
       id: "3"
       landmark_to_tracking_transform {
-        translation {
-          x: 4 y: 5 z: 6
-        }
-        rotation {
-          w:7 x: 8 y: 9 z: 10
-        }
+        translation { x: 4 y: 5 z: 6 }
+        rotation { w: 7 x: 8 y: 9 z: 10 }
       }
       translation_weight: 11.0
       rotation_weight: 12.0

--- a/cartographer_grpc/handlers/add_odometry_data_handler_test.cc
+++ b/cartographer_grpc/handlers/add_odometry_data_handler_test.cc
@@ -30,20 +30,10 @@ using ::testing::Pointee;
 using ::testing::Truly;
 
 const std::string kMessage = R"PROTO(
-  sensor_metadata {
-    trajectory_id: 1
-    sensor_id: "sensor_id"
-  }
+  sensor_metadata { trajectory_id: 1 sensor_id: "sensor_id" }
   odometry_data {
     timestamp: 2
-    pose {
-      translation {
-        x: 3 y: 4 z: 5
-      }
-      rotation {
-        w: 6 x: 7 y: 8 z: 9
-      }
-    }
+    pose { translation { x: 3 y: 4 z: 5 } rotation { w: 6 x: 7 y: 8 z: 9 } }
   })PROTO";
 
 using AddOdometryDataHandlerTest = testing::HandlerTest<AddOdometryDataHandler>;

--- a/cartographer_grpc/handlers/add_rangefinder_data_handler_test.cc
+++ b/cartographer_grpc/handlers/add_rangefinder_data_handler_test.cc
@@ -30,18 +30,11 @@ using ::testing::Pointee;
 using ::testing::Truly;
 
 const std::string kMessage = R"PROTO(
-  sensor_metadata {
-    trajectory_id: 1
-    sensor_id: "sensor_id"
-  }
+  sensor_metadata { trajectory_id: 1 sensor_id: "sensor_id" }
   timed_point_cloud_data {
     timestamp: 2
-    origin {
-      x: 3.f y: 4.f z: 5.f
-    }
-    point_data {
-      x: 6.f y: 7.f z: 8.f t: 9.f
-    }
+    origin { x: 3.f y: 4.f z: 5.f }
+    point_data { x: 6.f y: 7.f z: 8.f t: 9.f }
   })PROTO";
 
 using AddRangefinderDataHandlerTest =

--- a/cartographer_grpc/handlers/add_trajectory_handler_test.cc
+++ b/cartographer_grpc/handlers/add_trajectory_handler_test.cc
@@ -35,34 +35,21 @@ using ::testing::Test;
 using ::testing::Truly;
 
 const std::string kMessage = R"PROTO(
-    expected_sensor_ids {
-      id: "range_sensor"
-      type: RANGE
-    }
-    expected_sensor_ids {
-      id: "imu_sensor"
-      type: IMU
-    }
-    trajectory_builder_options {
-      trajectory_builder_2d_options {
-        min_range: 20
-        max_range: 30
+  expected_sensor_ids { id: "range_sensor" type: RANGE }
+  expected_sensor_ids { id: "imu_sensor" type: IMU }
+  trajectory_builder_options {
+    trajectory_builder_2d_options { min_range: 20 max_range: 30 }
+    pure_localization: true
+    initial_trajectory_pose {
+      relative_pose {
+        translation { x: 1 y: 2 z: 3 }
+        rotation { w: 4 x: 5 y: 6 z: 7 }
       }
-      pure_localization: true
-      initial_trajectory_pose {
-        relative_pose {
-          translation {
-            x: 1 y: 2 z: 3
-          }
-          rotation {
-            w: 4 x: 5 y: 6 z: 7
-          }
-        }
-        to_trajectory_id: 8
-        timestamp: 9
-      }
+      to_trajectory_id: 8
+      timestamp: 9
     }
-  )PROTO";
+  }
+)PROTO";
 
 class AddTrajectoryHandlerTest
     : public testing::HandlerTest<AddTrajectoryHandler> {

--- a/cartographer_grpc/handlers/get_landmark_poses_handler_test.cc
+++ b/cartographer_grpc/handlers/get_landmark_poses_handler_test.cc
@@ -34,23 +34,15 @@ const std::string kMessage = R"PROTO(
   landmark_poses {
     landmark_id: "landmark_1"
     global_pose {
-      translation {
-        x: 1 y: 2 z: 3
-      }
-      rotation {
-        w: 1 x: 0 y: 0 z: 0
-      }
+      translation { x: 1 y: 2 z: 3 }
+      rotation { w: 1 x: 0 y: 0 z: 0 }
     }
   }
   landmark_poses {
     landmark_id: "landmark_2"
     global_pose {
-      translation {
-        x: 3 y: 2 z: 1
-      }
-      rotation {
-        w: 0 x: 1 y: 0 z: 0
-      }
+      translation { x: 3 y: 2 z: 1 }
+      rotation { w: 0 x: 1 y: 0 z: 0 }
     }
   }
 )PROTO";

--- a/cartographer_grpc/testing/mock_map_builder.h
+++ b/cartographer_grpc/testing/mock_map_builder.h
@@ -49,8 +49,9 @@ class MockMapBuilder : public cartographer::mapping::MapBuilderInterface {
       SubmapToProto,
       std::string(const cartographer::mapping::SubmapId &,
                   cartographer::mapping::proto::SubmapQuery::Response *));
-  MOCK_METHOD1(SerializeState,
-               void(cartographer::io::ProtoStreamWriterInterface *));
+  MOCK_METHOD2(SerializeState,
+               void(cartographer::io::ProtoStreamWriterInterface *,
+                    const std::set<int>));
   MOCK_METHOD2(LoadState,
                void(cartographer::io::ProtoStreamReaderInterface *, bool));
   MOCK_CONST_METHOD0(num_trajectory_builders, int());


### PR DESCRIPTION
The optional parameter `trajectory_ids` allows to serialize only
a subset of the data. This is for example useful for re-mapping
on top of an existing map and serializing only the new map.
