### PR TITLE
Rename cartographer_grpc:: namespace as cartographer::cloud::.

### DIFF
--- a/cartographer_grpc/client/map_builder_stub.h
+++ b/cartographer_grpc/client/map_builder_stub.h
@@ -24,10 +24,10 @@
 #include "cartographer/mapping/trajectory_builder_interface.h"
 #include "grpc++/grpc++.h"
 
-namespace cartographer_grpc {
-namespace mapping {
+namespace cartographer {
+namespace cloud {
 
-class MapBuilderStub : public cartographer::mapping::MapBuilderInterface {
+class MapBuilderStub : public mapping::MapBuilderInterface {
  public:
   MapBuilderStub(const std::string& server_address);
 
@@ -36,37 +36,33 @@ class MapBuilderStub : public cartographer::mapping::MapBuilderInterface {
 
   int AddTrajectoryBuilder(
       const std::set<SensorId>& expected_sensor_ids,
-      const cartographer::mapping::proto::TrajectoryBuilderOptions&
-          trajectory_options,
+      const mapping::proto::TrajectoryBuilderOptions& trajectory_options,
       LocalSlamResultCallback local_slam_result_callback) override;
   int AddTrajectoryForDeserialization(
-      const cartographer::mapping::proto::TrajectoryBuilderOptionsWithSensorIds&
+      const mapping::proto::TrajectoryBuilderOptionsWithSensorIds&
           options_with_sensor_ids_proto) override;
-  cartographer::mapping::TrajectoryBuilderInterface* GetTrajectoryBuilder(
+  mapping::TrajectoryBuilderInterface* GetTrajectoryBuilder(
       int trajectory_id) const override;
   void FinishTrajectory(int trajectory_id) override;
   std::string SubmapToProto(
-      const cartographer::mapping::SubmapId& submap_id,
-      cartographer::mapping::proto::SubmapQuery::Response* response) override;
-  void SerializeState(
-      cartographer::io::ProtoStreamWriterInterface* writer) override;
-  void LoadState(cartographer::io::ProtoStreamReaderInterface* reader,
+      const mapping::SubmapId& submap_id,
+      mapping::proto::SubmapQuery::Response* response) override;
+  void SerializeState(io::ProtoStreamWriterInterface* writer) override;
+  void LoadState(io::ProtoStreamReaderInterface* reader,
                  bool load_frozen_state) override;
   int num_trajectory_builders() const override;
-  cartographer::mapping::PoseGraphInterface* pose_graph() override;
-  const std::vector<
-      cartographer::mapping::proto::TrajectoryBuilderOptionsWithSensorIds>&
+  mapping::PoseGraphInterface* pose_graph() override;
+  const std::vector<mapping::proto::TrajectoryBuilderOptionsWithSensorIds>&
   GetAllTrajectoryBuilderOptions() const override;
 
  private:
-  std::shared_ptr<grpc::Channel> client_channel_;
-  std::unique_ptr<cartographer::mapping::PoseGraphInterface> pose_graph_stub_;
-  std::map<int,
-           std::unique_ptr<cartographer::mapping::TrajectoryBuilderInterface>>
+  std::shared_ptr<::grpc::Channel> client_channel_;
+  std::unique_ptr<mapping::PoseGraphInterface> pose_graph_stub_;
+  std::map<int, std::unique_ptr<mapping::TrajectoryBuilderInterface>>
       trajectory_builder_stubs_;
 };
 
-}  // namespace mapping
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_CLIENT_MAP_BUILDER_STUB_H_

--- a/cartographer_grpc/internal/client/pose_graph_stub.cc
+++ b/cartographer_grpc/internal/client/pose_graph_stub.cc
@@ -25,10 +25,10 @@
 #include "cartographer_grpc/internal/handlers/run_final_optimization_handler.h"
 #include "glog/logging.h"
 
-namespace cartographer_grpc {
-namespace mapping {
+namespace cartographer {
+namespace cloud {
 
-PoseGraphStub::PoseGraphStub(std::shared_ptr<grpc::Channel> client_channel)
+PoseGraphStub::PoseGraphStub(std::shared_ptr<::grpc::Channel> client_channel)
     : client_channel_(client_channel) {}
 
 void PoseGraphStub::RunFinalOptimization() {
@@ -38,81 +38,68 @@ void PoseGraphStub::RunFinalOptimization() {
   CHECK(client.Write(request));
 }
 
-cartographer::mapping::MapById<
-    cartographer::mapping::SubmapId,
-    cartographer::mapping::PoseGraphInterface::SubmapData>
+mapping::MapById<mapping::SubmapId, mapping::PoseGraphInterface::SubmapData>
 PoseGraphStub::GetAllSubmapData() {
   LOG(FATAL) << "Not implemented";
 }
 
-cartographer::mapping::MapById<
-    cartographer::mapping::SubmapId,
-    cartographer::mapping::PoseGraphInterface::SubmapPose>
+mapping::MapById<mapping::SubmapId, mapping::PoseGraphInterface::SubmapPose>
 PoseGraphStub::GetAllSubmapPoses() {
   google::protobuf::Empty request;
   framework::Client<handlers::GetAllSubmapPosesHandler> client(client_channel_);
   CHECK(client.Write(request));
-  cartographer::mapping::MapById<
-      cartographer::mapping::SubmapId,
-      cartographer::mapping::PoseGraphInterface::SubmapPose>
+  mapping::MapById<mapping::SubmapId, mapping::PoseGraphInterface::SubmapPose>
       submap_poses;
   for (const auto& submap_pose : client.response().submap_poses()) {
     submap_poses.Insert(
-        cartographer::mapping::SubmapId{submap_pose.submap_id().trajectory_id(),
-                                        submap_pose.submap_id().submap_index()},
-        cartographer::mapping::PoseGraphInterface::SubmapPose{
+        mapping::SubmapId{submap_pose.submap_id().trajectory_id(),
+                          submap_pose.submap_id().submap_index()},
+        mapping::PoseGraphInterface::SubmapPose{
             submap_pose.submap_version(),
-            cartographer::transform::ToRigid3(submap_pose.global_pose())});
+            transform::ToRigid3(submap_pose.global_pose())});
   }
   return submap_poses;
 }
 
-cartographer::transform::Rigid3d PoseGraphStub::GetLocalToGlobalTransform(
-    int trajectory_id) {
+transform::Rigid3d PoseGraphStub::GetLocalToGlobalTransform(int trajectory_id) {
   proto::GetLocalToGlobalTransformRequest request;
   request.set_trajectory_id(trajectory_id);
   framework::Client<handlers::GetLocalToGlobalTransformHandler> client(
       client_channel_);
   CHECK(client.Write(request));
-  return cartographer::transform::ToRigid3(client.response().local_to_global());
+  return transform::ToRigid3(client.response().local_to_global());
 }
 
-cartographer::mapping::MapById<cartographer::mapping::NodeId,
-                               cartographer::mapping::TrajectoryNode>
+mapping::MapById<mapping::NodeId, mapping::TrajectoryNode>
 PoseGraphStub::GetTrajectoryNodes() {
   LOG(FATAL) << "Not implemented";
 }
 
-cartographer::mapping::MapById<cartographer::mapping::NodeId,
-                               cartographer::mapping::TrajectoryNodePose>
+mapping::MapById<mapping::NodeId, mapping::TrajectoryNodePose>
 PoseGraphStub::GetTrajectoryNodePoses() {
   google::protobuf::Empty request;
   framework::Client<handlers::GetTrajectoryNodePosesHandler> client(
       client_channel_);
   CHECK(client.Write(request));
-  cartographer::mapping::MapById<cartographer::mapping::NodeId,
-                                 cartographer::mapping::TrajectoryNodePose>
-      node_poses;
+  mapping::MapById<mapping::NodeId, mapping::TrajectoryNodePose> node_poses;
   for (const auto& node_pose : client.response().node_poses()) {
-    node_poses.Insert(
-        cartographer::mapping::NodeId{node_pose.node_id().trajectory_id(),
+    node_poses.Insert(mapping::NodeId{node_pose.node_id().trajectory_id(),
                                       node_pose.node_id().node_index()},
-        cartographer::mapping::TrajectoryNodePose{
-            node_pose.has_constant_data(),
-            cartographer::transform::ToRigid3(node_pose.global_pose())});
+                      mapping::TrajectoryNodePose{
+                          node_pose.has_constant_data(),
+                          transform::ToRigid3(node_pose.global_pose())});
   }
   return node_poses;
 }
 
-std::map<std::string, cartographer::transform::Rigid3d>
-PoseGraphStub::GetLandmarkPoses() {
+std::map<std::string, transform::Rigid3d> PoseGraphStub::GetLandmarkPoses() {
   google::protobuf::Empty request;
   framework::Client<handlers::GetLandmarkPosesHandler> client(client_channel_);
   CHECK(client.Write(request));
-  std::map<std::string, cartographer::transform::Rigid3d> landmark_poses;
+  std::map<std::string, transform::Rigid3d> landmark_poses;
   for (const auto& landmark_pose : client.response().landmark_poses()) {
     landmark_poses[landmark_pose.landmark_id()] =
-        cartographer::transform::ToRigid3(landmark_pose.global_pose());
+        transform::ToRigid3(landmark_pose.global_pose());
   }
   return landmark_poses;
 }
@@ -121,22 +108,22 @@ bool PoseGraphStub::IsTrajectoryFinished(int trajectory_id) {
   LOG(FATAL) << "Not implemented";
 }
 
-std::map<int, cartographer::mapping::PoseGraphInterface::TrajectoryData>
+std::map<int, mapping::PoseGraphInterface::TrajectoryData>
 PoseGraphStub::GetTrajectoryData() {
   LOG(FATAL) << "Not implemented";
 }
 
-std::vector<cartographer::mapping::PoseGraphInterface::Constraint>
+std::vector<mapping::PoseGraphInterface::Constraint>
 PoseGraphStub::constraints() {
   google::protobuf::Empty request;
   framework::Client<handlers::GetConstraintsHandler> client(client_channel_);
   CHECK(client.Write(request));
-  return cartographer::mapping::FromProto(client.response().constraints());
+  return mapping::FromProto(client.response().constraints());
 }
 
-cartographer::mapping::proto::PoseGraph PoseGraphStub::ToProto() {
+mapping::proto::PoseGraph PoseGraphStub::ToProto() {
   LOG(FATAL) << "Not implemented";
 }
 
-}  // namespace mapping
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/client/pose_graph_stub.h
+++ b/cartographer_grpc/internal/client/pose_graph_stub.h
@@ -20,42 +20,36 @@
 #include "cartographer/mapping/pose_graph_interface.h"
 #include "grpc++/grpc++.h"
 
-namespace cartographer_grpc {
-namespace mapping {
+namespace cartographer {
+namespace cloud {
 
-class PoseGraphStub : public cartographer::mapping::PoseGraphInterface {
+class PoseGraphStub : public ::cartographer::mapping::PoseGraphInterface {
  public:
-  PoseGraphStub(std::shared_ptr<grpc::Channel> client_channel);
+  PoseGraphStub(std::shared_ptr<::grpc::Channel> client_channel);
 
   PoseGraphStub(const PoseGraphStub&) = delete;
   PoseGraphStub& operator=(const PoseGraphStub&) = delete;
 
   void RunFinalOptimization() override;
-  cartographer::mapping::MapById<cartographer::mapping::SubmapId, SubmapData>
-  GetAllSubmapData() override;
-  cartographer::mapping::MapById<cartographer::mapping::SubmapId, SubmapPose>
-  GetAllSubmapPoses() override;
-  cartographer::transform::Rigid3d GetLocalToGlobalTransform(
-      int trajectory_id) override;
-  cartographer::mapping::MapById<cartographer::mapping::NodeId,
-                                 cartographer::mapping::TrajectoryNode>
+  mapping::MapById<mapping::SubmapId, SubmapData> GetAllSubmapData() override;
+  mapping::MapById<mapping::SubmapId, SubmapPose> GetAllSubmapPoses() override;
+  transform::Rigid3d GetLocalToGlobalTransform(int trajectory_id) override;
+  mapping::MapById<mapping::NodeId, mapping::TrajectoryNode>
   GetTrajectoryNodes() override;
-  cartographer::mapping::MapById<cartographer::mapping::NodeId,
-                                 cartographer::mapping::TrajectoryNodePose>
+  mapping::MapById<mapping::NodeId, mapping::TrajectoryNodePose>
   GetTrajectoryNodePoses() override;
-  std::map<std::string, cartographer::transform::Rigid3d> GetLandmarkPoses()
-      override;
+  std::map<std::string, transform::Rigid3d> GetLandmarkPoses() override;
   bool IsTrajectoryFinished(int trajectory_id) override;
-  std::map<int, cartographer::mapping::PoseGraphInterface::TrajectoryData>
-  GetTrajectoryData() override;
+  std::map<int, mapping::PoseGraphInterface::TrajectoryData> GetTrajectoryData()
+      override;
   std::vector<Constraint> constraints() override;
-  cartographer::mapping::proto::PoseGraph ToProto() override;
+  mapping::proto::PoseGraph ToProto() override;
 
  private:
-  std::shared_ptr<grpc::Channel> client_channel_;
+  std::shared_ptr<::grpc::Channel> client_channel_;
 };
 
-}  // namespace mapping
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_CLIENT_POSE_GRAPH_STUB_H_

--- a/cartographer_grpc/internal/client/trajectory_builder_stub.cc
+++ b/cartographer_grpc/internal/client/trajectory_builder_stub.cc
@@ -21,11 +21,11 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "glog/logging.h"
 
-namespace cartographer_grpc {
-namespace mapping {
+namespace cartographer {
+namespace cloud {
 
 TrajectoryBuilderStub::TrajectoryBuilderStub(
-    std::shared_ptr<grpc::Channel> client_channel, const int trajectory_id,
+    std::shared_ptr<::grpc::Channel> client_channel, const int trajectory_id,
     LocalSlamResultCallback local_slam_result_callback)
     : client_channel_(client_channel),
       trajectory_id_(trajectory_id),
@@ -36,13 +36,11 @@ TrajectoryBuilderStub::TrajectoryBuilderStub(
     receive_local_slam_results_client_.Write(request);
     auto* receive_local_slam_results_client_ptr =
         &receive_local_slam_results_client_;
-    receive_local_slam_results_thread_ =
-        cartographer::common::make_unique<std::thread>(
-            [receive_local_slam_results_client_ptr,
-             local_slam_result_callback]() {
-              RunLocalSlamResultsReader(receive_local_slam_results_client_ptr,
-                                        local_slam_result_callback);
-            });
+    receive_local_slam_results_thread_ = common::make_unique<std::thread>(
+        [receive_local_slam_results_client_ptr, local_slam_result_callback]() {
+          RunLocalSlamResultsReader(receive_local_slam_results_client_ptr,
+                                    local_slam_result_callback);
+        });
   }
 }
 
@@ -74,79 +72,72 @@ TrajectoryBuilderStub::~TrajectoryBuilderStub() {
 
 void TrajectoryBuilderStub::AddSensorData(
     const std::string& sensor_id,
-    const cartographer::sensor::TimedPointCloudData& timed_point_cloud_data) {
+    const sensor::TimedPointCloudData& timed_point_cloud_data) {
   if (!add_rangefinder_client_) {
-    add_rangefinder_client_ = cartographer::common::make_unique<
+    add_rangefinder_client_ = common::make_unique<
         framework::Client<handlers::AddRangefinderDataHandler>>(
         client_channel_);
   }
   proto::AddRangefinderDataRequest request;
-  sensor::CreateAddRangeFinderDataRequest(
-      sensor_id, trajectory_id_,
-      cartographer::sensor::ToProto(timed_point_cloud_data), &request);
+  CreateAddRangeFinderDataRequest(sensor_id, trajectory_id_,
+                                  sensor::ToProto(timed_point_cloud_data),
+                                  &request);
   add_rangefinder_client_->Write(request);
 }
 
-void TrajectoryBuilderStub::AddSensorData(
-    const std::string& sensor_id,
-    const cartographer::sensor::ImuData& imu_data) {
+void TrajectoryBuilderStub::AddSensorData(const std::string& sensor_id,
+                                          const sensor::ImuData& imu_data) {
   if (!add_imu_client_) {
-    add_imu_client_ = cartographer::common::make_unique<
-        framework::Client<handlers::AddImuDataHandler>>(client_channel_);
+    add_imu_client_ =
+        common::make_unique<framework::Client<handlers::AddImuDataHandler>>(
+            client_channel_);
   }
   proto::AddImuDataRequest request;
-  sensor::CreateAddImuDataRequest(sensor_id, trajectory_id_,
-                                  cartographer::sensor::ToProto(imu_data),
-                                  &request);
+  CreateAddImuDataRequest(sensor_id, trajectory_id_, sensor::ToProto(imu_data),
+                          &request);
   add_imu_client_->Write(request);
 }
 
 void TrajectoryBuilderStub::AddSensorData(
-    const std::string& sensor_id,
-    const cartographer::sensor::OdometryData& odometry_data) {
+    const std::string& sensor_id, const sensor::OdometryData& odometry_data) {
   if (!add_odometry_client_) {
-    add_odometry_client_ = cartographer::common::make_unique<
+    add_odometry_client_ = common::make_unique<
         framework::Client<handlers::AddOdometryDataHandler>>(client_channel_);
   }
   proto::AddOdometryDataRequest request;
-  sensor::CreateAddOdometryDataRequest(
-      sensor_id, trajectory_id_, cartographer::sensor::ToProto(odometry_data),
-      &request);
+  CreateAddOdometryDataRequest(sensor_id, trajectory_id_,
+                               sensor::ToProto(odometry_data), &request);
   add_odometry_client_->Write(request);
 }
 
 void TrajectoryBuilderStub::AddSensorData(
     const std::string& sensor_id,
-    const cartographer::sensor::FixedFramePoseData& fixed_frame_pose) {
+    const sensor::FixedFramePoseData& fixed_frame_pose) {
   if (!add_fixed_frame_pose_client_) {
-    add_fixed_frame_pose_client_ = cartographer::common::make_unique<
+    add_fixed_frame_pose_client_ = common::make_unique<
         framework::Client<handlers::AddFixedFramePoseDataHandler>>(
         client_channel_);
   }
   proto::AddFixedFramePoseDataRequest request;
-  sensor::CreateAddFixedFramePoseDataRequest(
-      sensor_id, trajectory_id_,
-      cartographer::sensor::ToProto(fixed_frame_pose), &request);
+  CreateAddFixedFramePoseDataRequest(
+      sensor_id, trajectory_id_, sensor::ToProto(fixed_frame_pose), &request);
   add_fixed_frame_pose_client_->Write(request);
 }
 
 void TrajectoryBuilderStub::AddSensorData(
-    const std::string& sensor_id,
-    const cartographer::sensor::LandmarkData& landmark_data) {
+    const std::string& sensor_id, const sensor::LandmarkData& landmark_data) {
   if (!add_landmark_client_) {
-    add_landmark_client_ = cartographer::common::make_unique<
+    add_landmark_client_ = common::make_unique<
         framework::Client<handlers::AddLandmarkDataHandler>>(client_channel_);
   }
   proto::AddLandmarkDataRequest request;
-  sensor::CreateAddLandmarkDataRequest(
-      sensor_id, trajectory_id_, cartographer::sensor::ToProto(landmark_data),
-      &request);
+  CreateAddLandmarkDataRequest(sensor_id, trajectory_id_,
+                               sensor::ToProto(landmark_data), &request);
   add_landmark_client_->Write(request);
 }
 
 void TrajectoryBuilderStub::AddLocalSlamResultData(
-    std::unique_ptr<cartographer::mapping::LocalSlamResultData>
-        local_slam_result_data) {
+    std::unique_ptr<mapping::LocalSlamResultData> local_slam_result_data) {
   LOG(FATAL) << "Not implemented";
 }
 
@@ -156,16 +147,13 @@ void TrajectoryBuilderStub::RunLocalSlamResultsReader(
   proto::ReceiveLocalSlamResultsResponse response;
   while (client->Read(&response)) {
     int trajectory_id = response.trajectory_id();
-    cartographer::common::Time time =
-        cartographer::common::FromUniversal(response.timestamp());
-    cartographer::transform::Rigid3d local_pose =
-        cartographer::transform::ToRigid3(response.local_pose());
-    cartographer::sensor::RangeData range_data =
-        cartographer::sensor::FromProto(response.range_data());
+    common::Time time = common::FromUniversal(response.timestamp());
+    transform::Rigid3d local_pose = transform::ToRigid3(response.local_pose());
+    sensor::RangeData range_data = sensor::FromProto(response.range_data());
     auto insertion_result =
         response.has_insertion_result()
-            ? cartographer::common::make_unique<InsertionResult>(
-                  InsertionResult{cartographer::mapping::NodeId{
+            ? common::make_unique<InsertionResult>(
+                  InsertionResult{mapping::NodeId{
                       response.insertion_result().node_id().trajectory_id(),
                       response.insertion_result().node_id().node_index()}})
             : nullptr;
@@ -175,5 +163,5 @@ void TrajectoryBuilderStub::RunLocalSlamResultsReader(
   client->Finish();
 }
 
-}  // namespace mapping
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/client/trajectory_builder_stub.h
+++ b/cartographer_grpc/internal/client/trajectory_builder_stub.h
@@ -33,36 +33,32 @@
 #include "pose_graph_stub.h"
 #include "trajectory_builder_stub.h"
 
-namespace cartographer_grpc {
-namespace mapping {
+namespace cartographer {
+namespace cloud {
 
-class TrajectoryBuilderStub
-    : public cartographer::mapping::TrajectoryBuilderInterface {
+class TrajectoryBuilderStub : public mapping::TrajectoryBuilderInterface {
  public:
-  TrajectoryBuilderStub(std::shared_ptr<grpc::Channel> client_channel,
+  TrajectoryBuilderStub(std::shared_ptr<::grpc::Channel> client_channel,
                         const int trajectory_id,
                         LocalSlamResultCallback local_slam_result_callback);
   ~TrajectoryBuilderStub() override;
   TrajectoryBuilderStub(const TrajectoryBuilderStub&) = delete;
   TrajectoryBuilderStub& operator=(const TrajectoryBuilderStub&) = delete;
 
-  void AddSensorData(const std::string& sensor_id,
-                     const cartographer::sensor::TimedPointCloudData&
-                         timed_point_cloud_data) override;
-  void AddSensorData(const std::string& sensor_id,
-                     const cartographer::sensor::ImuData& imu_data) override;
   void AddSensorData(
       const std::string& sensor_id,
-      const cartographer::sensor::OdometryData& odometry_data) override;
+      const sensor::TimedPointCloudData& timed_point_cloud_data) override;
   void AddSensorData(const std::string& sensor_id,
-                     const cartographer::sensor::FixedFramePoseData&
-                         fixed_frame_pose) override;
+                     const sensor::ImuData& imu_data) override;
+  void AddSensorData(const std::string& sensor_id,
+                     const sensor::OdometryData& odometry_data) override;
   void AddSensorData(
       const std::string& sensor_id,
-      const cartographer::sensor::LandmarkData& landmark_data) override;
-  void AddLocalSlamResultData(
-      std::unique_ptr<cartographer::mapping::LocalSlamResultData>
-          local_slam_result_data) override;
+      const sensor::FixedFramePoseData& fixed_frame_pose) override;
+  void AddSensorData(const std::string& sensor_id,
+                     const sensor::LandmarkData& landmark_data) override;
+  void AddLocalSlamResultData(std::unique_ptr<mapping::LocalSlamResultData>
+                                  local_slam_result_data) override;
 
  private:
   static void RunLocalSlamResultsReader(
@@ -70,7 +66,7 @@ class TrajectoryBuilderStub
           client_reader,
       LocalSlamResultCallback local_slam_result_callback);
 
-  std::shared_ptr<grpc::Channel> client_channel_;
+  std::shared_ptr<::grpc::Channel> client_channel_;
   const int trajectory_id_;
   std::unique_ptr<framework::Client<handlers::AddRangefinderDataHandler>>
       add_rangefinder_client_;
@@ -87,7 +83,7 @@ class TrajectoryBuilderStub
   std::unique_ptr<std::thread> receive_local_slam_results_thread_;
 };
 
-}  // namespace mapping
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_CLIENT_TRAJECTORY_BUILDER_STUB_H_

--- a/cartographer_grpc/internal/framework/completion_queue_thread.cc
+++ b/cartographer_grpc/internal/framework/completion_queue_thread.cc
@@ -19,7 +19,8 @@
 #include "cartographer/common/make_unique.h"
 #include "glog/logging.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 CompletionQueueThread::CompletionQueueThread(
@@ -32,7 +33,7 @@ CompletionQueueThread::CompletionQueueThread(
 
 void CompletionQueueThread::Start(CompletionQueueRunner runner) {
   CHECK(!worker_thread_);
-  worker_thread_ = cartographer::common::make_unique<std::thread>(
+  worker_thread_ = common::make_unique<std::thread>(
       [this, runner]() { runner(this->completion_queue_.get()); });
 }
 
@@ -43,4 +44,5 @@ void CompletionQueueThread::Shutdown() {
 }
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/framework/completion_queue_thread.h
+++ b/cartographer_grpc/internal/framework/completion_queue_thread.h
@@ -21,7 +21,8 @@
 #include <memory>
 #include <thread>
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 class CompletionQueueThread {
@@ -43,6 +44,7 @@ class CompletionQueueThread {
 };
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_COMPLETION_QUEUE_THREAD_H

--- a/cartographer_grpc/internal/framework/event_queue_thread.cc
+++ b/cartographer_grpc/internal/framework/event_queue_thread.cc
@@ -19,11 +19,12 @@
 #include "cartographer/common/make_unique.h"
 #include "glog/logging.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 EventQueueThread::EventQueueThread() {
-  event_queue_ = cartographer::common::make_unique<EventQueue>();
+  event_queue_ = common::make_unique<EventQueue>();
 }
 
 EventQueue* EventQueueThread::event_queue() { return event_queue_.get(); }
@@ -31,7 +32,7 @@ EventQueue* EventQueueThread::event_queue() { return event_queue_.get(); }
 void EventQueueThread::Start(EventQueueRunner runner) {
   CHECK(!thread_);
   EventQueue* event_queue = event_queue_.get();
-  thread_ = cartographer::common::make_unique<std::thread>(
+  thread_ = common::make_unique<std::thread>(
       [event_queue, runner]() { runner(event_queue); });
 }
 
@@ -41,4 +42,5 @@ void EventQueueThread::Shutdown() {
 }
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/framework/event_queue_thread.h
+++ b/cartographer_grpc/internal/framework/event_queue_thread.h
@@ -23,7 +23,8 @@
 #include "cartographer/common/blocking_queue.h"
 #include "cartographer_grpc/internal/framework/rpc.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 class EventQueueThread {
@@ -43,6 +44,7 @@ class EventQueueThread {
 };
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_FRAMEWORK_EVENT_QUEUE_THREAD_H

--- a/cartographer_grpc/internal/framework/execution_context.h
+++ b/cartographer_grpc/internal/framework/execution_context.h
@@ -20,7 +20,8 @@
 #include "cartographer/common/mutex.h"
 #include "glog/logging.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 // Implementations of this class allow RPC handlers to share state among one
@@ -39,27 +40,27 @@ class ExecutionContext {
     ContextType* operator->() {
       return static_cast<ContextType*>(execution_context_);
     }
-    Synchronized(cartographer::common::Mutex* lock,
-                 ExecutionContext* execution_context)
+    Synchronized(common::Mutex* lock, ExecutionContext* execution_context)
         : locker_(lock), execution_context_(execution_context) {}
     Synchronized(const Synchronized&) = delete;
     Synchronized(Synchronized&&) = delete;
 
    private:
-    cartographer::common::MutexLocker locker_;
+    common::MutexLocker locker_;
     ExecutionContext* execution_context_;
   };
   ExecutionContext() = default;
   virtual ~ExecutionContext() = default;
   ExecutionContext(const ExecutionContext&) = delete;
   ExecutionContext& operator=(const ExecutionContext&) = delete;
-  cartographer::common::Mutex* lock() { return &lock_; }
+  common::Mutex* lock() { return &lock_; }
 
  private:
-  cartographer::common::Mutex lock_;
+  common::Mutex lock_;
 };
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_FRAMEWORK_EXECUTION_CONTEXT_H

--- a/cartographer_grpc/internal/framework/proto/math_service.proto
+++ b/cartographer_grpc/internal/framework/proto/math_service.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package cartographer_grpc.framework.proto;
+package cartographer.cloud.framework.proto;
 
 message GetSumRequest {
   int32 input = 1;

--- a/cartographer_grpc/internal/framework/retry.cc
+++ b/cartographer_grpc/internal/framework/retry.cc
@@ -20,7 +20,8 @@
 #include "cartographer_grpc/internal/framework/retry.h"
 #include "glog/logging.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 RetryStrategy CreateRetryStrategy(RetryIndicator retry_indicator,
@@ -43,8 +44,8 @@ RetryDelayCalculator CreateBackoffDelayCalculator(Duration min_delay,
                                                   float backoff_factor) {
   return [min_delay, backoff_factor](int failed_attempts) -> Duration {
     CHECK_GE(failed_attempts, 0);
-    using cartographer::common::FromSeconds;
-    using cartographer::common::ToSeconds;
+    using common::FromSeconds;
+    using common::ToSeconds;
     return FromSeconds(std::pow(backoff_factor, failed_attempts - 1) *
                        ToSeconds(min_delay));
   };
@@ -87,4 +88,5 @@ bool RetryWithStrategy(RetryStrategy retry_strategy, std::function<bool()> op,
 }
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/framework/retry.h
+++ b/cartographer_grpc/internal/framework/retry.h
@@ -21,11 +21,12 @@
 #include "cartographer/common/time.h"
 #include "grpc++/grpc++.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
-using cartographer::common::Duration;
-using cartographer::common::optional;
+using common::Duration;
+using common::optional;
 
 using RetryStrategy =
     std::function<optional<Duration>(int /* failed_attempts */)>;
@@ -46,6 +47,7 @@ bool RetryWithStrategy(RetryStrategy retry_strategy, std::function<bool()> op,
                        std::function<void()> reset = nullptr);
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_FRAMEWORK_RETRY_H

--- a/cartographer_grpc/internal/framework/rpc.h
+++ b/cartographer_grpc/internal/framework/rpc.h
@@ -32,7 +32,8 @@
 #include "grpc++/impl/codegen/proto_utils.h"
 #include "grpc++/impl/codegen/service_type.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 class Service;
@@ -77,7 +78,7 @@ class Rpc {
   };
 
   using UniqueEventPtr = std::unique_ptr<EventBase, EventDeleter>;
-  using EventQueue = cartographer::common::BlockingQueue<UniqueEventPtr>;
+  using EventQueue = common::BlockingQueue<UniqueEventPtr>;
 
   // Flows through gRPC's CompletionQueue and then our EventQueue.
   struct CompletionQueueRpcEvent : public EventBase {
@@ -180,7 +181,7 @@ class Rpc {
   std::unique_ptr<::grpc::ServerAsyncWriter<google::protobuf::Message>>
       server_async_writer_;
 
-  cartographer::common::Mutex send_queue_lock_;
+  common::Mutex send_queue_lock_;
   std::queue<SendItem> send_queue_;
 };
 
@@ -201,11 +202,12 @@ class ActiveRpcs {
  private:
   std::weak_ptr<Rpc> GetWeakPtr(Rpc* rpc);
 
-  cartographer::common::Mutex lock_;
+  common::Mutex lock_;
   std::map<Rpc*, std::shared_ptr<Rpc>> rpcs_;
 };
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_FRAMEWORK_RPC_H

--- a/cartographer_grpc/internal/framework/rpc_handler.h
+++ b/cartographer_grpc/internal/framework/rpc_handler.h
@@ -25,7 +25,8 @@
 #include "google/protobuf/message.h"
 #include "grpc++/grpc++.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 template <typename Incoming, typename Outgoing>
@@ -86,6 +87,7 @@ class RpcHandler : public RpcHandlerInterface {
 };
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_FRAMEWORK_RPC_HANDLER_H

--- a/cartographer_grpc/internal/framework/rpc_handler_interface.h
+++ b/cartographer_grpc/internal/framework/rpc_handler_interface.h
@@ -22,7 +22,8 @@
 #include "google/protobuf/message.h"
 #include "grpc++/grpc++.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 class Rpc;
@@ -43,7 +44,7 @@ class RpcHandlerInterface {
   virtual void OnFinish(){};
   template <class RpcHandlerType>
   static std::unique_ptr<RpcHandlerType> Instantiate() {
-    return cartographer::common::make_unique<RpcHandlerType>();
+    return common::make_unique<RpcHandlerType>();
   }
 };
 
@@ -54,11 +55,12 @@ struct RpcHandlerInfo {
   const google::protobuf::Descriptor* request_descriptor;
   const google::protobuf::Descriptor* response_descriptor;
   const RpcHandlerFactory rpc_handler_factory;
-  const grpc::internal::RpcMethod::RpcType rpc_type;
+  const ::grpc::internal::RpcMethod::RpcType rpc_type;
   const std::string fully_qualified_name;
 };
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_FRAMEWORK_RPC_HANDLER_INTERFACE_H_H

--- a/cartographer_grpc/internal/framework/server.cc
+++ b/cartographer_grpc/internal/framework/server.cc
@@ -18,12 +18,12 @@
 
 #include "glog/logging.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 namespace {
 
-const cartographer::common::Duration kPopEventTimeout =
-    cartographer::common::FromMilliseconds(100);
+const common::Duration kPopEventTimeout = common::FromMilliseconds(100);
 
 }  // namespace
 
@@ -61,7 +61,7 @@ std::unique_ptr<Server> Server::Builder::Build() {
 
 Server::Server(const Options& options) : options_(options) {
   server_builder_.AddListeningPort(options_.server_address,
-                                   grpc::InsecureServerCredentials());
+                                   ::grpc::InsecureServerCredentials());
 
   // Set up event queue threads.
   event_queue_threads_ =
@@ -99,7 +99,7 @@ void Server::RunCompletionQueue(
 }
 
 EventQueue* Server::SelectNextEventQueueRoundRobin() {
-  cartographer::common::MutexLocker locker(&current_event_queue_id_lock_);
+  common::MutexLocker locker(&current_event_queue_id_lock_);
   current_event_queue_id_ =
       (current_event_queue_id_ + 1) % options_.num_event_threads;
   return event_queue_threads_.at(current_event_queue_id_).event_queue();
@@ -189,4 +189,5 @@ void Server::SetExecutionContext(
 }
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/framework/server.h
+++ b/cartographer_grpc/internal/framework/server.h
@@ -31,7 +31,8 @@
 #include "cartographer_grpc/internal/framework/service.h"
 #include "grpc++/grpc++.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 class Server {
@@ -71,7 +72,7 @@ class Server {
               RpcHandlerType::ResponseType::default_instance().GetDescriptor(),
               [](Rpc* const rpc, ExecutionContext* const execution_context) {
                 std::unique_ptr<RpcHandlerInterface> rpc_handler =
-                    cartographer::common::make_unique<RpcHandlerType>();
+                    common::make_unique<RpcHandlerType>();
                 rpc_handler->SetRpc(rpc);
                 rpc_handler->SetExecutionContext(execution_context);
                 return rpc_handler;
@@ -181,7 +182,7 @@ class Server {
 
   // Threads processing RPC events.
   std::vector<EventQueueThread> event_queue_threads_;
-  cartographer::common::Mutex current_event_queue_id_lock_;
+  common::Mutex current_event_queue_id_lock_;
   int current_event_queue_id_ = 0;
 
   // Map of service names to services.
@@ -193,6 +194,7 @@ class Server {
 };
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_FRAMEWORK_SERVER_H

--- a/cartographer_grpc/internal/framework/service.cc
+++ b/cartographer_grpc/internal/framework/service.cc
@@ -21,7 +21,8 @@
 #include "glog/logging.h"
 #include "grpc++/impl/codegen/proto_utils.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 Service::Service(const std::string& service_name,
@@ -32,7 +33,7 @@ Service::Service(const std::string& service_name,
   for (const auto& rpc_handler_info : rpc_handler_infos_) {
     // The 'handler' below is set to 'nullptr' indicating that we want to
     // handle this method asynchronously.
-    this->AddMethod(new grpc::internal::RpcServiceMethod(
+    this->AddMethod(new ::grpc::internal::RpcServiceMethod(
         rpc_handler_info.second.fully_qualified_name.c_str(),
         rpc_handler_info.second.rpc_type, nullptr /* handler */));
   }
@@ -44,11 +45,10 @@ void Service::StartServing(
   int i = 0;
   for (const auto& rpc_handler_info : rpc_handler_infos_) {
     for (auto& completion_queue_thread : completion_queue_threads) {
-      std::shared_ptr<Rpc> rpc =
-          active_rpcs_.Add(cartographer::common::make_unique<Rpc>(
-              i, completion_queue_thread.completion_queue(),
-              event_queue_selector_(), execution_context,
-              rpc_handler_info.second, this, active_rpcs_.GetWeakPtrFactory()));
+      std::shared_ptr<Rpc> rpc = active_rpcs_.Add(common::make_unique<Rpc>(
+          i, completion_queue_thread.completion_queue(),
+          event_queue_selector_(), execution_context, rpc_handler_info.second,
+          this, active_rpcs_.GetWeakPtrFactory()));
       rpc->RequestNextMethodInvocation();
     }
     ++i;
@@ -147,4 +147,5 @@ void Service::RemoveIfNotPending(Rpc* rpc) {
 }
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/framework/service.h
+++ b/cartographer_grpc/internal/framework/service.h
@@ -24,7 +24,8 @@
 #include "cartographer_grpc/internal/framework/rpc_handler.h"
 #include "grpc++/impl/codegen/service_type.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 // A 'Service' represents a generic service for gRPC asynchronous methods and is
@@ -60,6 +61,7 @@ class Service : public ::grpc::Service {
 };
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_FRAMEWORK_SERVICE_H

--- a/cartographer_grpc/internal/framework/testing/rpc_handler_test_server.h
+++ b/cartographer_grpc/internal/framework/testing/rpc_handler_test_server.h
@@ -28,7 +28,8 @@
 #include "grpc++/grpc++.h"
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 namespace testing {
 
@@ -41,8 +42,8 @@ class RpcHandlerTestServer : public Server {
  public:
   RpcHandlerTestServer(std::unique_ptr<ExecutionContext> execution_context)
       : Server(Options{1, 1, kServerAddress}),
-        channel_(grpc::CreateChannel(kServerAddress,
-                                     grpc::InsecureChannelCredentials())),
+        channel_(::grpc::CreateChannel(kServerAddress,
+                                       ::grpc::InsecureChannelCredentials())),
         client_(channel_) {
     std::string method_full_name_under_test =
         RpcHandlerInterface::Instantiate<RpcHandlerType>()->method_name();
@@ -113,7 +114,7 @@ class RpcHandlerTestServer : public Server {
                                     Rpc *const rpc,
                                     ExecutionContext *const execution_context) {
       std::unique_ptr<RpcHandlerInterface> rpc_handler =
-          cartographer::common::make_unique<RpcHandlerWrapper<RpcHandlerType>>(
+          common::make_unique<RpcHandlerWrapper<RpcHandlerType>>(
               event_callback);
       rpc_handler->SetRpc(rpc);
       rpc_handler->SetExecutionContext(execution_context);
@@ -126,14 +127,15 @@ class RpcHandlerTestServer : public Server {
   }
 
   std::shared_ptr<::grpc::Channel> channel_;
-  cartographer_grpc::framework::Client<RpcHandlerType> client_;
-  cartographer::common::BlockingQueue<
+  cloud::framework::Client<RpcHandlerType> client_;
+  common::BlockingQueue<
       typename RpcHandlerWrapper<RpcHandlerType>::RpcHandlerEvent>
       rpc_handler_event_queue_;
 };
 
 }  // namespace testing
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_FRAMEWORK_TESTING_RPC_HANDLER_TEST_SERVER_H_

--- a/cartographer_grpc/internal/framework/testing/rpc_handler_wrapper.h
+++ b/cartographer_grpc/internal/framework/testing/rpc_handler_wrapper.h
@@ -19,7 +19,8 @@
 
 #include <functional>
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 namespace testing {
 
@@ -53,6 +54,7 @@ class RpcHandlerWrapper : public RpcHandlerType {
 
 }  // namespace testing
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_FRAMEWORK_TESTING_RPC_HANDLER_WRAPPER_H_

--- a/cartographer_grpc/internal/framework/type_traits.h
+++ b/cartographer_grpc/internal/framework/type_traits.h
@@ -19,7 +19,8 @@
 
 #include <grpc++/grpc++.h>
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 
 template <typename Request>
@@ -42,28 +43,29 @@ using StripStream = typename Strip<Stream, T>::type;
 
 template <typename Incoming, typename Outgoing>
 struct RpcType
-    : public std::integral_constant<grpc::internal::RpcMethod::RpcType,
-                                    grpc::internal::RpcMethod::NORMAL_RPC> {};
+    : public std::integral_constant<::grpc::internal::RpcMethod::RpcType,
+                                    ::grpc::internal::RpcMethod::NORMAL_RPC> {};
 
 template <typename Incoming, typename Outgoing>
 struct RpcType<Stream<Incoming>, Outgoing>
     : public std::integral_constant<
-          grpc::internal::RpcMethod::RpcType,
-          grpc::internal::RpcMethod::CLIENT_STREAMING> {};
+          ::grpc::internal::RpcMethod::RpcType,
+          ::grpc::internal::RpcMethod::CLIENT_STREAMING> {};
 
 template <typename Incoming, typename Outgoing>
 struct RpcType<Incoming, Stream<Outgoing>>
     : public std::integral_constant<
-          grpc::internal::RpcMethod::RpcType,
-          grpc::internal::RpcMethod::SERVER_STREAMING> {};
+          ::grpc::internal::RpcMethod::RpcType,
+          ::grpc::internal::RpcMethod::SERVER_STREAMING> {};
 
 template <typename Incoming, typename Outgoing>
 struct RpcType<Stream<Incoming>, Stream<Outgoing>>
-    : public std::integral_constant<grpc::internal::RpcMethod::RpcType,
-                                    grpc::internal::RpcMethod::BIDI_STREAMING> {
-};
+    : public std::integral_constant<
+          ::grpc::internal::RpcMethod::RpcType,
+          ::grpc::internal::RpcMethod::BIDI_STREAMING> {};
 
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_FRAMEWORK_TYPES_H

--- a/cartographer_grpc/internal/framework/type_traits_test.cc
+++ b/cartographer_grpc/internal/framework/type_traits_test.cc
@@ -18,7 +18,8 @@
 
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace framework {
 namespace {
 
@@ -40,4 +41,5 @@ TEST(TypeTraitsTest, RpcTypes) {
 
 }  // namespace
 }  // namespace framework
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/add_fixed_frame_pose_data_handler.cc
+++ b/cartographer_grpc/internal/handlers/add_fixed_frame_pose_data_handler.cc
@@ -25,7 +25,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void AddFixedFramePoseDataHandler::OnRequest(
@@ -35,18 +36,18 @@ void AddFixedFramePoseDataHandler::OnRequest(
   // the 'MapBuilderContext'.
   GetUnsynchronizedContext<MapBuilderContextInterface>()->EnqueueSensorData(
       request.sensor_metadata().trajectory_id(),
-      cartographer::sensor::MakeDispatchable(
+      sensor::MakeDispatchable(
           request.sensor_metadata().sensor_id(),
-          cartographer::sensor::FromProto(request.fixed_frame_pose_data())));
+          sensor::FromProto(request.fixed_frame_pose_data())));
 
   // The 'BlockingQueue' in 'LocalTrajectoryUploader' is thread-safe.
   // Therefore it suffices to get an unsynchronized reference to the
   // 'MapBuilderContext'.
   if (GetUnsynchronizedContext<MapBuilderContextInterface>()
           ->local_trajectory_uploader()) {
-    auto data_request = cartographer::common::make_unique<
-        proto::AddFixedFramePoseDataRequest>();
-    sensor::CreateAddFixedFramePoseDataRequest(
+    auto data_request =
+        common::make_unique<proto::AddFixedFramePoseDataRequest>();
+    CreateAddFixedFramePoseDataRequest(
         request.sensor_metadata().sensor_id(),
         request.sensor_metadata().trajectory_id(),
         request.fixed_frame_pose_data(), data_request.get());
@@ -57,8 +58,9 @@ void AddFixedFramePoseDataHandler::OnRequest(
 }
 
 void AddFixedFramePoseDataHandler::OnReadsDone() {
-  Send(cartographer::common::make_unique<google::protobuf::Empty>());
+  Send(common::make_unique<google::protobuf::Empty>());
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/add_fixed_frame_pose_data_handler.h
+++ b/cartographer_grpc/internal/handlers/add_fixed_frame_pose_data_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class AddFixedFramePoseDataHandler
@@ -30,13 +31,14 @@ class AddFixedFramePoseDataHandler
           google::protobuf::Empty> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/AddFixedFramePoseData";
+    return "/cartographer.cloud.proto.MapBuilderService/AddFixedFramePoseData";
   }
   void OnRequest(const proto::AddFixedFramePoseDataRequest &request) override;
   void OnReadsDone() override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_ADD_FIXED_FRAME_POSE_DATA_HANDLER_H

--- a/cartographer_grpc/internal/handlers/add_fixed_frame_pose_data_handler_test.cc
+++ b/cartographer_grpc/internal/handlers/add_fixed_frame_pose_data_handler_test.cc
@@ -20,7 +20,8 @@
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 namespace {
 
@@ -82,4 +83,5 @@ TEST_F(AddFixedFramePoseDataHandlerTest, WithMockLocalSlamUploader) {
 
 }  // namespace
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/add_imu_data_handler.h
+++ b/cartographer_grpc/internal/handlers/add_imu_data_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class AddImuDataHandler
@@ -29,13 +30,14 @@ class AddImuDataHandler
                                    google::protobuf::Empty> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/AddImuData";
+    return "/cartographer.cloud.proto.MapBuilderService/AddImuData";
   }
   void OnRequest(const proto::AddImuDataRequest &request) override;
   void OnReadsDone() override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_ADD_IMU_DATA_HANDLER_H

--- a/cartographer_grpc/internal/handlers/add_imu_data_handler_test.cc
+++ b/cartographer_grpc/internal/handlers/add_imu_data_handler_test.cc
@@ -20,7 +20,8 @@
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 namespace {
 
@@ -79,4 +80,5 @@ TEST_F(AddImuDataHandlerTest, WithMockLocalSlamUploader) {
 
 }  // namespace
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/add_landmark_data_handler.h
+++ b/cartographer_grpc/internal/handlers/add_landmark_data_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class AddLandmarkDataHandler
@@ -30,13 +31,14 @@ class AddLandmarkDataHandler
           google::protobuf::Empty> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/AddLandmarkData";
+    return "/cartographer.cloud.proto.MapBuilderService/AddLandmarkData";
   }
   void OnRequest(const proto::AddLandmarkDataRequest &request) override;
   void OnReadsDone() override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_ADD_LANDMARK_DATA_HANDLER_H

--- a/cartographer_grpc/internal/handlers/add_landmark_data_handler_test.cc
+++ b/cartographer_grpc/internal/handlers/add_landmark_data_handler_test.cc
@@ -20,7 +20,8 @@
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 namespace {
 
@@ -86,4 +87,5 @@ TEST_F(AddLandmarkDataHandlerTest, WithMockLocalSlamUploader) {
 
 }  // namespace
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/add_local_slam_result_data_handler.cc
+++ b/cartographer_grpc/internal/handlers/add_local_slam_result_data_handler.cc
@@ -25,7 +25,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void AddLocalSlamResultDataHandler::OnRequest(
@@ -33,8 +34,7 @@ void AddLocalSlamResultDataHandler::OnRequest(
   auto local_slam_result_data =
       GetContext<MapBuilderContextInterface>()->ProcessLocalSlamResultData(
           request.sensor_metadata().sensor_id(),
-          cartographer::common::FromUniversal(
-              request.local_slam_result_data().timestamp()),
+          common::FromUniversal(request.local_slam_result_data().timestamp()),
           request.local_slam_result_data());
   GetContext<MapBuilderContextInterface>()->EnqueueLocalSlamResultData(
       request.sensor_metadata().trajectory_id(),
@@ -42,8 +42,9 @@ void AddLocalSlamResultDataHandler::OnRequest(
 }
 
 void AddLocalSlamResultDataHandler::OnReadsDone() {
-  Send(cartographer::common::make_unique<google::protobuf::Empty>());
+  Send(common::make_unique<google::protobuf::Empty>());
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/add_local_slam_result_data_handler.h
+++ b/cartographer_grpc/internal/handlers/add_local_slam_result_data_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class AddLocalSlamResultDataHandler
@@ -30,13 +31,14 @@ class AddLocalSlamResultDataHandler
           google::protobuf::Empty> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/AddLocalSlamResultData";
+    return "/cartographer.cloud.proto.MapBuilderService/AddLocalSlamResultData";
   }
   void OnRequest(const proto::AddLocalSlamResultDataRequest& request) override;
   void OnReadsDone() override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_ADD_LOCAL_SLAM_RESULT_DATA_HANDLER_H

--- a/cartographer_grpc/internal/handlers/add_odometry_data_handler.cc
+++ b/cartographer_grpc/internal/handlers/add_odometry_data_handler.cc
@@ -25,7 +25,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void AddOdometryDataHandler::OnRequest(
@@ -35,21 +36,18 @@ void AddOdometryDataHandler::OnRequest(
   // the 'MapBuilderContext'.
   GetUnsynchronizedContext<MapBuilderContextInterface>()->EnqueueSensorData(
       request.sensor_metadata().trajectory_id(),
-      cartographer::sensor::MakeDispatchable(
-          request.sensor_metadata().sensor_id(),
-          cartographer::sensor::FromProto(request.odometry_data())));
+      sensor::MakeDispatchable(request.sensor_metadata().sensor_id(),
+                               sensor::FromProto(request.odometry_data())));
 
   // The 'BlockingQueue' in 'LocalTrajectoryUploader' is thread-safe.
   // Therefore it suffices to get an unsynchronized reference to the
   // 'MapBuilderContext'.
   if (GetUnsynchronizedContext<MapBuilderContextInterface>()
           ->local_trajectory_uploader()) {
-    auto data_request =
-        cartographer::common::make_unique<proto::AddOdometryDataRequest>();
-    sensor::CreateAddOdometryDataRequest(
-        request.sensor_metadata().sensor_id(),
-        request.sensor_metadata().trajectory_id(), request.odometry_data(),
-        data_request.get());
+    auto data_request = common::make_unique<proto::AddOdometryDataRequest>();
+    CreateAddOdometryDataRequest(request.sensor_metadata().sensor_id(),
+                                 request.sensor_metadata().trajectory_id(),
+                                 request.odometry_data(), data_request.get());
     GetUnsynchronizedContext<MapBuilderContextInterface>()
         ->local_trajectory_uploader()
         ->EnqueueDataRequest(std::move(data_request));
@@ -57,8 +55,9 @@ void AddOdometryDataHandler::OnRequest(
 }
 
 void AddOdometryDataHandler::OnReadsDone() {
-  Send(cartographer::common::make_unique<google::protobuf::Empty>());
+  Send(common::make_unique<google::protobuf::Empty>());
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/add_odometry_data_handler.h
+++ b/cartographer_grpc/internal/handlers/add_odometry_data_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class AddOdometryDataHandler
@@ -30,13 +31,14 @@ class AddOdometryDataHandler
           google::protobuf::Empty> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/AddOdometryData";
+    return "/cartographer.cloud.proto.MapBuilderService/AddOdometryData";
   }
   void OnRequest(const proto::AddOdometryDataRequest &request) override;
   void OnReadsDone() override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_ADD_ODOMETRY_DATA_HANDLER_H

--- a/cartographer_grpc/internal/handlers/add_odometry_data_handler_test.cc
+++ b/cartographer_grpc/internal/handlers/add_odometry_data_handler_test.cc
@@ -20,7 +20,8 @@
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 namespace {
 
@@ -81,4 +82,5 @@ TEST_F(AddOdometryDataHandlerTest, WithMockLocalSlamUploader) {
 
 }  // namespace
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/add_rangefinder_data_handler.cc
+++ b/cartographer_grpc/internal/handlers/add_rangefinder_data_handler.cc
@@ -24,7 +24,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void AddRangefinderDataHandler::OnRequest(
@@ -34,14 +35,15 @@ void AddRangefinderDataHandler::OnRequest(
   // the 'MapBuilderContext'.
   GetUnsynchronizedContext<MapBuilderContextInterface>()->EnqueueSensorData(
       request.sensor_metadata().trajectory_id(),
-      cartographer::sensor::MakeDispatchable(
+      sensor::MakeDispatchable(
           request.sensor_metadata().sensor_id(),
-          cartographer::sensor::FromProto(request.timed_point_cloud_data())));
+          sensor::FromProto(request.timed_point_cloud_data())));
 }
 
 void AddRangefinderDataHandler::OnReadsDone() {
-  Send(cartographer::common::make_unique<google::protobuf::Empty>());
+  Send(common::make_unique<google::protobuf::Empty>());
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/add_rangefinder_data_handler.h
+++ b/cartographer_grpc/internal/handlers/add_rangefinder_data_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class AddRangefinderDataHandler
@@ -30,13 +31,14 @@ class AddRangefinderDataHandler
           google::protobuf::Empty> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/AddRangefinderData";
+    return "/cartographer.cloud.proto.MapBuilderService/AddRangefinderData";
   }
   void OnRequest(const proto::AddRangefinderDataRequest &request) override;
   void OnReadsDone() override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_ADD_RANGEFINDER_DATA_HANDLER_H

--- a/cartographer_grpc/internal/handlers/add_rangefinder_data_handler_test.cc
+++ b/cartographer_grpc/internal/handlers/add_rangefinder_data_handler_test.cc
@@ -20,7 +20,8 @@
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 namespace {
 
@@ -62,4 +63,5 @@ TEST_F(AddRangefinderDataHandlerTest, NoLocalSlamUploader) {
 
 }  // namespace
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/add_trajectory_handler.cc
+++ b/cartographer_grpc/internal/handlers/add_trajectory_handler.cc
@@ -22,7 +22,8 @@
 #include "cartographer_grpc/internal/sensor/serialization.h"
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void AddTrajectoryHandler::OnRequest(
@@ -30,10 +31,9 @@ void AddTrajectoryHandler::OnRequest(
   auto local_slam_result_callback =
       GetUnsynchronizedContext<MapBuilderContextInterface>()
           ->GetLocalSlamResultCallbackForSubscriptions();
-  std::set<cartographer::mapping::TrajectoryBuilderInterface::SensorId>
-      expected_sensor_ids;
+  std::set<mapping::TrajectoryBuilderInterface::SensorId> expected_sensor_ids;
   for (const auto& sensor_id : request.expected_sensor_ids()) {
-    expected_sensor_ids.insert(sensor::FromProto(sensor_id));
+    expected_sensor_ids.insert(FromProto(sensor_id));
   }
   const int trajectory_id =
       GetContext<MapBuilderContextInterface>()
@@ -61,11 +61,11 @@ void AddTrajectoryHandler::OnRequest(
                         trajectory_builder_options);
   }
 
-  auto response =
-      cartographer::common::make_unique<proto::AddTrajectoryResponse>();
+  auto response = common::make_unique<proto::AddTrajectoryResponse>();
   response->set_trajectory_id(trajectory_id);
   Send(std::move(response));
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/add_trajectory_handler.h
+++ b/cartographer_grpc/internal/handlers/add_trajectory_handler.h
@@ -20,7 +20,8 @@
 #include "cartographer_grpc/internal/framework/rpc_handler.h"
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class AddTrajectoryHandler
@@ -28,12 +29,13 @@ class AddTrajectoryHandler
                                    proto::AddTrajectoryResponse> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/AddTrajectory";
+    return "/cartographer.cloud.proto.MapBuilderService/AddTrajectory";
   }
   void OnRequest(const proto::AddTrajectoryRequest& request) override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_ADD_TRAJECTORY_HANDLER_H

--- a/cartographer_grpc/internal/handlers/add_trajectory_handler_test.cc
+++ b/cartographer_grpc/internal/handlers/add_trajectory_handler_test.cc
@@ -22,7 +22,8 @@
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 namespace {
 
@@ -69,8 +70,7 @@ class AddTrajectoryHandlerTest
  public:
   void SetUp() override {
     testing::HandlerTest<AddTrajectoryHandler>::SetUp();
-    mock_map_builder_ =
-        cartographer::common::make_unique<testing::MockMapBuilder>();
+    mock_map_builder_ = common::make_unique<testing::MockMapBuilder>();
     EXPECT_CALL(*mock_map_builder_context_,
                 GetLocalSlamResultCallbackForSubscriptions())
         .WillOnce(Return(nullptr));
@@ -79,12 +79,11 @@ class AddTrajectoryHandlerTest
   }
 
  protected:
-  std::set<cartographer::mapping::TrajectoryBuilderInterface::SensorId>
-  ParseSensorIds(const proto::AddTrajectoryRequest &request) {
-    std::set<cartographer::mapping::TrajectoryBuilderInterface::SensorId>
-        expected_sensor_ids;
+  std::set<mapping::TrajectoryBuilderInterface::SensorId> ParseSensorIds(
+      const proto::AddTrajectoryRequest &request) {
+    std::set<mapping::TrajectoryBuilderInterface::SensorId> expected_sensor_ids;
     for (const auto &sensor_id : request.expected_sensor_ids()) {
-      expected_sensor_ids.insert(sensor::FromProto(sensor_id));
+      expected_sensor_ids.insert(cloud::FromProto(sensor_id));
     }
     return expected_sensor_ids;
   }
@@ -133,4 +132,5 @@ TEST_F(AddTrajectoryHandlerTest, WithLocalSlamUploader) {
 
 }  // namespace
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/finish_trajectory_handler.cc
+++ b/cartographer_grpc/internal/handlers/finish_trajectory_handler.cc
@@ -22,7 +22,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void FinishTrajectoryHandler::OnRequest(
@@ -37,8 +38,9 @@ void FinishTrajectoryHandler::OnRequest(
         ->local_trajectory_uploader()
         ->FinishTrajectory(request.trajectory_id());
   }
-  Send(cartographer::common::make_unique<google::protobuf::Empty>());
+  Send(common::make_unique<google::protobuf::Empty>());
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/finish_trajectory_handler.h
+++ b/cartographer_grpc/internal/handlers/finish_trajectory_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class FinishTrajectoryHandler
@@ -29,12 +30,13 @@ class FinishTrajectoryHandler
                                    google::protobuf::Empty> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/FinishTrajectory";
+    return "/cartographer.cloud.proto.MapBuilderService/FinishTrajectory";
   }
   void OnRequest(const proto::FinishTrajectoryRequest& request) override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_FINISH_TRAJECTORY_HANDLER_H

--- a/cartographer_grpc/internal/handlers/get_all_submap_poses.cc
+++ b/cartographer_grpc/internal/handlers/get_all_submap_poses.cc
@@ -22,7 +22,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void GetAllSubmapPosesHandler::OnRequest(
@@ -31,17 +32,17 @@ void GetAllSubmapPosesHandler::OnRequest(
                           ->map_builder()
                           .pose_graph()
                           ->GetAllSubmapPoses();
-  auto response =
-      cartographer::common::make_unique<proto::GetAllSubmapPosesResponse>();
+  auto response = common::make_unique<proto::GetAllSubmapPosesResponse>();
   for (const auto& submap_id_pose : submap_poses) {
     auto* submap_pose = response->add_submap_poses();
     submap_id_pose.id.ToProto(submap_pose->mutable_submap_id());
     submap_pose->set_submap_version(submap_id_pose.data.version);
     *submap_pose->mutable_global_pose() =
-        cartographer::transform::ToProto(submap_id_pose.data.pose);
+        transform::ToProto(submap_id_pose.data.pose);
   }
   Send(std::move(response));
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/get_all_submap_poses.h
+++ b/cartographer_grpc/internal/handlers/get_all_submap_poses.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class GetAllSubmapPosesHandler
@@ -29,12 +30,13 @@ class GetAllSubmapPosesHandler
                                    proto::GetAllSubmapPosesResponse> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/GetAllSubmapPoses";
+    return "/cartographer.cloud.proto.MapBuilderService/GetAllSubmapPoses";
   }
   void OnRequest(const google::protobuf::Empty& request) override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_GET_ALL_SUBMAP_POSES_H

--- a/cartographer_grpc/internal/handlers/get_constraints_handler.cc
+++ b/cartographer_grpc/internal/handlers/get_constraints_handler.cc
@@ -23,7 +23,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void GetConstraintsHandler::OnRequest(const google::protobuf::Empty& request) {
@@ -31,14 +32,14 @@ void GetConstraintsHandler::OnRequest(const google::protobuf::Empty& request) {
                          ->map_builder()
                          .pose_graph()
                          ->constraints();
-  auto response =
-      cartographer::common::make_unique<proto::GetConstraintsResponse>();
+  auto response = common::make_unique<proto::GetConstraintsResponse>();
   response->mutable_constraints()->Reserve(constraints.size());
   for (const auto& constraint : constraints) {
-    *response->add_constraints() = cartographer::mapping::ToProto(constraint);
+    *response->add_constraints() = mapping::ToProto(constraint);
   }
   Send(std::move(response));
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/get_constraints_handler.h
+++ b/cartographer_grpc/internal/handlers/get_constraints_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class GetConstraintsHandler
@@ -29,12 +30,13 @@ class GetConstraintsHandler
                                    proto::GetConstraintsResponse> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/GetConstraints";
+    return "/cartographer.cloud.proto.MapBuilderService/GetConstraints";
   }
   void OnRequest(const google::protobuf::Empty& request) override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_GET_CONSTRAINTS_HANDLER_H

--- a/cartographer_grpc/internal/handlers/get_landmark_poses_handler.cc
+++ b/cartographer_grpc/internal/handlers/get_landmark_poses_handler.cc
@@ -22,7 +22,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void GetLandmarkPosesHandler::OnRequest(
@@ -31,16 +32,15 @@ void GetLandmarkPosesHandler::OnRequest(
                             ->map_builder()
                             .pose_graph()
                             ->GetLandmarkPoses();
-  auto response =
-      cartographer::common::make_unique<proto::GetLandmarkPosesResponse>();
+  auto response = common::make_unique<proto::GetLandmarkPosesResponse>();
   for (const auto& landmark_pose : landmark_poses) {
     auto* landmark = response->add_landmark_poses();
     landmark->set_landmark_id(landmark_pose.first);
-    *landmark->mutable_global_pose() =
-        cartographer::transform::ToProto(landmark_pose.second);
+    *landmark->mutable_global_pose() = transform::ToProto(landmark_pose.second);
   }
   Send(std::move(response));
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/get_landmark_poses_handler.h
+++ b/cartographer_grpc/internal/handlers/get_landmark_poses_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class GetLandmarkPosesHandler
@@ -29,12 +30,13 @@ class GetLandmarkPosesHandler
                                    proto::GetLandmarkPosesResponse> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/GetLandmarkPoses";
+    return "/cartographer.cloud.proto.MapBuilderService/GetLandmarkPoses";
   }
   void OnRequest(const google::protobuf::Empty& request) override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_GET_LANDMARK_POSES_HANDLER_H

--- a/cartographer_grpc/internal/handlers/get_landmark_poses_handler_test.cc
+++ b/cartographer_grpc/internal/handlers/get_landmark_poses_handler_test.cc
@@ -20,7 +20,8 @@
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 namespace {
 
@@ -78,4 +79,5 @@ TEST_F(GetLandmarkPosesHandlerTest, NoLocalSlamUploader) {
 
 }  // namespace
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/get_local_to_global_transform_handler.cc
+++ b/cartographer_grpc/internal/handlers/get_local_to_global_transform_handler.cc
@@ -21,22 +21,23 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void GetLocalToGlobalTransformHandler::OnRequest(
     const proto::GetLocalToGlobalTransformRequest& request) {
-  auto response = cartographer::common::make_unique<
-      proto::GetLocalToGlobalTransformResponse>();
+  auto response =
+      common::make_unique<proto::GetLocalToGlobalTransformResponse>();
   auto local_to_global =
       GetContext<MapBuilderContextInterface>()
           ->map_builder()
           .pose_graph()
           ->GetLocalToGlobalTransform(request.trajectory_id());
-  *response->mutable_local_to_global() =
-      cartographer::transform::ToProto(local_to_global);
+  *response->mutable_local_to_global() = transform::ToProto(local_to_global);
   Send(std::move(response));
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/get_local_to_global_transform_handler.h
+++ b/cartographer_grpc/internal/handlers/get_local_to_global_transform_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class GetLocalToGlobalTransformHandler
@@ -29,7 +30,7 @@ class GetLocalToGlobalTransformHandler
                                    proto::GetLocalToGlobalTransformResponse> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/"
+    return "/cartographer.cloud.proto.MapBuilderService/"
            "GetLocalToGlobalTransform";
   }
   void OnRequest(
@@ -37,6 +38,7 @@ class GetLocalToGlobalTransformHandler
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_GET_LOCAL_TO_GLOBAL_TRANSFORM_HANDLER_H

--- a/cartographer_grpc/internal/handlers/get_submap_handler.cc
+++ b/cartographer_grpc/internal/handlers/get_submap_handler.cc
@@ -22,18 +22,20 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void GetSubmapHandler::OnRequest(const proto::GetSubmapRequest &request) {
-  auto response = cartographer::common::make_unique<proto::GetSubmapResponse>();
+  auto response = common::make_unique<proto::GetSubmapResponse>();
   response->set_error_msg(
       GetContext<MapBuilderContextInterface>()->map_builder().SubmapToProto(
-          cartographer::mapping::SubmapId{request.submap_id().trajectory_id(),
-                                          request.submap_id().submap_index()},
+          mapping::SubmapId{request.submap_id().trajectory_id(),
+                            request.submap_id().submap_index()},
           response->mutable_submap_query_response()));
   Send(std::move(response));
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/get_submap_handler.h
+++ b/cartographer_grpc/internal/handlers/get_submap_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class GetSubmapHandler
@@ -29,12 +30,13 @@ class GetSubmapHandler
                                    proto::GetSubmapResponse> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/GetSubmap";
+    return "/cartographer.cloud.proto.MapBuilderService/GetSubmap";
   }
   void OnRequest(const proto::GetSubmapRequest &request) override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_GET_SUBMAP_HANDLER_H

--- a/cartographer_grpc/internal/handlers/get_trajectory_node_poses_handler.cc
+++ b/cartographer_grpc/internal/handlers/get_trajectory_node_poses_handler.cc
@@ -22,7 +22,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void GetTrajectoryNodePosesHandler::OnRequest(
@@ -31,17 +32,17 @@ void GetTrajectoryNodePosesHandler::OnRequest(
                         ->map_builder()
                         .pose_graph()
                         ->GetTrajectoryNodePoses();
-  auto response = cartographer::common::make_unique<
-      proto::GetTrajectoryNodePosesResponse>();
+  auto response = common::make_unique<proto::GetTrajectoryNodePosesResponse>();
   for (const auto& node_id_pose : node_poses) {
     auto* node_pose = response->add_node_poses();
     node_id_pose.id.ToProto(node_pose->mutable_node_id());
     *node_pose->mutable_global_pose() =
-        cartographer::transform::ToProto(node_id_pose.data.global_pose);
+        transform::ToProto(node_id_pose.data.global_pose);
     node_pose->set_has_constant_data(node_id_pose.data.has_constant_data);
   }
   Send(std::move(response));
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/get_trajectory_node_poses_handler.h
+++ b/cartographer_grpc/internal/handlers/get_trajectory_node_poses_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class GetTrajectoryNodePosesHandler
@@ -29,12 +30,13 @@ class GetTrajectoryNodePosesHandler
                                    proto::GetTrajectoryNodePosesResponse> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/GetTrajectoryNodePoses";
+    return "/cartographer.cloud.proto.MapBuilderService/GetTrajectoryNodePoses";
   }
   void OnRequest(const google::protobuf::Empty& request) override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_GET_TRAJECTORY_NODE_POSES_HANDLER_H

--- a/cartographer_grpc/internal/handlers/load_state_handler.cc
+++ b/cartographer_grpc/internal/handlers/load_state_handler.cc
@@ -23,7 +23,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void LoadStateHandler::OnRequest(const proto::LoadStateRequest& request) {
@@ -45,8 +46,9 @@ void LoadStateHandler::OnRequest(const proto::LoadStateRequest& request) {
 void LoadStateHandler::OnReadsDone() {
   GetContext<MapBuilderContextInterface>()->map_builder().LoadState(&reader_,
                                                                     true);
-  Send(cartographer::common::make_unique<google::protobuf::Empty>());
+  Send(common::make_unique<google::protobuf::Empty>());
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/load_state_handler.h
+++ b/cartographer_grpc/internal/handlers/load_state_handler.h
@@ -22,7 +22,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class LoadStateHandler
@@ -30,16 +31,17 @@ class LoadStateHandler
                                    google::protobuf::Empty> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/LoadState";
+    return "/cartographer.cloud.proto.MapBuilderService/LoadState";
   }
   void OnRequest(const proto::LoadStateRequest& request) override;
   void OnReadsDone() override;
 
  private:
-  cartographer::io::InMemoryProtoStreamReader reader_;
+  io::InMemoryProtoStreamReader reader_;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_LOAD_STATE_HANDLER_H

--- a/cartographer_grpc/internal/handlers/receive_local_slam_results_handler.cc
+++ b/cartographer_grpc/internal/handlers/receive_local_slam_results_handler.cc
@@ -21,23 +21,22 @@
 #include "cartographer_grpc/internal/map_builder_context_interface.h"
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 namespace {
 
 std::unique_ptr<proto::ReceiveLocalSlamResultsResponse> GenerateResponse(
     std::unique_ptr<MapBuilderContextInterface::LocalSlamResult>
         local_slam_result) {
-  auto response = cartographer::common::make_unique<
-      proto::ReceiveLocalSlamResultsResponse>();
+  auto response = common::make_unique<proto::ReceiveLocalSlamResultsResponse>();
   response->set_trajectory_id(local_slam_result->trajectory_id);
-  response->set_timestamp(
-      cartographer::common::ToUniversal(local_slam_result->time));
+  response->set_timestamp(common::ToUniversal(local_slam_result->time));
   *response->mutable_local_pose() =
-      cartographer::transform::ToProto(local_slam_result->local_pose);
+      transform::ToProto(local_slam_result->local_pose);
   if (local_slam_result->range_data) {
     *response->mutable_range_data() =
-        cartographer::sensor::ToProto(*local_slam_result->range_data);
+        sensor::ToProto(*local_slam_result->range_data);
   }
   if (local_slam_result->insertion_result) {
     local_slam_result->insertion_result->node_id.ToProto(
@@ -67,8 +66,9 @@ void ReceiveLocalSlamResultsHandler::OnRequest(
                 }
               });
 
-  subscription_id_ = cartographer::common::make_unique<
-      MapBuilderContextInterface::SubscriptionId>(subscription_id);
+  subscription_id_ =
+      common::make_unique<MapBuilderContextInterface::SubscriptionId>(
+          subscription_id);
 }
 
 void ReceiveLocalSlamResultsHandler::OnFinish() {
@@ -79,4 +79,5 @@ void ReceiveLocalSlamResultsHandler::OnFinish() {
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/receive_local_slam_results_handler.h
+++ b/cartographer_grpc/internal/handlers/receive_local_slam_results_handler.h
@@ -23,7 +23,8 @@
 #include "cartographer_grpc/internal/map_builder_context_interface.h"
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class ReceiveLocalSlamResultsHandler
@@ -32,7 +33,8 @@ class ReceiveLocalSlamResultsHandler
           framework::Stream<proto::ReceiveLocalSlamResultsResponse>> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/ReceiveLocalSlamResults";
+    return "/cartographer.cloud.proto.MapBuilderService/"
+           "ReceiveLocalSlamResults";
   }
   void OnRequest(const proto::ReceiveLocalSlamResultsRequest& request) override;
   void OnFinish() override;
@@ -42,6 +44,7 @@ class ReceiveLocalSlamResultsHandler
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_RECEIVE_LOCAL_SLAM_RESULTS_HANDLER_H

--- a/cartographer_grpc/internal/handlers/run_final_optimization_handler.cc
+++ b/cartographer_grpc/internal/handlers/run_final_optimization_handler.cc
@@ -24,7 +24,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void RunFinalOptimizationHandler::OnRequest(
@@ -33,8 +34,9 @@ void RunFinalOptimizationHandler::OnRequest(
       ->map_builder()
       .pose_graph()
       ->RunFinalOptimization();
-  Send(cartographer::common::make_unique<google::protobuf::Empty>());
+  Send(common::make_unique<google::protobuf::Empty>());
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/run_final_optimization_handler.h
+++ b/cartographer_grpc/internal/handlers/run_final_optimization_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class RunFinalOptimizationHandler
@@ -29,12 +30,13 @@ class RunFinalOptimizationHandler
                                    google::protobuf::Empty> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/RunFinalOptimization";
+    return "/cartographer.cloud.proto.MapBuilderService/RunFinalOptimization";
   }
   void OnRequest(const google::protobuf::Empty& request) override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_RUN_FINAL_OPTIMIZATION_H

--- a/cartographer_grpc/internal/handlers/write_state_handler.cc
+++ b/cartographer_grpc/internal/handlers/write_state_handler.cc
@@ -23,20 +23,20 @@
 #include "cartographer_grpc/internal/map_builder_server.h"
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 void WriteStateHandler::OnRequest(const google::protobuf::Empty& request) {
   auto writer = GetWriter();
-  cartographer::io::ForwardingProtoStreamWriter proto_stream_writer(
+  io::ForwardingProtoStreamWriter proto_stream_writer(
       [writer](const google::protobuf::Message* proto) {
         if (!proto) {
           writer.WritesDone();
           return true;
         }
 
-        auto response =
-            cartographer::common::make_unique<proto::WriteStateResponse>();
+        auto response = common::make_unique<proto::WriteStateResponse>();
         if (proto->GetTypeName() == "cartographer.mapping.proto.PoseGraph") {
           response->mutable_pose_graph()->CopyFrom(*proto);
         } else if (proto->GetTypeName() ==
@@ -56,4 +56,5 @@ void WriteStateHandler::OnRequest(const google::protobuf::Empty& request) {
 }
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/handlers/write_state_handler.h
+++ b/cartographer_grpc/internal/handlers/write_state_handler.h
@@ -21,7 +21,8 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/empty.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace handlers {
 
 class WriteStateHandler : public framework::RpcHandler<
@@ -29,12 +30,13 @@ class WriteStateHandler : public framework::RpcHandler<
                               framework::Stream<proto::WriteStateResponse>> {
  public:
   std::string method_name() const override {
-    return "/cartographer_grpc.proto.MapBuilderService/WriteState";
+    return "/cartographer.cloud.proto.MapBuilderService/WriteState";
   }
   void OnRequest(const google::protobuf::Empty& request) override;
 };
 
 }  // namespace handlers
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_HANDLERS_WRITE_STATE_HANDLER_H

--- a/cartographer_grpc/internal/local_trajectory_uploader.h
+++ b/cartographer_grpc/internal/local_trajectory_uploader.h
@@ -24,11 +24,12 @@
 #include "cartographer/mapping/proto/trajectory_builder_options.pb.h"
 #include "cartographer/mapping/trajectory_builder_interface.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 
 class LocalTrajectoryUploaderInterface {
  public:
-  using SensorId = cartographer::mapping::TrajectoryBuilderInterface::SensorId;
+  using SensorId = mapping::TrajectoryBuilderInterface::SensorId;
 
   virtual ~LocalTrajectoryUploaderInterface() = default;
 
@@ -44,8 +45,7 @@ class LocalTrajectoryUploaderInterface {
       std::unique_ptr<google::protobuf::Message> data_request) = 0;
   virtual void AddTrajectory(
       int local_trajectory_id, const std::set<SensorId>& expected_sensor_ids,
-      const cartographer::mapping::proto::TrajectoryBuilderOptions&
-          trajectory_options) = 0;
+      const mapping::proto::TrajectoryBuilderOptions& trajectory_options) = 0;
   virtual void FinishTrajectory(int local_trajectory_id) = 0;
 
   virtual SensorId GetLocalSlamResultSensorId(
@@ -56,6 +56,7 @@ class LocalTrajectoryUploaderInterface {
 std::unique_ptr<LocalTrajectoryUploaderInterface> CreateLocalTrajectoryUploader(
     const std::string& uplink_server_address);
 
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_LOCAL_TRAJECTORY_UPLOADER_H

--- a/cartographer_grpc/internal/map_builder_context.h
+++ b/cartographer_grpc/internal/map_builder_context.h
@@ -21,15 +21,15 @@
 #include "cartographer/mapping/3d/submap_3d.h"
 #include "cartographer_grpc/internal/map_builder_context_interface.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 
 class MapBuilderContext : public MapBuilderContextInterface {
  public:
   MapBuilderContext(MapBuilderServer* map_builder_server);
-  cartographer::mapping::MapBuilderInterface& map_builder() override;
-  cartographer::common::BlockingQueue<std::unique_ptr<Data>>&
-  sensor_data_queue() override;
-  cartographer::mapping::TrajectoryBuilderInterface::LocalSlamResultCallback
+  mapping::MapBuilderInterface& map_builder() override;
+  common::BlockingQueue<std::unique_ptr<Data>>& sensor_data_queue() override;
+  mapping::TrajectoryBuilderInterface::LocalSlamResultCallback
   GetLocalSlamResultCallbackForSubscriptions() override;
   void AddSensorDataToTrajectory(const Data& sensor_data) override;
   SubscriptionId SubscribeLocalSlamResults(
@@ -37,31 +37,29 @@ class MapBuilderContext : public MapBuilderContextInterface {
   void UnsubscribeLocalSlamResults(
       const SubscriptionId& subscription_id) override;
   void NotifyFinishTrajectory(int trajectory_id) override;
-  std::unique_ptr<cartographer::mapping::LocalSlamResultData>
-  ProcessLocalSlamResultData(
-      const std::string& sensor_id, cartographer::common::Time time,
-      const cartographer::mapping::proto::LocalSlamResultData& proto) override;
+  std::unique_ptr<mapping::LocalSlamResultData> ProcessLocalSlamResultData(
+      const std::string& sensor_id, common::Time time,
+      const mapping::proto::LocalSlamResultData& proto) override;
   LocalTrajectoryUploaderInterface* local_trajectory_uploader() override;
-  void EnqueueSensorData(
-      int trajectory_id,
-      std::unique_ptr<cartographer::sensor::Data> data) override;
-  void EnqueueLocalSlamResultData(
-      int trajectory_id, const std::string& sensor_id,
-      std::unique_ptr<cartographer::mapping::LocalSlamResultData>
-          local_slam_result_data) override;
+  void EnqueueSensorData(int trajectory_id,
+                         std::unique_ptr<sensor::Data> data) override;
+  void EnqueueLocalSlamResultData(int trajectory_id,
+                                  const std::string& sensor_id,
+                                  std::unique_ptr<mapping::LocalSlamResultData>
+                                      local_slam_result_data) override;
 
  private:
-  std::shared_ptr<cartographer::mapping::Submap2D> UpdateSubmap2D(
-      const cartographer::mapping::proto::Submap& proto);
-  std::shared_ptr<cartographer::mapping::Submap3D> UpdateSubmap3D(
-      const cartographer::mapping::proto::Submap& proto);
+  std::shared_ptr<mapping::Submap2D> UpdateSubmap2D(
+      const mapping::proto::Submap& proto);
+  std::shared_ptr<mapping::Submap3D> UpdateSubmap3D(
+      const mapping::proto::Submap& proto);
 
   MapBuilderServer* map_builder_server_;
-  cartographer::mapping::MapById<cartographer::mapping::SubmapId,
-                                 std::shared_ptr<cartographer::mapping::Submap>>
+  mapping::MapById<mapping::SubmapId, std::shared_ptr<mapping::Submap>>
       unfinished_submaps_;
 };
 
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_MAP_BUILDER_CONTEXT_H

--- a/cartographer_grpc/internal/map_builder_context_interface.h
+++ b/cartographer_grpc/internal/map_builder_context_interface.h
@@ -25,18 +25,18 @@
 #include "cartographer_grpc/internal/framework/execution_context.h"
 #include "cartographer_grpc/internal/local_trajectory_uploader.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 
 class MapBuilderServer;
 class MapBuilderContextInterface : public framework::ExecutionContext {
  public:
   struct LocalSlamResult {
     int trajectory_id;
-    cartographer::common::Time time;
-    cartographer::transform::Rigid3d local_pose;
-    std::shared_ptr<const cartographer::sensor::RangeData> range_data;
-    std::unique_ptr<const cartographer::mapping::TrajectoryBuilderInterface::
-                        InsertionResult>
+    common::Time time;
+    transform::Rigid3d local_pose;
+    std::shared_ptr<const sensor::RangeData> range_data;
+    std::unique_ptr<const mapping::TrajectoryBuilderInterface::InsertionResult>
         insertion_result;
   };
   // Calling with 'nullptr' signals subscribers that the subscription has ended.
@@ -44,7 +44,7 @@ class MapBuilderContextInterface : public framework::ExecutionContext {
       std::function<void(std::unique_ptr<LocalSlamResult>)>;
   struct Data {
     int trajectory_id;
-    std::unique_ptr<cartographer::sensor::Data> data;
+    std::unique_ptr<sensor::Data> data;
   };
   struct SubscriptionId {
     const int trajectory_id;
@@ -58,31 +58,29 @@ class MapBuilderContextInterface : public framework::ExecutionContext {
   MapBuilderContextInterface& operator=(const MapBuilderContextInterface&) =
       delete;
 
-  virtual cartographer::mapping::MapBuilderInterface& map_builder() = 0;
-  virtual cartographer::common::BlockingQueue<std::unique_ptr<Data>>&
-  sensor_data_queue() = 0;
-  virtual cartographer::mapping::TrajectoryBuilderInterface::
-      LocalSlamResultCallback
-      GetLocalSlamResultCallbackForSubscriptions() = 0;
+  virtual mapping::MapBuilderInterface& map_builder() = 0;
+  virtual common::BlockingQueue<std::unique_ptr<Data>>& sensor_data_queue() = 0;
+  virtual mapping::TrajectoryBuilderInterface::LocalSlamResultCallback
+  GetLocalSlamResultCallbackForSubscriptions() = 0;
   virtual void AddSensorDataToTrajectory(const Data& sensor_data) = 0;
   virtual SubscriptionId SubscribeLocalSlamResults(
       int trajectory_id, LocalSlamSubscriptionCallback callback) = 0;
   virtual void UnsubscribeLocalSlamResults(
       const SubscriptionId& subscription_id) = 0;
   virtual void NotifyFinishTrajectory(int trajectory_id) = 0;
-  virtual std::unique_ptr<cartographer::mapping::LocalSlamResultData>
+  virtual std::unique_ptr<mapping::LocalSlamResultData>
   ProcessLocalSlamResultData(
-      const std::string& sensor_id, cartographer::common::Time time,
-      const cartographer::mapping::proto::LocalSlamResultData& proto) = 0;
+      const std::string& sensor_id, common::Time time,
+      const mapping::proto::LocalSlamResultData& proto) = 0;
   virtual LocalTrajectoryUploaderInterface* local_trajectory_uploader() = 0;
-  virtual void EnqueueSensorData(
-      int trajectory_id, std::unique_ptr<cartographer::sensor::Data> data) = 0;
+  virtual void EnqueueSensorData(int trajectory_id,
+                                 std::unique_ptr<sensor::Data> data) = 0;
   virtual void EnqueueLocalSlamResultData(
       int trajectory_id, const std::string& sensor_id,
-      std::unique_ptr<cartographer::mapping::LocalSlamResultData>
-          local_slam_result_data) = 0;
+      std::unique_ptr<mapping::LocalSlamResultData> local_slam_result_data) = 0;
 };
 
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_MAP_BUILDER_CONTEXT_INTERFACE_H

--- a/cartographer_grpc/internal/map_builder_server.h
+++ b/cartographer_grpc/internal/map_builder_server.h
@@ -30,7 +30,8 @@
 #include "cartographer_grpc/map_builder_server_interface.h"
 #include "cartographer_grpc/proto/map_builder_server_options.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 
 class MapBuilderServer : public MapBuilderServerInterface {
  public:
@@ -38,7 +39,7 @@ class MapBuilderServer : public MapBuilderServerInterface {
 
   MapBuilderServer(
       const proto::MapBuilderServerOptions& map_builder_server_options,
-      std::unique_ptr<cartographer::mapping::MapBuilderInterface> map_builder);
+      std::unique_ptr<mapping::MapBuilderInterface> map_builder);
   ~MapBuilderServer() {}
 
   // Starts the gRPC server, the 'LocalTrajectoryUploader' and the SLAM thread.
@@ -64,11 +65,10 @@ class MapBuilderServer : public MapBuilderServerInterface {
   void ProcessSensorDataQueue();
   void StartSlamThread();
   void OnLocalSlamResult(
-      int trajectory_id, cartographer::common::Time time,
-      cartographer::transform::Rigid3d local_pose,
-      cartographer::sensor::RangeData range_data,
-      std::unique_ptr<const cartographer::mapping::TrajectoryBuilderInterface::
-                          InsertionResult>
+      int trajectory_id, common::Time time, transform::Rigid3d local_pose,
+      sensor::RangeData range_data,
+      std::unique_ptr<
+          const mapping::TrajectoryBuilderInterface::InsertionResult>
           insertion_result);
   MapBuilderContextInterface::SubscriptionId SubscribeLocalSlamResults(
       int trajectory_id,
@@ -80,11 +80,10 @@ class MapBuilderServer : public MapBuilderServerInterface {
   bool shutting_down_ = false;
   std::unique_ptr<std::thread> slam_thread_;
   std::unique_ptr<framework::Server> grpc_server_;
-  std::unique_ptr<cartographer::mapping::MapBuilderInterface> map_builder_;
-  cartographer::common::BlockingQueue<
-      std::unique_ptr<MapBuilderContextInterface::Data>>
+  std::unique_ptr<mapping::MapBuilderInterface> map_builder_;
+  common::BlockingQueue<std::unique_ptr<MapBuilderContextInterface::Data>>
       incoming_data_queue_;
-  cartographer::common::Mutex local_slam_subscriptions_lock_;
+  common::Mutex local_slam_subscriptions_lock_;
   int current_subscription_index_ = 0;
   std::map<int /* trajectory ID */, LocalSlamResultHandlerSubscriptions>
       local_slam_subscriptions_ GUARDED_BY(local_slam_subscriptions_lock_);
@@ -92,6 +91,7 @@ class MapBuilderServer : public MapBuilderServerInterface {
   int starting_submap_index_ = 0;
 };
 
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_MAP_BUILDER_SERVER_H

--- a/cartographer_grpc/internal/sensor/serialization.cc
+++ b/cartographer_grpc/internal/sensor/serialization.cc
@@ -16,8 +16,8 @@
 
 #include "cartographer_grpc/internal/sensor/serialization.h"
 
-namespace cartographer_grpc {
-namespace sensor {
+namespace cartographer {
+namespace cloud {
 
 void CreateSensorMetadata(const std::string& sensor_id, const int trajectory_id,
                           proto::SensorMetadata* proto) {
@@ -27,18 +27,17 @@ void CreateSensorMetadata(const std::string& sensor_id, const int trajectory_id,
 
 void CreateAddFixedFramePoseDataRequest(
     const std::string& sensor_id, int trajectory_id,
-    const cartographer::sensor::proto::FixedFramePoseData&
-        fixed_frame_pose_data,
+    const sensor::proto::FixedFramePoseData& fixed_frame_pose_data,
     proto::AddFixedFramePoseDataRequest* proto) {
   CreateSensorMetadata(sensor_id, trajectory_id,
                        proto->mutable_sensor_metadata());
   *proto->mutable_fixed_frame_pose_data() = fixed_frame_pose_data;
 }
 
-void CreateAddImuDataRequest(
-    const std::string& sensor_id, const int trajectory_id,
-    const cartographer::sensor::proto::ImuData& imu_data,
-    proto::AddImuDataRequest* proto) {
+void CreateAddImuDataRequest(const std::string& sensor_id,
+                             const int trajectory_id,
+                             const sensor::proto::ImuData& imu_data,
+                             proto::AddImuDataRequest* proto) {
   CreateSensorMetadata(sensor_id, trajectory_id,
                        proto->mutable_sensor_metadata());
   *proto->mutable_imu_data() = imu_data;
@@ -46,7 +45,7 @@ void CreateAddImuDataRequest(
 
 void CreateAddOdometryDataRequest(
     const std::string& sensor_id, int trajectory_id,
-    const cartographer::sensor::proto::OdometryData& odometry_data,
+    const sensor::proto::OdometryData& odometry_data,
     proto::AddOdometryDataRequest* proto) {
   CreateSensorMetadata(sensor_id, trajectory_id,
                        proto->mutable_sensor_metadata());
@@ -55,8 +54,7 @@ void CreateAddOdometryDataRequest(
 
 void CreateAddRangeFinderDataRequest(
     const std::string& sensor_id, int trajectory_id,
-    const cartographer::sensor::proto::TimedPointCloudData&
-        timed_point_cloud_data,
+    const sensor::proto::TimedPointCloudData& timed_point_cloud_data,
     proto::AddRangefinderDataRequest* proto) {
   CreateSensorMetadata(sensor_id, trajectory_id,
                        proto->mutable_sensor_metadata());
@@ -65,7 +63,7 @@ void CreateAddRangeFinderDataRequest(
 
 void CreateAddLandmarkDataRequest(
     const std::string& sensor_id, int trajectory_id,
-    const cartographer::sensor::proto::LandmarkData& landmark_data,
+    const sensor::proto::LandmarkData& landmark_data,
     proto::AddLandmarkDataRequest* proto) {
   CreateSensorMetadata(sensor_id, trajectory_id,
                        proto->mutable_sensor_metadata());
@@ -73,17 +71,17 @@ void CreateAddLandmarkDataRequest(
 }
 
 void CreateAddLocalSlamResultDataRequest(
-    const std::string& sensor_id, int trajectory_id,
-    cartographer::common::Time time, int starting_submap_index,
-    const cartographer::mapping::TrajectoryBuilderInterface::InsertionResult&
+    const std::string& sensor_id, int trajectory_id, common::Time time,
+    int starting_submap_index,
+    const mapping::TrajectoryBuilderInterface::InsertionResult&
         insertion_result,
     proto::AddLocalSlamResultDataRequest* proto) {
-  sensor::CreateSensorMetadata(sensor_id, trajectory_id,
-                               proto->mutable_sensor_metadata());
+  CreateSensorMetadata(sensor_id, trajectory_id,
+                       proto->mutable_sensor_metadata());
   proto->mutable_local_slam_result_data()->set_timestamp(
-      cartographer::common::ToUniversal(time));
+      common::ToUniversal(time));
   *proto->mutable_local_slam_result_data()->mutable_node_data() =
-      cartographer::mapping::ToProto(*insertion_result.constant_data);
+      mapping::ToProto(*insertion_result.constant_data);
   for (const auto& insertion_submap : insertion_result.insertion_submaps) {
     // We only send the probability grid up if the submap is finished.
     auto* submap = proto->mutable_local_slam_result_data()->add_submaps();
@@ -95,10 +93,8 @@ void CreateAddLocalSlamResultDataRequest(
 }
 
 proto::SensorId ToProto(
-    const cartographer::mapping::TrajectoryBuilderInterface::SensorId&
-        sensor_id) {
-  using SensorType =
-      cartographer::mapping::TrajectoryBuilderInterface::SensorId::SensorType;
+    const mapping::TrajectoryBuilderInterface::SensorId& sensor_id) {
+  using SensorType = mapping::TrajectoryBuilderInterface::SensorId::SensorType;
   proto::SensorType type;
   switch (sensor_id.type) {
     case SensorType::RANGE:
@@ -128,9 +124,9 @@ proto::SensorId ToProto(
   return proto;
 }
 
-cartographer::mapping::TrajectoryBuilderInterface::SensorId FromProto(
+mapping::TrajectoryBuilderInterface::SensorId FromProto(
     const proto::SensorId& proto) {
-  using SensorId = cartographer::mapping::TrajectoryBuilderInterface::SensorId;
+  using SensorId = mapping::TrajectoryBuilderInterface::SensorId;
   using SensorType = SensorId::SensorType;
   SensorType type;
   switch (proto.type()) {
@@ -158,5 +154,5 @@ cartographer::mapping::TrajectoryBuilderInterface::SensorId FromProto(
   return SensorId{type, proto.id()};
 }
 
-}  // namespace sensor
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/sensor/serialization.h
+++ b/cartographer_grpc/internal/sensor/serialization.h
@@ -26,48 +26,44 @@
 #include "cartographer/sensor/timed_point_cloud_data.h"
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 
-namespace cartographer_grpc {
-namespace sensor {
+namespace cartographer {
+namespace cloud {
 
 void CreateSensorMetadata(const std::string& sensor_id, int trajectory_id,
                           proto::SensorMetadata* proto);
 
 void CreateAddFixedFramePoseDataRequest(
     const std::string& sensor_id, int trajectory_id,
-    const cartographer::sensor::proto::FixedFramePoseData&
-        fixed_frame_pose_data,
+    const sensor::proto::FixedFramePoseData& fixed_frame_pose_data,
     proto::AddFixedFramePoseDataRequest* proto);
-void CreateAddImuDataRequest(
-    const std::string& sensor_id, int trajectory_id,
-    const cartographer::sensor::proto::ImuData& imu_data,
-    proto::AddImuDataRequest* proto);
+void CreateAddImuDataRequest(const std::string& sensor_id, int trajectory_id,
+                             const sensor::proto::ImuData& imu_data,
+                             proto::AddImuDataRequest* proto);
 void CreateAddOdometryDataRequest(
     const std::string& sensor_id, int trajectory_id,
-    const cartographer::sensor::proto::OdometryData& odometry_data,
+    const sensor::proto::OdometryData& odometry_data,
     proto::AddOdometryDataRequest* proto);
 void CreateAddRangeFinderDataRequest(
     const std::string& sensor_id, int trajectory_id,
-    const cartographer::sensor::proto::TimedPointCloudData&
-        timed_point_cloud_data,
+    const sensor::proto::TimedPointCloudData& timed_point_cloud_data,
     proto::AddRangefinderDataRequest* proto);
 void CreateAddLandmarkDataRequest(
     const std::string& sensor_id, int trajectory_id,
-    const cartographer::sensor::proto::LandmarkData& landmark_data,
+    const sensor::proto::LandmarkData& landmark_data,
     proto::AddLandmarkDataRequest* proto);
 void CreateAddLocalSlamResultDataRequest(
-    const std::string& sensor_id, int trajectory_id,
-    cartographer::common::Time time, int starting_submap_index,
-    const cartographer::mapping::TrajectoryBuilderInterface::InsertionResult&
+    const std::string& sensor_id, int trajectory_id, common::Time time,
+    int starting_submap_index,
+    const mapping::TrajectoryBuilderInterface::InsertionResult&
         insertion_result,
     proto::AddLocalSlamResultDataRequest* proto);
 
 proto::SensorId ToProto(
-    const cartographer::mapping::TrajectoryBuilderInterface::SensorId&
-        sensor_id);
-cartographer::mapping::TrajectoryBuilderInterface::SensorId FromProto(
+    const mapping::TrajectoryBuilderInterface::SensorId& sensor_id);
+mapping::TrajectoryBuilderInterface::SensorId FromProto(
     const proto::SensorId& proto);
 
-}  // namespace sensor
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_SENSOR_SERIALIZATION_H

--- a/cartographer_grpc/internal/testing/handler_test.h
+++ b/cartographer_grpc/internal/testing/handler_test.h
@@ -25,7 +25,8 @@
 #include "mock_map_builder_context.h"
 #include "mock_pose_graph.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace testing {
 
 using ::testing::Return;
@@ -35,16 +36,16 @@ template <typename HandlerType>
 class HandlerTest : public Test {
  public:
   void SetUp() override {
-    test_server_ = cartographer::common::make_unique<
+    test_server_ = common::make_unique<
         framework::testing::RpcHandlerTestServer<HandlerType>>(
-        cartographer::common::make_unique<MockMapBuilderContext>());
+        common::make_unique<MockMapBuilderContext>());
     mock_map_builder_context_ =
         test_server_
             ->template GetUnsynchronizedContext<MockMapBuilderContext>();
     mock_local_trajectory_uploader_ =
-        cartographer::common::make_unique<MockLocalTrajectoryUploader>();
-    mock_map_builder_ = cartographer::common::make_unique<MockMapBuilder>();
-    mock_pose_graph_ = cartographer::common::make_unique<MockPoseGraph>();
+        common::make_unique<MockLocalTrajectoryUploader>();
+    mock_map_builder_ = common::make_unique<MockMapBuilder>();
+    mock_pose_graph_ = common::make_unique<MockPoseGraph>();
 
     EXPECT_CALL(*mock_map_builder_context_, map_builder())
         .Times(::testing::AnyNumber())
@@ -74,6 +75,7 @@ class HandlerTest : public Test {
 };
 
 }  // namespace testing
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_TESTING_HANDLER_TEST_H

--- a/cartographer_grpc/internal/testing/mock_local_trajectory_uploader.h
+++ b/cartographer_grpc/internal/testing/mock_local_trajectory_uploader.h
@@ -22,7 +22,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace testing {
 
 class MockLocalTrajectoryUploader : public LocalTrajectoryUploaderInterface {
@@ -34,15 +35,15 @@ class MockLocalTrajectoryUploader : public LocalTrajectoryUploaderInterface {
   }
   MOCK_METHOD0(Start, void());
   MOCK_METHOD0(Shutdown, void());
-  MOCK_METHOD3(
-      AddTrajectory,
-      void(int, const std::set<SensorId> &,
-           const cartographer::mapping::proto::TrajectoryBuilderOptions &));
+  MOCK_METHOD3(AddTrajectory,
+               void(int, const std::set<SensorId> &,
+                    const mapping::proto::TrajectoryBuilderOptions &));
   MOCK_METHOD1(FinishTrajectory, void(int));
   MOCK_CONST_METHOD1(GetLocalSlamResultSensorId, SensorId(int));
 };
 
 }  // namespace testing
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_TESTING_MOCK_LOCAL_TRAJECTORY_UPLOADER_H

--- a/cartographer_grpc/internal/testing/mock_map_builder.h
+++ b/cartographer_grpc/internal/testing/mock_map_builder.h
@@ -25,44 +25,39 @@
 
 using testing::_;
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace testing {
 
-class MockMapBuilder : public cartographer::mapping::MapBuilderInterface {
+class MockMapBuilder : public mapping::MapBuilderInterface {
  public:
   MOCK_METHOD3(
       AddTrajectoryBuilder,
       int(const std::set<SensorId> &expected_sensor_ids,
-          const cartographer::mapping::proto::TrajectoryBuilderOptions
-              &trajectory_options,
-          cartographer::mapping::MapBuilderInterface::LocalSlamResultCallback
+          const mapping::proto::TrajectoryBuilderOptions &trajectory_options,
+          mapping::MapBuilderInterface::LocalSlamResultCallback
               local_slam_result_callback));
   MOCK_METHOD1(AddTrajectoryForDeserialization,
-               int(const cartographer::mapping::proto::
-                       TrajectoryBuilderOptionsWithSensorIds
-                           &options_with_sensor_ids_proto));
-  MOCK_CONST_METHOD1(
-      GetTrajectoryBuilder,
-      cartographer::mapping::TrajectoryBuilderInterface *(int trajectory_id));
+               int(const mapping::proto::TrajectoryBuilderOptionsWithSensorIds
+                       &options_with_sensor_ids_proto));
+  MOCK_CONST_METHOD1(GetTrajectoryBuilder,
+                     mapping::TrajectoryBuilderInterface *(int trajectory_id));
   MOCK_METHOD1(FinishTrajectory, void(int trajectory_id));
-  MOCK_METHOD2(
-      SubmapToProto,
-      std::string(const cartographer::mapping::SubmapId &,
-                  cartographer::mapping::proto::SubmapQuery::Response *));
-  MOCK_METHOD1(SerializeState,
-               void(cartographer::io::ProtoStreamWriterInterface *));
-  MOCK_METHOD2(LoadState,
-               void(cartographer::io::ProtoStreamReaderInterface *, bool));
+  MOCK_METHOD2(SubmapToProto,
+               std::string(const mapping::SubmapId &,
+                           mapping::proto::SubmapQuery::Response *));
+  MOCK_METHOD1(SerializeState, void(io::ProtoStreamWriterInterface *));
+  MOCK_METHOD2(LoadState, void(io::ProtoStreamReaderInterface *, bool));
   MOCK_CONST_METHOD0(num_trajectory_builders, int());
-  MOCK_METHOD0(pose_graph, cartographer::mapping::PoseGraphInterface *());
+  MOCK_METHOD0(pose_graph, mapping::PoseGraphInterface *());
   MOCK_CONST_METHOD0(
       GetAllTrajectoryBuilderOptions,
-      const std::vector<
-          cartographer::mapping::proto::TrajectoryBuilderOptionsWithSensorIds>
+      const std::vector<mapping::proto::TrajectoryBuilderOptionsWithSensorIds>
           &());
 };
 
 }  // namespace testing
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_TESTING_MOCK_MAP_BUILDER_H

--- a/cartographer_grpc/internal/testing/mock_map_builder_context.h
+++ b/cartographer_grpc/internal/testing/mock_map_builder_context.h
@@ -23,18 +23,19 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace testing {
 
 class MockMapBuilderContext : public MapBuilderContextInterface {
  public:
-  MOCK_METHOD0(map_builder, cartographer::mapping::MapBuilderInterface &());
-  MOCK_METHOD0(sensor_data_queue,
-               cartographer::common::BlockingQueue<
-                   std::unique_ptr<MapBuilderContextInterface::Data>> &());
+  MOCK_METHOD0(map_builder, mapping::MapBuilderInterface &());
+  MOCK_METHOD0(
+      sensor_data_queue,
+      common::BlockingQueue<std::unique_ptr<MapBuilderContextInterface::Data>>
+          &());
   MOCK_METHOD0(GetLocalSlamResultCallbackForSubscriptions,
-               cartographer::mapping::TrajectoryBuilderInterface::
-                   LocalSlamResultCallback());
+               mapping::TrajectoryBuilderInterface::LocalSlamResultCallback());
   MOCK_METHOD1(AddSensorDataToTrajectory,
                void(const MapBuilderContextInterface::Data &));
   MOCK_METHOD2(SubscribeLocalSlamResults,
@@ -45,37 +46,35 @@ class MockMapBuilderContext : public MapBuilderContextInterface {
                void(const MapBuilderContextInterface::SubscriptionId &));
   MOCK_METHOD1(NotifyFinishTrajectory, void(int));
   MOCK_METHOD3(DoProcessLocalSlamResultData,
-               cartographer::mapping::LocalSlamResultData *(
-                   const std::string &, cartographer::common::Time,
-                   const cartographer::mapping::proto::LocalSlamResultData &));
-  std::unique_ptr<cartographer::mapping::LocalSlamResultData>
-  ProcessLocalSlamResultData(
-      const std::string &sensor_id, cartographer::common::Time time,
-      const cartographer::mapping::proto::LocalSlamResultData &proto) override {
-    return std::unique_ptr<cartographer::mapping::LocalSlamResultData>(
+               mapping::LocalSlamResultData *(
+                   const std::string &, common::Time,
+                   const mapping::proto::LocalSlamResultData &));
+  std::unique_ptr<mapping::LocalSlamResultData> ProcessLocalSlamResultData(
+      const std::string &sensor_id, common::Time time,
+      const mapping::proto::LocalSlamResultData &proto) override {
+    return std::unique_ptr<mapping::LocalSlamResultData>(
         DoProcessLocalSlamResultData(sensor_id, time, proto));
   }
   MOCK_METHOD0(local_trajectory_uploader, LocalTrajectoryUploaderInterface *());
 
-  MOCK_METHOD2(DoEnqueueSensorData, void(int, cartographer::sensor::Data *));
-  void EnqueueSensorData(
-      int trajectory_id,
-      std::unique_ptr<cartographer::sensor::Data> data) override {
+  MOCK_METHOD2(DoEnqueueSensorData, void(int, sensor::Data *));
+  void EnqueueSensorData(int trajectory_id,
+                         std::unique_ptr<sensor::Data> data) override {
     DoEnqueueSensorData(trajectory_id, data.get());
   }
   MOCK_METHOD3(DoEnqueueLocalSlamResultData,
-               void(int, const std::string &,
-                    cartographer::mapping::LocalSlamResultData *));
-  void EnqueueLocalSlamResultData(
-      int trajectory_id, const std::string &sensor_id,
-      std::unique_ptr<cartographer::mapping::LocalSlamResultData>
-          local_slam_result_data) override {
+               void(int, const std::string &, mapping::LocalSlamResultData *));
+  void EnqueueLocalSlamResultData(int trajectory_id,
+                                  const std::string &sensor_id,
+                                  std::unique_ptr<mapping::LocalSlamResultData>
+                                      local_slam_result_data) override {
     DoEnqueueLocalSlamResultData(trajectory_id, sensor_id,
                                  local_slam_result_data.get());
   }
 };
 
 }  // namespace testing
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_TESTING_MOCK_MAP_BUILDER_CONTEXT_H

--- a/cartographer_grpc/internal/testing/mock_pose_graph.h
+++ b/cartographer_grpc/internal/testing/mock_pose_graph.h
@@ -22,43 +22,36 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace testing {
 
-class MockPoseGraph : public cartographer::mapping::PoseGraphInterface {
+class MockPoseGraph : public mapping::PoseGraphInterface {
  public:
   MockPoseGraph() = default;
   ~MockPoseGraph() override = default;
 
   MOCK_METHOD0(RunFinalOptimization, void());
   MOCK_METHOD0(GetAllSubmapData,
-               cartographer::mapping::MapById<cartographer::mapping::SubmapId,
-                                              SubmapData>());
+               mapping::MapById<mapping::SubmapId, SubmapData>());
   MOCK_METHOD0(GetAllSubmapPoses,
-               cartographer::mapping::MapById<cartographer::mapping::SubmapId,
-                                              SubmapPose>());
-  MOCK_METHOD1(GetLocalToGlobalTransform,
-               cartographer::transform::Rigid3d(int));
+               mapping::MapById<mapping::SubmapId, SubmapPose>());
+  MOCK_METHOD1(GetLocalToGlobalTransform, transform::Rigid3d(int));
+  MOCK_METHOD0(GetTrajectoryNodes,
+               mapping::MapById<mapping::NodeId, mapping::TrajectoryNode>());
   MOCK_METHOD0(
-      GetTrajectoryNodes,
-      cartographer::mapping::MapById<cartographer::mapping::NodeId,
-                                     cartographer::mapping::TrajectoryNode>());
-  MOCK_METHOD0(GetTrajectoryNodePoses,
-               cartographer::mapping::MapById<
-                   cartographer::mapping::NodeId,
-                   cartographer::mapping::TrajectoryNodePose>());
-  MOCK_METHOD0(GetLandmarkPoses,
-               std::map<std::string, cartographer::transform::Rigid3d>());
+      GetTrajectoryNodePoses,
+      mapping::MapById<mapping::NodeId, mapping::TrajectoryNodePose>());
+  MOCK_METHOD0(GetLandmarkPoses, std::map<std::string, transform::Rigid3d>());
   MOCK_METHOD1(IsTrajectoryFinished, bool(int));
-  MOCK_METHOD0(
-      GetTrajectoryData,
-      std::map<int,
-               cartographer::mapping::PoseGraphInterface::TrajectoryData>());
+  MOCK_METHOD0(GetTrajectoryData,
+               std::map<int, mapping::PoseGraphInterface::TrajectoryData>());
   MOCK_METHOD0(constraints, std::vector<Constraint>());
-  MOCK_METHOD0(ToProto, cartographer::mapping::proto::PoseGraph());
+  MOCK_METHOD0(ToProto, mapping::proto::PoseGraph());
 };
 
 }  // namespace testing
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_TESTING_MOCK_POSE_GRAPH_H

--- a/cartographer_grpc/internal/testing/mock_trajectory_builder.h
+++ b/cartographer_grpc/internal/testing/mock_trajectory_builder.h
@@ -22,40 +22,37 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace testing {
 
-class MockTrajectoryBuilder
-    : public cartographer::mapping::TrajectoryBuilderInterface {
+class MockTrajectoryBuilder : public mapping::TrajectoryBuilderInterface {
  public:
   MockTrajectoryBuilder() = default;
   ~MockTrajectoryBuilder() override = default;
 
   MOCK_METHOD2(AddSensorData,
-               void(const std::string &,
-                    const cartographer::sensor::TimedPointCloudData &));
-  MOCK_METHOD2(AddSensorData, void(const std::string &,
-                                   const cartographer::sensor::ImuData &));
-  MOCK_METHOD2(AddSensorData, void(const std::string &,
-                                   const cartographer::sensor::OdometryData &));
+               void(const std::string &, const sensor::TimedPointCloudData &));
   MOCK_METHOD2(AddSensorData,
-               void(const std::string &,
-                    const cartographer::sensor::FixedFramePoseData &));
-  MOCK_METHOD2(AddSensorData, void(const std::string &,
-                                   const cartographer::sensor::LandmarkData &));
+               void(const std::string &, const sensor::ImuData &));
+  MOCK_METHOD2(AddSensorData,
+               void(const std::string &, const sensor::OdometryData &));
+  MOCK_METHOD2(AddSensorData,
+               void(const std::string &, const sensor::FixedFramePoseData &));
+  MOCK_METHOD2(AddSensorData,
+               void(const std::string &, const sensor::LandmarkData &));
 
   // Some of the platforms we run on may ship with a version of gmock which does
   // not yet support move-only types.
-  MOCK_METHOD1(DoAddLocalSlamResultData,
-               void(cartographer::mapping::LocalSlamResultData *));
-  void AddLocalSlamResultData(
-      std::unique_ptr<cartographer::mapping::LocalSlamResultData>
-          local_slam_result_data) override {
+  MOCK_METHOD1(DoAddLocalSlamResultData, void(mapping::LocalSlamResultData *));
+  void AddLocalSlamResultData(std::unique_ptr<mapping::LocalSlamResultData>
+                                  local_slam_result_data) override {
     DoAddLocalSlamResultData(local_slam_result_data.get());
   }
 };
 
 }  // namespace testing
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_TESTING_MOCK_TRAJECTORY_BUILDER_CONTEXT_H

--- a/cartographer_grpc/internal/testing/test_helpers.cc
+++ b/cartographer_grpc/internal/testing/test_helpers.cc
@@ -16,20 +16,19 @@
 
 #include "cartographer_grpc/internal/testing/test_helpers.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace testing {
 
 template <>
 DataPredicateType BuildDataPredicateEquals<proto::AddImuDataRequest>(
     const proto::AddImuDataRequest &proto) {
-  return [proto](const cartographer::sensor::Data &data) {
+  return [proto](const sensor::Data &data) {
     const auto *dispatchable =
-        dynamic_cast<const cartographer::sensor::Dispatchable<
-            cartographer::sensor::ImuData> *>(&data);
+        dynamic_cast<const sensor::Dispatchable<sensor::ImuData> *>(&data);
     CHECK_NOTNULL(dispatchable);
     return google::protobuf::util::MessageDifferencer::Equals(
-               cartographer::sensor::ToProto(dispatchable->data()),
-               proto.imu_data()) &&
+               sensor::ToProto(dispatchable->data()), proto.imu_data()) &&
            dispatchable->GetSensorId() == proto.sensor_metadata().sensor_id();
   };
 }
@@ -37,13 +36,13 @@ DataPredicateType BuildDataPredicateEquals<proto::AddImuDataRequest>(
 template <>
 DataPredicateType BuildDataPredicateEquals<proto::AddFixedFramePoseDataRequest>(
     const proto::AddFixedFramePoseDataRequest &proto) {
-  return [proto](const cartographer::sensor::Data &data) {
+  return [proto](const sensor::Data &data) {
     const auto *dispatchable =
-        dynamic_cast<const cartographer::sensor::Dispatchable<
-            cartographer::sensor::FixedFramePoseData> *>(&data);
+        dynamic_cast<const sensor::Dispatchable<sensor::FixedFramePoseData> *>(
+            &data);
     CHECK_NOTNULL(dispatchable);
     return google::protobuf::util::MessageDifferencer::Equals(
-               cartographer::sensor::ToProto(dispatchable->data()),
+               sensor::ToProto(dispatchable->data()),
                proto.fixed_frame_pose_data()) &&
            dispatchable->GetSensorId() == proto.sensor_metadata().sensor_id();
   };
@@ -52,14 +51,12 @@ DataPredicateType BuildDataPredicateEquals<proto::AddFixedFramePoseDataRequest>(
 template <>
 DataPredicateType BuildDataPredicateEquals<proto::AddOdometryDataRequest>(
     const proto::AddOdometryDataRequest &proto) {
-  return [proto](const cartographer::sensor::Data &data) {
+  return [proto](const sensor::Data &data) {
     const auto *dispatchable =
-        dynamic_cast<const cartographer::sensor::Dispatchable<
-            cartographer::sensor::OdometryData> *>(&data);
+        dynamic_cast<const sensor::Dispatchable<sensor::OdometryData> *>(&data);
     CHECK_NOTNULL(dispatchable);
     return google::protobuf::util::MessageDifferencer::Equals(
-               cartographer::sensor::ToProto(dispatchable->data()),
-               proto.odometry_data()) &&
+               sensor::ToProto(dispatchable->data()), proto.odometry_data()) &&
            dispatchable->GetSensorId() == proto.sensor_metadata().sensor_id();
   };
 }
@@ -67,14 +64,12 @@ DataPredicateType BuildDataPredicateEquals<proto::AddOdometryDataRequest>(
 template <>
 DataPredicateType BuildDataPredicateEquals<proto::AddLandmarkDataRequest>(
     const proto::AddLandmarkDataRequest &proto) {
-  return [proto](const cartographer::sensor::Data &data) {
+  return [proto](const sensor::Data &data) {
     const auto *dispatchable =
-        dynamic_cast<const cartographer::sensor::Dispatchable<
-            cartographer::sensor::LandmarkData> *>(&data);
+        dynamic_cast<const sensor::Dispatchable<sensor::LandmarkData> *>(&data);
     CHECK_NOTNULL(dispatchable);
     return google::protobuf::util::MessageDifferencer::Equals(
-               cartographer::sensor::ToProto(dispatchable->data()),
-               proto.landmark_data()) &&
+               sensor::ToProto(dispatchable->data()), proto.landmark_data()) &&
            dispatchable->GetSensorId() == proto.sensor_metadata().sensor_id();
   };
 }
@@ -82,13 +77,13 @@ DataPredicateType BuildDataPredicateEquals<proto::AddLandmarkDataRequest>(
 template <>
 DataPredicateType BuildDataPredicateEquals<proto::AddRangefinderDataRequest>(
     const proto::AddRangefinderDataRequest &proto) {
-  return [proto](const cartographer::sensor::Data &data) {
+  return [proto](const sensor::Data &data) {
     const auto *dispatchable =
-        dynamic_cast<const cartographer::sensor::Dispatchable<
-            cartographer::sensor::TimedPointCloudData> *>(&data);
+        dynamic_cast<const sensor::Dispatchable<sensor::TimedPointCloudData> *>(
+            &data);
     CHECK_NOTNULL(dispatchable);
     return google::protobuf::util::MessageDifferencer::Equals(
-               cartographer::sensor::ToProto(dispatchable->data()),
+               sensor::ToProto(dispatchable->data()),
                proto.timed_point_cloud_data()) &&
            dispatchable->GetSensorId() == proto.sensor_metadata().sensor_id();
   };
@@ -102,4 +97,5 @@ ProtoPredicateType BuildProtoPredicateEquals(
 }
 
 }  // namespace testing
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/internal/testing/test_helpers.h
+++ b/cartographer_grpc/internal/testing/test_helpers.h
@@ -21,11 +21,11 @@
 #include "cartographer_grpc/proto/map_builder_service.pb.h"
 #include "google/protobuf/util/message_differencer.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace testing {
 
-using DataPredicateType =
-    std::function<bool(const cartographer::sensor::Data &)>;
+using DataPredicateType = std::function<bool(const sensor::Data &)>;
 using ProtoPredicateType =
     std::function<bool(const google::protobuf::Message &)>;
 
@@ -52,6 +52,7 @@ ProtoPredicateType BuildProtoPredicateEquals(
     const google::protobuf::Message *proto);
 
 }  // namespace testing
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_INTERNAL_TESTING_TEST_HELPERS_H

--- a/cartographer_grpc/map_builder_server_interface.cc
+++ b/cartographer_grpc/map_builder_server_interface.cc
@@ -3,13 +3,15 @@
 #include "cartographer/common/make_unique.h"
 #include "cartographer_grpc/internal/map_builder_server.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 
 std::unique_ptr<MapBuilderServerInterface> CreateMapBuilderServer(
     const proto::MapBuilderServerOptions& map_builder_server_options,
-    std::unique_ptr<::cartographer::mapping::MapBuilderInterface> map_builder) {
-  return ::cartographer::common::make_unique<MapBuilderServer>(
-      map_builder_server_options, std::move(map_builder));
+    std::unique_ptr<mapping::MapBuilderInterface> map_builder) {
+  return common::make_unique<MapBuilderServer>(map_builder_server_options,
+                                               std::move(map_builder));
 }
 
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/map_builder_server_interface.h
+++ b/cartographer_grpc/map_builder_server_interface.h
@@ -22,7 +22,8 @@
 #include "cartographer/mapping/map_builder_interface.h"
 #include "cartographer_grpc/proto/map_builder_server_options.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 
 class MapBuilderServerInterface {
  public:
@@ -47,8 +48,9 @@ class MapBuilderServerInterface {
 // Returns MapBuilderServer with the actual implementation.
 std::unique_ptr<MapBuilderServerInterface> CreateMapBuilderServer(
     const proto::MapBuilderServerOptions& map_builder_server_options,
-    std::unique_ptr<cartographer::mapping::MapBuilderInterface> map_builder);
+    std::unique_ptr<mapping::MapBuilderInterface> map_builder);
 
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_MAP_BUILDER_SERVER_INTERFACE_H

--- a/cartographer_grpc/map_builder_server_main.cc
+++ b/cartographer_grpc/map_builder_server_main.cc
@@ -33,13 +33,14 @@ DEFINE_string(configuration_basename, "",
               "Basename, i.e. not containing any directory prefix, of the "
               "configuration file.");
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 
 void Run(const std::string& configuration_directory,
          const std::string& configuration_basename) {
 #if USE_PROMETHEUS
   metrics::prometheus::FamilyFactory registry;
-  cartographer::metrics::RegisterAllMetrics(&registry);
+  metrics::RegisterAllMetrics(&registry);
   ::prometheus::Exposer exposer("0.0.0.0:9100");
   exposer.RegisterCollectable(registry.GetCollectable());
   LOG(INFO) << "Exposing metrics at http://localhost:9100/metrics";
@@ -52,9 +53,8 @@ void Run(const std::string& configuration_directory,
   // config.
   map_builder_server_options.mutable_map_builder_options()
       ->set_collate_by_trajectory(true);
-  auto map_builder =
-      cartographer::common::make_unique<cartographer::mapping::MapBuilder>(
-          map_builder_server_options.map_builder_options());
+  auto map_builder = common::make_unique<mapping::MapBuilder>(
+      map_builder_server_options.map_builder_options());
   std::unique_ptr<MapBuilderServerInterface> map_builder_server =
       CreateMapBuilderServer(map_builder_server_options,
                              std::move(map_builder));
@@ -62,7 +62,8 @@ void Run(const std::string& configuration_directory,
   map_builder_server->WaitForShutdown();
 }
 
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 int main(int argc, char** argv) {
   google::InitGoogleLogging(argv[0]);
@@ -73,9 +74,9 @@ int main(int argc, char** argv) {
   google::ParseCommandLineFlags(&argc, &argv, true);
   if (FLAGS_configuration_directory.empty() ||
       FLAGS_configuration_basename.empty()) {
-    google::ShowUsageWithFlagsRestrict(argv[0], "cartographer_grpc_server");
+    google::ShowUsageWithFlagsRestrict(argv[0], "cloud_server");
     return EXIT_FAILURE;
   }
-  cartographer_grpc::Run(FLAGS_configuration_directory,
-                         FLAGS_configuration_basename);
+  cartographer::cloud::Run(FLAGS_configuration_directory,
+                           FLAGS_configuration_basename);
 }

--- a/cartographer_grpc/map_builder_server_main.cc
+++ b/cartographer_grpc/map_builder_server_main.cc
@@ -40,7 +40,7 @@ void Run(const std::string& configuration_directory,
          const std::string& configuration_basename) {
 #if USE_PROMETHEUS
   metrics::prometheus::FamilyFactory registry;
-  metrics::RegisterAllMetrics(&registry);
+  ::cartographer::metrics::RegisterAllMetrics(&registry);
   ::prometheus::Exposer exposer("0.0.0.0:9100");
   exposer.RegisterCollectable(registry.GetCollectable());
   LOG(INFO) << "Exposing metrics at http://localhost:9100/metrics";

--- a/cartographer_grpc/map_builder_server_options.cc
+++ b/cartographer_grpc/map_builder_server_options.cc
@@ -20,10 +20,11 @@
 #include "cartographer/common/make_unique.h"
 #include "cartographer/mapping/map_builder.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 
 proto::MapBuilderServerOptions CreateMapBuilderServerOptions(
-    ::cartographer::common::LuaParameterDictionary* lua_parameter_dictionary) {
+    common::LuaParameterDictionary* lua_parameter_dictionary) {
   proto::MapBuilderServerOptions map_builder_server_options;
   map_builder_server_options.set_server_address(
       lua_parameter_dictionary->GetString("server_address"));
@@ -32,7 +33,7 @@ proto::MapBuilderServerOptions CreateMapBuilderServerOptions(
   map_builder_server_options.set_num_event_threads(
       lua_parameter_dictionary->GetInt("num_event_threads"));
   *map_builder_server_options.mutable_map_builder_options() =
-      cartographer::mapping::CreateMapBuilderOptions(
+      mapping::CreateMapBuilderOptions(
           lua_parameter_dictionary->GetDictionary("map_builder").get());
   map_builder_server_options.set_uplink_server_address(
       lua_parameter_dictionary->GetString("uplink_server_address"));
@@ -42,14 +43,14 @@ proto::MapBuilderServerOptions CreateMapBuilderServerOptions(
 proto::MapBuilderServerOptions LoadMapBuilderServerOptions(
     const std::string& configuration_directory,
     const std::string& configuration_basename) {
-  auto file_resolver = cartographer::common::make_unique<
-      cartographer::common::ConfigurationFileResolver>(
+  auto file_resolver = common::make_unique<common::ConfigurationFileResolver>(
       std::vector<std::string>{configuration_directory});
   const std::string code =
       file_resolver->GetFileContentOrDie(configuration_basename);
-  cartographer::common::LuaParameterDictionary lua_parameter_dictionary(
+  common::LuaParameterDictionary lua_parameter_dictionary(
       code, std::move(file_resolver));
   return CreateMapBuilderServerOptions(&lua_parameter_dictionary);
 }
 
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/map_builder_server_options.h
+++ b/cartographer_grpc/map_builder_server_options.h
@@ -22,15 +22,17 @@
 #include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer_grpc/proto/map_builder_server_options.pb.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 
 proto::MapBuilderServerOptions CreateMapBuilderServerOptions(
-    ::cartographer::common::LuaParameterDictionary* lua_parameter_dictionary);
+    common::LuaParameterDictionary* lua_parameter_dictionary);
 
 proto::MapBuilderServerOptions LoadMapBuilderServerOptions(
     const std::string& configuration_directory,
     const std::string& configuration_basename);
 
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_MAP_BUILDER_SERVER_OPTIONS_H

--- a/cartographer_grpc/metrics/prometheus/family_factory.cc
+++ b/cartographer_grpc/metrics/prometheus/family_factory.cc
@@ -26,12 +26,11 @@ namespace cartographer {
 namespace cloud {
 namespace metrics {
 namespace prometheus {
-
 namespace {
 
-using BucketBoundaries = metrics::Histogram::BucketBoundaries;
+using BucketBoundaries = ::cartographer::metrics::Histogram::BucketBoundaries;
 
-class Counter : public metrics::Counter {
+class Counter : public ::cartographer::metrics::Counter {
  public:
   explicit Counter(::prometheus::Counter* prometheus)
       : prometheus_(prometheus) {}
@@ -43,7 +42,8 @@ class Counter : public metrics::Counter {
   ::prometheus::Counter* prometheus_;
 };
 
-class CounterFamily : public metrics::Family<metrics::Counter> {
+class CounterFamily
+    : public ::cartographer::metrics::Family<::cartographer::metrics::Counter> {
  public:
   explicit CounterFamily(
       ::prometheus::Family<::prometheus::Counter>* prometheus)
@@ -62,7 +62,7 @@ class CounterFamily : public metrics::Family<metrics::Counter> {
   std::vector<std::unique_ptr<Counter>> wrappers_;
 };
 
-class Gauge : public metrics::Gauge {
+class Gauge : public ::cartographer::metrics::Gauge {
  public:
   explicit Gauge(::prometheus::Gauge* prometheus) : prometheus_(prometheus) {}
 
@@ -76,7 +76,8 @@ class Gauge : public metrics::Gauge {
   ::prometheus::Gauge* prometheus_;
 };
 
-class GaugeFamily : public metrics::Family<metrics::Gauge> {
+class GaugeFamily
+    : public ::cartographer::metrics::Family<::cartographer::metrics::Gauge> {
  public:
   explicit GaugeFamily(::prometheus::Family<::prometheus::Gauge>* prometheus)
       : prometheus_(prometheus) {}
@@ -94,7 +95,7 @@ class GaugeFamily : public metrics::Family<metrics::Gauge> {
   std::vector<std::unique_ptr<Gauge>> wrappers_;
 };
 
-class Histogram : public metrics::Histogram {
+class Histogram : public ::cartographer::metrics::Histogram {
  public:
   explicit Histogram(::prometheus::Histogram* prometheus)
       : prometheus_(prometheus) {}
@@ -105,7 +106,8 @@ class Histogram : public metrics::Histogram {
   ::prometheus::Histogram* prometheus_;
 };
 
-class HistogramFamily : public metrics::Family<metrics::Histogram> {
+class HistogramFamily : public ::cartographer::metrics::Family<
+                            ::cartographer::metrics::Histogram> {
  public:
   HistogramFamily(::prometheus::Family<::prometheus::Histogram>* prometheus,
                   const BucketBoundaries& boundaries)
@@ -130,8 +132,9 @@ class HistogramFamily : public metrics::Family<metrics::Histogram> {
 FamilyFactory::FamilyFactory()
     : registry_(std::make_shared<::prometheus::Registry>()) {}
 
-metrics::Family<metrics::Counter>* FamilyFactory::NewCounterFamily(
-    const std::string& name, const std::string& description) {
+::cartographer::metrics::Family<::cartographer::metrics::Counter>*
+FamilyFactory::NewCounterFamily(const std::string& name,
+                                const std::string& description) {
   auto& family = ::prometheus::BuildCounter()
                      .Name(name)
                      .Help(description)
@@ -142,8 +145,9 @@ metrics::Family<metrics::Counter>* FamilyFactory::NewCounterFamily(
   return ptr;
 }
 
-metrics::Family<metrics::Gauge>* FamilyFactory::NewGaugeFamily(
-    const std::string& name, const std::string& description) {
+::cartographer::metrics::Family<::cartographer::metrics::Gauge>*
+FamilyFactory::NewGaugeFamily(const std::string& name,
+                              const std::string& description) {
   auto& family = ::prometheus::BuildGauge()
                      .Name(name)
                      .Help(description)
@@ -154,9 +158,10 @@ metrics::Family<metrics::Gauge>* FamilyFactory::NewGaugeFamily(
   return ptr;
 }
 
-metrics::Family<metrics::Histogram>* FamilyFactory::NewHistogramFamily(
-    const std::string& name, const std::string& description,
-    const BucketBoundaries& boundaries) {
+::cartographer::metrics::Family<::cartographer::metrics::Histogram>*
+FamilyFactory::NewHistogramFamily(const std::string& name,
+                                  const std::string& description,
+                                  const BucketBoundaries& boundaries) {
   auto& family = ::prometheus::BuildHistogram()
                      .Name(name)
                      .Help(description)

--- a/cartographer_grpc/metrics/prometheus/family_factory.cc
+++ b/cartographer_grpc/metrics/prometheus/family_factory.cc
@@ -22,15 +22,16 @@
 #include "prometheus/gauge.h"
 #include "prometheus/histogram.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace metrics {
 namespace prometheus {
 
 namespace {
 
-using BucketBoundaries = cartographer::metrics::Histogram::BucketBoundaries;
+using BucketBoundaries = metrics::Histogram::BucketBoundaries;
 
-class Counter : public cartographer::metrics::Counter {
+class Counter : public metrics::Counter {
  public:
   explicit Counter(::prometheus::Counter* prometheus)
       : prometheus_(prometheus) {}
@@ -42,8 +43,7 @@ class Counter : public cartographer::metrics::Counter {
   ::prometheus::Counter* prometheus_;
 };
 
-class CounterFamily
-    : public cartographer::metrics::Family<cartographer::metrics::Counter> {
+class CounterFamily : public metrics::Family<metrics::Counter> {
  public:
   explicit CounterFamily(
       ::prometheus::Family<::prometheus::Counter>* prometheus)
@@ -51,7 +51,7 @@ class CounterFamily
 
   Counter* Add(const std::map<std::string, std::string>& labels) override {
     ::prometheus::Counter* counter = &prometheus_->Add(labels);
-    auto wrapper = cartographer::common::make_unique<Counter>(counter);
+    auto wrapper = common::make_unique<Counter>(counter);
     auto* ptr = wrapper.get();
     wrappers_.emplace_back(std::move(wrapper));
     return ptr;
@@ -62,7 +62,7 @@ class CounterFamily
   std::vector<std::unique_ptr<Counter>> wrappers_;
 };
 
-class Gauge : public cartographer::metrics::Gauge {
+class Gauge : public metrics::Gauge {
  public:
   explicit Gauge(::prometheus::Gauge* prometheus) : prometheus_(prometheus) {}
 
@@ -76,15 +76,14 @@ class Gauge : public cartographer::metrics::Gauge {
   ::prometheus::Gauge* prometheus_;
 };
 
-class GaugeFamily
-    : public cartographer::metrics::Family<cartographer::metrics::Gauge> {
+class GaugeFamily : public metrics::Family<metrics::Gauge> {
  public:
   explicit GaugeFamily(::prometheus::Family<::prometheus::Gauge>* prometheus)
       : prometheus_(prometheus) {}
 
   Gauge* Add(const std::map<std::string, std::string>& labels) override {
     ::prometheus::Gauge* gauge = &prometheus_->Add(labels);
-    auto wrapper = cartographer::common::make_unique<Gauge>(gauge);
+    auto wrapper = common::make_unique<Gauge>(gauge);
     auto* ptr = wrapper.get();
     wrappers_.emplace_back(std::move(wrapper));
     return ptr;
@@ -95,7 +94,7 @@ class GaugeFamily
   std::vector<std::unique_ptr<Gauge>> wrappers_;
 };
 
-class Histogram : public cartographer::metrics::Histogram {
+class Histogram : public metrics::Histogram {
  public:
   explicit Histogram(::prometheus::Histogram* prometheus)
       : prometheus_(prometheus) {}
@@ -106,8 +105,7 @@ class Histogram : public cartographer::metrics::Histogram {
   ::prometheus::Histogram* prometheus_;
 };
 
-class HistogramFamily
-    : public cartographer::metrics::Family<cartographer::metrics::Histogram> {
+class HistogramFamily : public metrics::Family<metrics::Histogram> {
  public:
   HistogramFamily(::prometheus::Family<::prometheus::Histogram>* prometheus,
                   const BucketBoundaries& boundaries)
@@ -115,7 +113,7 @@ class HistogramFamily
 
   Histogram* Add(const std::map<std::string, std::string>& labels) override {
     ::prometheus::Histogram* histogram = &prometheus_->Add(labels, boundaries_);
-    auto wrapper = cartographer::common::make_unique<Histogram>(histogram);
+    auto wrapper = common::make_unique<Histogram>(histogram);
     auto* ptr = wrapper.get();
     wrappers_.emplace_back(std::move(wrapper));
     return ptr;
@@ -132,42 +130,38 @@ class HistogramFamily
 FamilyFactory::FamilyFactory()
     : registry_(std::make_shared<::prometheus::Registry>()) {}
 
-cartographer::metrics::Family<cartographer::metrics::Counter>*
-FamilyFactory::NewCounterFamily(const std::string& name,
-                                const std::string& description) {
+metrics::Family<metrics::Counter>* FamilyFactory::NewCounterFamily(
+    const std::string& name, const std::string& description) {
   auto& family = ::prometheus::BuildCounter()
                      .Name(name)
                      .Help(description)
                      .Register(*registry_);
-  auto wrapper = cartographer::common::make_unique<CounterFamily>(&family);
+  auto wrapper = common::make_unique<CounterFamily>(&family);
   auto* ptr = wrapper.get();
   counters_.emplace_back(std::move(wrapper));
   return ptr;
 }
 
-cartographer::metrics::Family<cartographer::metrics::Gauge>*
-FamilyFactory::NewGaugeFamily(const std::string& name,
-                              const std::string& description) {
+metrics::Family<metrics::Gauge>* FamilyFactory::NewGaugeFamily(
+    const std::string& name, const std::string& description) {
   auto& family = ::prometheus::BuildGauge()
                      .Name(name)
                      .Help(description)
                      .Register(*registry_);
-  auto wrapper = cartographer::common::make_unique<GaugeFamily>(&family);
+  auto wrapper = common::make_unique<GaugeFamily>(&family);
   auto* ptr = wrapper.get();
   gauges_.emplace_back(std::move(wrapper));
   return ptr;
 }
 
-cartographer::metrics::Family<cartographer::metrics::Histogram>*
-FamilyFactory::NewHistogramFamily(const std::string& name,
-                                  const std::string& description,
-                                  const BucketBoundaries& boundaries) {
+metrics::Family<metrics::Histogram>* FamilyFactory::NewHistogramFamily(
+    const std::string& name, const std::string& description,
+    const BucketBoundaries& boundaries) {
   auto& family = ::prometheus::BuildHistogram()
                      .Name(name)
                      .Help(description)
                      .Register(*registry_);
-  auto wrapper =
-      cartographer::common::make_unique<HistogramFamily>(&family, boundaries);
+  auto wrapper = common::make_unique<HistogramFamily>(&family, boundaries);
   auto* ptr = wrapper.get();
   histograms_.emplace_back(std::move(wrapper));
   return ptr;
@@ -179,4 +173,5 @@ std::weak_ptr<::prometheus::Collectable> FamilyFactory::GetCollectable() const {
 
 }  // namespace prometheus
 }  // namespace metrics
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/metrics/prometheus/family_factory.h
+++ b/cartographer_grpc/metrics/prometheus/family_factory.h
@@ -23,41 +23,35 @@
 #include "cartographer/metrics/family_factory.h"
 #include "prometheus/registry.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace metrics {
 namespace prometheus {
 
-class FamilyFactory : public cartographer::metrics::FamilyFactory {
+class FamilyFactory : public metrics::FamilyFactory {
  public:
   FamilyFactory();
 
-  cartographer::metrics::Family<cartographer::metrics::Counter>*
-  NewCounterFamily(const std::string& name,
-                   const std::string& description) override;
-  cartographer::metrics::Family<cartographer::metrics::Gauge>* NewGaugeFamily(
+  metrics::Family<metrics::Counter>* NewCounterFamily(
       const std::string& name, const std::string& description) override;
-  cartographer::metrics::Family<cartographer::metrics::Histogram>*
-  NewHistogramFamily(const std::string& name, const std::string& description,
-                     const cartographer::metrics::Histogram::BucketBoundaries&
-                         boundaries) override;
+  metrics::Family<metrics::Gauge>* NewGaugeFamily(
+      const std::string& name, const std::string& description) override;
+  metrics::Family<metrics::Histogram>* NewHistogramFamily(
+      const std::string& name, const std::string& description,
+      const metrics::Histogram::BucketBoundaries& boundaries) override;
 
   std::weak_ptr<::prometheus::Collectable> GetCollectable() const;
 
  private:
-  std::vector<std::unique_ptr<
-      cartographer::metrics::Family<cartographer::metrics::Counter>>>
-      counters_;
-  std::vector<std::unique_ptr<
-      cartographer::metrics::Family<cartographer::metrics::Gauge>>>
-      gauges_;
-  std::vector<std::unique_ptr<
-      cartographer::metrics::Family<cartographer::metrics::Histogram>>>
-      histograms_;
+  std::vector<std::unique_ptr<metrics::Family<metrics::Counter>>> counters_;
+  std::vector<std::unique_ptr<metrics::Family<metrics::Gauge>>> gauges_;
+  std::vector<std::unique_ptr<metrics::Family<metrics::Histogram>>> histograms_;
   std::shared_ptr<::prometheus::Registry> registry_;
 };
 
 }  // namespace prometheus
 }  // namespace metrics
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer
 
 #endif  // CARTOGRAPHER_GRPC_METRICS_PROMETHEUS_FAMILY_FACTORY_H_

--- a/cartographer_grpc/metrics/prometheus/family_factory.h
+++ b/cartographer_grpc/metrics/prometheus/family_factory.h
@@ -28,24 +28,33 @@ namespace cloud {
 namespace metrics {
 namespace prometheus {
 
-class FamilyFactory : public metrics::FamilyFactory {
+class FamilyFactory : public ::cartographer::metrics::FamilyFactory {
  public:
   FamilyFactory();
 
-  metrics::Family<metrics::Counter>* NewCounterFamily(
-      const std::string& name, const std::string& description) override;
-  metrics::Family<metrics::Gauge>* NewGaugeFamily(
-      const std::string& name, const std::string& description) override;
-  metrics::Family<metrics::Histogram>* NewHistogramFamily(
-      const std::string& name, const std::string& description,
-      const metrics::Histogram::BucketBoundaries& boundaries) override;
+  ::cartographer::metrics::Family<::cartographer::metrics::Counter>*
+  NewCounterFamily(const std::string& name,
+                   const std::string& description) override;
+  ::cartographer::metrics::Family<::cartographer::metrics::Gauge>*
+  NewGaugeFamily(const std::string& name,
+                 const std::string& description) override;
+  ::cartographer::metrics::Family<::cartographer::metrics::Histogram>*
+  NewHistogramFamily(const std::string& name, const std::string& description,
+                     const ::cartographer::metrics::Histogram::BucketBoundaries&
+                         boundaries) override;
 
   std::weak_ptr<::prometheus::Collectable> GetCollectable() const;
 
  private:
-  std::vector<std::unique_ptr<metrics::Family<metrics::Counter>>> counters_;
-  std::vector<std::unique_ptr<metrics::Family<metrics::Gauge>>> gauges_;
-  std::vector<std::unique_ptr<metrics::Family<metrics::Histogram>>> histograms_;
+  std::vector<std::unique_ptr<
+      ::cartographer::metrics::Family<::cartographer::metrics::Counter>>>
+      counters_;
+  std::vector<std::unique_ptr<
+      ::cartographer::metrics::Family<::cartographer::metrics::Gauge>>>
+      gauges_;
+  std::vector<std::unique_ptr<
+      ::cartographer::metrics::Family<::cartographer::metrics::Histogram>>>
+      histograms_;
   std::shared_ptr<::prometheus::Registry> registry_;
 };
 

--- a/cartographer_grpc/metrics/prometheus/metrics_test.cc
+++ b/cartographer_grpc/metrics/prometheus/metrics_test.cc
@@ -22,14 +22,15 @@
 #include "gtest/gtest.h"
 #include "prometheus/exposer.h"
 
-namespace cartographer_grpc {
+namespace cartographer {
+namespace cloud {
 namespace metrics {
 namespace prometheus {
 namespace {
 
-static auto* kCounter = cartographer::metrics::Counter::Null();
-static auto* kGauge = cartographer::metrics::Gauge::Null();
-static auto* kScoresMetric = cartographer::metrics::Histogram::Null();
+static auto* kCounter = metrics::Counter::Null();
+static auto* kGauge = metrics::Gauge::Null();
+static auto* kScoresMetric = metrics::Histogram::Null();
 
 const char kLabelKey[] = "kind";
 const char kLabelValue[] = "score";
@@ -37,8 +38,8 @@ const std::array<double, 5> kObserveScores = {{-1, 0.11, 0.2, 0.5, 2}};
 
 class Algorithm {
  public:
-  static void RegisterMetrics(cartographer::metrics::FamilyFactory* factory) {
-    auto boundaries = cartographer::metrics::Histogram::FixedWidth(0.05, 20);
+  static void RegisterMetrics(metrics::FamilyFactory* factory) {
+    auto boundaries = metrics::Histogram::FixedWidth(0.05, 20);
     auto* scores_family = factory->NewHistogramFamily(
         "/algorithm/scores", "Scores achieved", boundaries);
     kScoresMetric = scores_family->Add({{kLabelKey, kLabelValue}});
@@ -134,7 +135,7 @@ TEST(MetricsTest, CollectHistogram) {
 TEST(MetricsTest, RunExposerServer) {
   FamilyFactory registry;
   Algorithm::RegisterMetrics(&registry);
-  cartographer::metrics::RegisterAllMetrics(&registry);
+  metrics::RegisterAllMetrics(&registry);
   ::prometheus::Exposer exposer("0.0.0.0:9100");
   exposer.RegisterCollectable(registry.GetCollectable());
 
@@ -145,4 +146,5 @@ TEST(MetricsTest, RunExposerServer) {
 }  // namespace
 }  // namespace prometheus
 }  // namespace metrics
-}  // namespace cartographer_grpc
+}  // namespace cloud
+}  // namespace cartographer

--- a/cartographer_grpc/metrics/prometheus/metrics_test.cc
+++ b/cartographer_grpc/metrics/prometheus/metrics_test.cc
@@ -28,9 +28,9 @@ namespace metrics {
 namespace prometheus {
 namespace {
 
-static auto* kCounter = metrics::Counter::Null();
-static auto* kGauge = metrics::Gauge::Null();
-static auto* kScoresMetric = metrics::Histogram::Null();
+static auto* kCounter = ::cartographer::metrics::Counter::Null();
+static auto* kGauge = ::cartographer::metrics::Gauge::Null();
+static auto* kScoresMetric = ::cartographer::metrics::Histogram::Null();
 
 const char kLabelKey[] = "kind";
 const char kLabelValue[] = "score";
@@ -38,8 +38,8 @@ const std::array<double, 5> kObserveScores = {{-1, 0.11, 0.2, 0.5, 2}};
 
 class Algorithm {
  public:
-  static void RegisterMetrics(metrics::FamilyFactory* factory) {
-    auto boundaries = metrics::Histogram::FixedWidth(0.05, 20);
+  static void RegisterMetrics(::cartographer::metrics::FamilyFactory* factory) {
+    auto boundaries = ::cartographer::metrics::Histogram::FixedWidth(0.05, 20);
     auto* scores_family = factory->NewHistogramFamily(
         "/algorithm/scores", "Scores achieved", boundaries);
     kScoresMetric = scores_family->Add({{kLabelKey, kLabelValue}});
@@ -135,7 +135,7 @@ TEST(MetricsTest, CollectHistogram) {
 TEST(MetricsTest, RunExposerServer) {
   FamilyFactory registry;
   Algorithm::RegisterMetrics(&registry);
-  metrics::RegisterAllMetrics(&registry);
+  ::cartographer::metrics::RegisterAllMetrics(&registry);
   ::prometheus::Exposer exposer("0.0.0.0:9100");
   exposer.RegisterCollectable(registry.GetCollectable());
 

--- a/cartographer_grpc/proto/map_builder_server_options.proto
+++ b/cartographer_grpc/proto/map_builder_server_options.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 import "cartographer/mapping/proto/map_builder_options.proto";
 
-package cartographer_grpc.proto;
+package cartographer.cloud.proto;
 
 message MapBuilderServerOptions {
   string server_address = 1;

--- a/cartographer_grpc/proto/map_builder_service.proto
+++ b/cartographer_grpc/proto/map_builder_service.proto
@@ -22,7 +22,7 @@ import "cartographer/sensor/proto/sensor.proto";
 import "cartographer/transform/proto/transform.proto";
 import "google/protobuf/empty.proto";
 
-package cartographer_grpc.proto;
+package cartographer.cloud.proto;
 
 enum SensorType {
   RANGE = 0;


### PR DESCRIPTION
[Code structure RFC](https://github.com/pifon2a/rfcs/blob/e11bca586f8cc733063ea9c94bdade71086ed9ea/text/0000-code-structure.md)

also
`cartographer_grpc::mapping::` ->  `cartographer::cloud::`.
`cartographer_grpc::sensor::` ->  `cartographer::cloud::`.