### PR TITLE
Allow trimmer to get nodes/constraints.

### DIFF
--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -798,6 +798,16 @@ std::vector<SubmapId> PoseGraph2D::TrimmingHandle::GetSubmapIds(
   return submap_ids;
 }
 
+MapById<NodeId, TrajectoryNode>
+PoseGraph2D::TrimmingHandle::GetTrajectoryNodes() {
+  return parent_->trajectory_nodes_;
+}
+
+std::vector<PoseGraphInterface::Constraint>
+PoseGraph2D::TrimmingHandle::GetConstraints() {
+  return parent_->constraints_;
+}
+
 bool PoseGraph2D::TrimmingHandle::IsFinished(const int trajectory_id) const {
   return parent_->IsTrajectoryFinished(trajectory_id);
 }

--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -799,12 +799,12 @@ std::vector<SubmapId> PoseGraph2D::TrimmingHandle::GetSubmapIds(
 }
 
 MapById<NodeId, TrajectoryNode>
-PoseGraph2D::TrimmingHandle::GetTrajectoryNodes() {
+PoseGraph2D::TrimmingHandle::GetTrajectoryNodes() const {
   return parent_->trajectory_nodes_;
 }
 
 std::vector<PoseGraphInterface::Constraint>
-PoseGraph2D::TrimmingHandle::GetConstraints() {
+PoseGraph2D::TrimmingHandle::GetConstraints() const {
   return parent_->constraints_;
 }
 

--- a/cartographer/mapping/internal/2d/pose_graph_2d.h
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.h
@@ -283,6 +283,8 @@ class PoseGraph2D : public PoseGraph {
     std::vector<SubmapId> GetSubmapIds(int trajectory_id) const override;
     MapById<SubmapId, PoseGraphInterface::SubmapData> GetAllSubmapData()
         const override;
+    MapById<NodeId, TrajectoryNode> GetTrajectoryNodes() override;
+    std::vector<PoseGraphInterface::Constraint> GetConstraints() override;
     void MarkSubmapAsTrimmed(const SubmapId& submap_id)
         REQUIRES(parent_->mutex_) override;
     bool IsFinished(int trajectory_id) const override;

--- a/cartographer/mapping/internal/2d/pose_graph_2d.h
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.h
@@ -283,8 +283,8 @@ class PoseGraph2D : public PoseGraph {
     std::vector<SubmapId> GetSubmapIds(int trajectory_id) const override;
     MapById<SubmapId, PoseGraphInterface::SubmapData> GetAllSubmapData()
         const override;
-    MapById<NodeId, TrajectoryNode> GetTrajectoryNodes() override;
-    std::vector<PoseGraphInterface::Constraint> GetConstraints() override;
+    MapById<NodeId, TrajectoryNode> GetTrajectoryNodes() const override;
+    std::vector<PoseGraphInterface::Constraint> GetConstraints() const override;
     void MarkSubmapAsTrimmed(const SubmapId& submap_id)
         REQUIRES(parent_->mutex_) override;
     bool IsFinished(int trajectory_id) const override;

--- a/cartographer/mapping/internal/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.cc
@@ -828,6 +828,16 @@ PoseGraph3D::TrimmingHandle::GetAllSubmapData() const {
   return parent_->GetSubmapDataUnderLock();
 }
 
+MapById<NodeId, TrajectoryNode>
+PoseGraph3D::TrimmingHandle::GetTrajectoryNodes() {
+  return parent_->trajectory_nodes_;
+}
+
+std::vector<PoseGraphInterface::Constraint>
+PoseGraph3D::TrimmingHandle::GetConstraints() {
+  return parent_->constraints_;
+}
+
 bool PoseGraph3D::TrimmingHandle::IsFinished(const int trajectory_id) const {
   return parent_->IsTrajectoryFinished(trajectory_id);
 }

--- a/cartographer/mapping/internal/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.cc
@@ -829,12 +829,12 @@ PoseGraph3D::TrimmingHandle::GetAllSubmapData() const {
 }
 
 MapById<NodeId, TrajectoryNode>
-PoseGraph3D::TrimmingHandle::GetTrajectoryNodes() {
+PoseGraph3D::TrimmingHandle::GetTrajectoryNodes() const {
   return parent_->trajectory_nodes_;
 }
 
 std::vector<PoseGraphInterface::Constraint>
-PoseGraph3D::TrimmingHandle::GetConstraints() {
+PoseGraph3D::TrimmingHandle::GetConstraints() const {
   return parent_->constraints_;
 }
 

--- a/cartographer/mapping/internal/3d/pose_graph_3d.h
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.h
@@ -288,6 +288,8 @@ class PoseGraph3D : public PoseGraph {
     std::vector<SubmapId> GetSubmapIds(int trajectory_id) const override;
     MapById<SubmapId, PoseGraphInterface::SubmapData> GetAllSubmapData()
         const override;
+    MapById<NodeId, TrajectoryNode> GetTrajectoryNodes() override;
+    std::vector<PoseGraphInterface::Constraint> GetConstraints() override;
     void MarkSubmapAsTrimmed(const SubmapId& submap_id)
         REQUIRES(parent_->mutex_) override;
     bool IsFinished(int trajectory_id) const override;

--- a/cartographer/mapping/internal/3d/pose_graph_3d.h
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.h
@@ -288,8 +288,8 @@ class PoseGraph3D : public PoseGraph {
     std::vector<SubmapId> GetSubmapIds(int trajectory_id) const override;
     MapById<SubmapId, PoseGraphInterface::SubmapData> GetAllSubmapData()
         const override;
-    MapById<NodeId, TrajectoryNode> GetTrajectoryNodes() override;
-    std::vector<PoseGraphInterface::Constraint> GetConstraints() override;
+    MapById<NodeId, TrajectoryNode> GetTrajectoryNodes() const override;
+    std::vector<PoseGraphInterface::Constraint> GetConstraints() const override;
     void MarkSubmapAsTrimmed(const SubmapId& submap_id)
         REQUIRES(parent_->mutex_) override;
     bool IsFinished(int trajectory_id) const override;

--- a/cartographer/mapping/pose_graph_trimmer.h
+++ b/cartographer/mapping/pose_graph_trimmer.h
@@ -34,8 +34,9 @@ class Trimmable {
   virtual std::vector<SubmapId> GetSubmapIds(int trajectory_id) const = 0;
   virtual MapById<SubmapId, PoseGraphInterface::SubmapData> GetAllSubmapData()
       const = 0;
-  virtual MapById<NodeId, TrajectoryNode> GetTrajectoryNodes() = 0;
-  virtual std::vector<PoseGraphInterface::Constraint> GetConstraints() = 0;
+  virtual MapById<NodeId, TrajectoryNode> GetTrajectoryNodes() const = 0;
+  virtual std::vector<PoseGraphInterface::Constraint> GetConstraints()
+      const = 0;
 
   // Marks 'submap_id' and corresponding intra-submap nodes as trimmed. They
   // will no longer take part in scan matching, loop closure, visualization.

--- a/cartographer/mapping/pose_graph_trimmer.h
+++ b/cartographer/mapping/pose_graph_trimmer.h
@@ -34,6 +34,8 @@ class Trimmable {
   virtual std::vector<SubmapId> GetSubmapIds(int trajectory_id) const = 0;
   virtual MapById<SubmapId, PoseGraphInterface::SubmapData> GetAllSubmapData()
       const = 0;
+  virtual MapById<NodeId, TrajectoryNode> GetTrajectoryNodes() = 0;
+  virtual std::vector<PoseGraphInterface::Constraint> GetConstraints() = 0;
 
   // Marks 'submap_id' and corresponding intra-submap nodes as trimmed. They
   // will no longer take part in scan matching, loop closure, visualization.

--- a/cartographer/mapping/pose_graph_trimmer_test.cc
+++ b/cartographer/mapping/pose_graph_trimmer_test.cc
@@ -47,9 +47,11 @@ class FakePoseGraph : public Trimmable {
     return {};
   }
 
-  MapById<NodeId, TrajectoryNode> GetTrajectoryNodes() override { return {}; }
+  MapById<NodeId, TrajectoryNode> GetTrajectoryNodes() const override {
+    return {};
+  }
 
-  std::vector<PoseGraphInterface::Constraint> GetConstraints() override {
+  std::vector<PoseGraphInterface::Constraint> GetConstraints() const override {
     return {};
   }
 

--- a/cartographer/mapping/pose_graph_trimmer_test.cc
+++ b/cartographer/mapping/pose_graph_trimmer_test.cc
@@ -47,6 +47,12 @@ class FakePoseGraph : public Trimmable {
     return {};
   }
 
+  MapById<NodeId, TrajectoryNode> GetTrajectoryNodes() override { return {}; }
+
+  std::vector<PoseGraphInterface::Constraint> GetConstraints() override {
+    return {};
+  }
+
   void MarkSubmapAsTrimmed(const SubmapId& submap_id) override {
     trimmed_submaps_.push_back(submap_id);
   }


### PR DESCRIPTION
We can compute timestamp for submaps using this data.