### PR TITLE
Make FindGMock.cmake more robust

### DIFF
--- a/cmake/modules/FindGMock.cmake
+++ b/cmake/modules/FindGMock.cmake
@@ -12,56 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_path(GMOCK_INCLUDE_DIRS gmock/gmock.h
-  HINTS
-    ENV GMOCK_DIR
-  PATH_SUFFIXES include
-  PATHS
-    /usr
-)
-
-# Find system-wide installed gmock.
-find_library(GMOCK_LIBRARIES
-  NAMES gmock_main
-  HINTS
-    ENV GMOCK_DIR
-  PATH_SUFFIXES lib
-  PATHS
-    /usr
-)
-
-# Find system-wide gtest header.
-find_path(GTEST_INCLUDE_DIRS gtest/gtest.h
-  HINTS
-    ENV GTEST_DIR
-  PATH_SUFFIXES include
-  PATHS
-    /usr
-)
-list(APPEND GMOCK_INCLUDE_DIRS ${GTEST_INCLUDE_DIRS})
-
-if(NOT GMOCK_LIBRARIES)
-  # If no system-wide gmock found, then find src version.
-  # Ubuntu might have this.
-  find_path(GMOCK_SRC_DIR src/gmock.cc
+if(NOT GMock_FOUND)
+  find_path(GMOCK_INCLUDE_DIRS gmock/gmock.h
     HINTS
       ENV GMOCK_DIR
+    PATH_SUFFIXES include
     PATHS
-      /usr/src/googletest/googlemock
-      /usr/src/gmock
+      /usr
   )
-  if(GMOCK_SRC_DIR)
-    # If src version found, build it.
-    add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
-    # The next line is needed for Ubuntu Trusty.
-    set(GMOCK_INCLUDE_DIRS "${GMOCK_SRC_DIR}/gtest/include")
-    set(GMOCK_LIBRARIES gmock_main)
-  endif()
-endif()
 
-# System-wide installed gmock library might require pthreads.
-find_package(Threads REQUIRED)
-list(APPEND GMOCK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+  # Find system-wide installed gmock.
+  find_library(GMOCK_LIBRARIES
+    NAMES gmock_main
+    HINTS
+      ENV GMOCK_DIR
+    PATH_SUFFIXES lib
+    PATHS
+      /usr
+  )
+
+  # Find system-wide gtest header.
+  find_path(GTEST_INCLUDE_DIRS gtest/gtest.h
+    HINTS
+      ENV GTEST_DIR
+    PATH_SUFFIXES include
+    PATHS
+      /usr
+  )
+  list(APPEND GMOCK_INCLUDE_DIRS ${GTEST_INCLUDE_DIRS})
+
+  if(NOT GMOCK_LIBRARIES)
+    # If no system-wide gmock found, then find src version.
+    # Ubuntu might have this.
+    find_path(GMOCK_SRC_DIR src/gmock.cc
+      HINTS
+        ENV GMOCK_DIR
+      PATHS
+        /usr/src/googletest/googlemock
+        /usr/src/gmock
+    )
+    if(GMOCK_SRC_DIR)
+      # If src version found, build it.
+      if(NOT TARGET gmock)
+        add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
+      endif()
+      # The next line is needed for Ubuntu Trusty.
+      set(GMOCK_INCLUDE_DIRS "${GMOCK_SRC_DIR}/gtest/include")
+      set(GMOCK_LIBRARIES gmock_main)
+    endif()
+  endif()
+
+  # System-wide installed gmock library might require pthreads.
+  find_package(Threads REQUIRED)
+  list(APPEND GMOCK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GMock DEFAULT_MSG GMOCK_LIBRARIES


### PR DESCRIPTION
Handle case with multiple invocations (avoid pasting ${CMAKE_THREAD_LIBS_INIT} multiple times).
Also check if target 'gmock' already exists before building GMock to avoid failures if GMock was already
find_packaged() from another subproject.

Want to contribute? Great! Make sure you've read, understood and considered all
the points below before creating your PR:

- Keep your PR under 200 lines of code and address a single concern.
- Add unit test(s) and documentation (these do not count toward your 200 lines).
- Adhere to the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
- Run `ninja test` or `catkin_make_isolated --install --use-ninja --pkg cartographer --make-args test` as appropriate.
- Keep rebasing (or merging) of master branch to a minimum. It triggers Travis
  runs for every update which blocks merging of other changes. Our merge bot
  will rebase your branch, reformat your source code and merge as the last step
  in the review process.
- Please replace this template text with the commit message you want for your
  PR. You and/or the reviewer should keep it updated during the course of the
  review using the GitHub edit feature.
