### PR TITLE
Fix warning about incorrect workspace name

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -219,10 +219,10 @@ def cartographer_repositories():
 
   _maybe(native.http_archive,
       name = "com_github_jupp0r_prometheus_cpp",
-      sha256 = "701789ff0cc3a5ea7ba78d31b2d18265969f1c7d669f83800fffd8f39c4fa1bb",
-      strip_prefix = "prometheus-cpp-743722db96465aa867bf569eb455ad82dab9f819",
+      sha256 = "41b202a206ba6339c4678ffe3690659fdb77287d97507aad82a83c5360b8ba8b",
+      strip_prefix = "prometheus-cpp-b3914b1045c92649e81d020851f3bb06ef858df4",
       urls = [
-          "https://github.com/jupp0r/prometheus-cpp/archive/743722db96465aa867bf569eb455ad82dab9f819.tar.gz",
+          "https://github.com/jupp0r/prometheus-cpp/archive/b3914b1045c92649e81d020851f3bb06ef858df4.tar.gz",
       ],
   )
 


### PR DESCRIPTION
The workspace name for prometheus-cpp has been updated to the correct
canonical name.
