### PR TITLE
Make the cloud_uplink address empty by default.

### DIFF
--- a/configuration_files/map_builder_server.lua
+++ b/configuration_files/map_builder_server.lua
@@ -19,5 +19,5 @@ MAP_BUILDER_SERVER = {
   num_event_threads = 4,
   num_grpc_threads = 4,
   server_address = "0.0.0.0:50051",
-  uplink_server_address = "localhost:50052",
+  uplink_server_address = "",
 }


### PR DESCRIPTION
Currently, in order to launch gRPC demos, one has to empty this flag first.