### PR TITLE
Move pose_graph_stub/trajectory_builder_stub to internal.

### DIFF
--- a/cartographer_grpc/client/map_builder_stub.h
+++ b/cartographer_grpc/client/map_builder_stub.h
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#ifndef CARTOGRAPHER_GRPC_MAPPING_MAP_BUILDER_STUB_H_
-#define CARTOGRAPHER_GRPC_MAPPING_MAP_BUILDER_STUB_H_
+#ifndef CARTOGRAPHER_GRPC_CLIENT_MAP_BUILDER_STUB_H_
+#define CARTOGRAPHER_GRPC_CLIENT_MAP_BUILDER_STUB_H_
 
 #include <memory>
 
 #include "cartographer/mapping/map_builder_interface.h"
-#include "cartographer_grpc/mapping/pose_graph_stub.h"
-#include "cartographer_grpc/mapping/trajectory_builder_stub.h"
+#include "cartographer/mapping/pose_graph_interface.h"
+#include "cartographer/mapping/trajectory_builder_interface.h"
 #include "grpc++/grpc++.h"
 
 namespace cartographer_grpc {
@@ -60,12 +60,13 @@ class MapBuilderStub : public cartographer::mapping::MapBuilderInterface {
 
  private:
   std::shared_ptr<grpc::Channel> client_channel_;
-  PoseGraphStub pose_graph_stub_;
-  std::map<int, std::unique_ptr<TrajectoryBuilderStub>>
+  std::unique_ptr<cartographer::mapping::PoseGraphInterface> pose_graph_stub_;
+  std::map<int,
+           std::unique_ptr<cartographer::mapping::TrajectoryBuilderInterface>>
       trajectory_builder_stubs_;
 };
 
 }  // namespace mapping
 }  // namespace cartographer_grpc
 
-#endif  // CARTOGRAPHER_GRPC_MAPPING_MAP_BUILDER_STUB_H_
+#endif  // CARTOGRAPHER_GRPC_CLIENT_MAP_BUILDER_STUB_H_

--- a/cartographer_grpc/client_server_test.cc
+++ b/cartographer_grpc/client_server_test.cc
@@ -21,7 +21,7 @@
 #include "cartographer/mapping/local_slam_result_data.h"
 #include "cartographer_grpc/map_builder_server.h"
 #include "cartographer_grpc/map_builder_server_options.h"
-#include "cartographer_grpc/mapping/map_builder_stub.h"
+#include "cartographer_grpc/client/map_builder_stub.h"
 #include "cartographer_grpc/testing/mock_map_builder.h"
 #include "cartographer_grpc/testing/mock_trajectory_builder.h"
 #include "glog/logging.h"

--- a/cartographer_grpc/client_server_test.cc
+++ b/cartographer_grpc/client_server_test.cc
@@ -19,9 +19,9 @@
 
 #include "cartographer/mapping/internal/test_helpers.h"
 #include "cartographer/mapping/local_slam_result_data.h"
+#include "cartographer_grpc/client/map_builder_stub.h"
 #include "cartographer_grpc/map_builder_server.h"
 #include "cartographer_grpc/map_builder_server_options.h"
-#include "cartographer_grpc/client/map_builder_stub.h"
 #include "cartographer_grpc/testing/mock_map_builder.h"
 #include "cartographer_grpc/testing/mock_trajectory_builder.h"
 #include "glog/logging.h"

--- a/cartographer_grpc/internal/client/pose_graph_stub.cc
+++ b/cartographer_grpc/internal/client/pose_graph_stub.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "cartographer_grpc/mapping/pose_graph_stub.h"
+#include "cartographer_grpc/internal/client/pose_graph_stub.h"
 #include "cartographer/mapping/pose_graph.h"
 #include "cartographer_grpc/framework/client.h"
 #include "cartographer_grpc/handlers/get_all_submap_poses.h"

--- a/cartographer_grpc/internal/client/pose_graph_stub.h
+++ b/cartographer_grpc/internal/client/pose_graph_stub.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef CARTOGRAPHER_GRPC_MAPPING_POSE_GRAPH_STUB_H_
-#define CARTOGRAPHER_GRPC_MAPPING_POSE_GRAPH_STUB_H_
+#ifndef CARTOGRAPHER_GRPC_INTERNAL_CLIENT_POSE_GRAPH_STUB_H_
+#define CARTOGRAPHER_GRPC_INTERNAL_CLIENT_POSE_GRAPH_STUB_H_
 
 #include "cartographer/mapping/pose_graph_interface.h"
 #include "grpc++/grpc++.h"
@@ -58,4 +58,4 @@ class PoseGraphStub : public cartographer::mapping::PoseGraphInterface {
 }  // namespace mapping
 }  // namespace cartographer_grpc
 
-#endif  // CARTOGRAPHER_GRPC_MAPPING_POSE_GRAPH_STUB_H_
+#endif  // CARTOGRAPHER_GRPC_INTERNAL_CLIENT_POSE_GRAPH_STUB_H_

--- a/cartographer_grpc/internal/client/trajectory_builder_stub.cc
+++ b/cartographer_grpc/internal/client/trajectory_builder_stub.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "cartographer_grpc/mapping/trajectory_builder_stub.h"
+#include "cartographer_grpc/internal/client/trajectory_builder_stub.h"
 
 #include "cartographer/mapping/local_slam_result_data.h"
 #include "cartographer_grpc/proto/map_builder_service.pb.h"

--- a/cartographer_grpc/internal/client/trajectory_builder_stub.h
+++ b/cartographer_grpc/internal/client/trajectory_builder_stub.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef CARTOGRAPHER_GRPC_MAPPING_TRAJECTORY_BUILDER_STUB_H_
-#define CARTOGRAPHER_GRPC_MAPPING_TRAJECTORY_BUILDER_STUB_H_
+#ifndef CARTOGRAPHER_GRPC_INTERNAL_CLIENT_TRAJECTORY_BUILDER_STUB_H_
+#define CARTOGRAPHER_GRPC_INTERNAL_CLIENT_TRAJECTORY_BUILDER_STUB_H_
 
 #include <thread>
 
@@ -30,6 +30,8 @@
 #include "cartographer_grpc/handlers/add_rangefinder_data_handler.h"
 #include "cartographer_grpc/handlers/receive_local_slam_results_handler.h"
 #include "grpc++/grpc++.h"
+#include "pose_graph_stub.h"
+#include "trajectory_builder_stub.h"
 
 namespace cartographer_grpc {
 namespace mapping {
@@ -88,4 +90,4 @@ class TrajectoryBuilderStub
 }  // namespace mapping
 }  // namespace cartographer_grpc
 
-#endif  // CARTOGRAPHER_GRPC_MAPPING_TRAJECTORY_BUILDER_STUB_H_
+#endif  // CARTOGRAPHER_GRPC_INTERNAL_CLIENT_TRAJECTORY_BUILDER_STUB_H_


### PR DESCRIPTION
[Internal hdrs RFC](https://github.com/googlecartographer/rfcs/blob/master/text/0003-internal-headers.md)

Also moved /mapping to /client. Namespace changes will follow.