### PR TITLE
Allow execution of Submap2D::ToResponseProto without a grid

### DIFF
--- a/cartographer/mapping/2d/submap_2d.cc
+++ b/cartographer/mapping/2d/submap_2d.cc
@@ -103,9 +103,7 @@ void Submap2D::UpdateFromProto(const proto::Submap& proto) {
 void Submap2D::ToResponseProto(
     const transform::Rigid3d&,
     proto::SubmapQuery::Response* const response) const {
-  if (!probability_grid_) {
-    return;
-  }
+  if (!probability_grid_) return;
   response->set_submap_version(num_range_data());
 
   Eigen::Array2i offset;

--- a/cartographer/mapping/2d/submap_2d.cc
+++ b/cartographer/mapping/2d/submap_2d.cc
@@ -103,7 +103,9 @@ void Submap2D::UpdateFromProto(const proto::Submap& proto) {
 void Submap2D::ToResponseProto(
     const transform::Rigid3d&,
     proto::SubmapQuery::Response* const response) const {
-  CHECK(probability_grid_);
+  if (!probability_grid_) {
+    return;
+  }
   response->set_submap_version(num_range_data());
 
   Eigen::Array2i offset;


### PR DESCRIPTION
- related to https://github.com/googlecartographer/cartographer_ros/issues/819