### PR TITLE
Ignore non-ordered data added to an ordered queue

### DIFF
--- a/cartographer/sensor/internal/ordered_multi_queue.cc
+++ b/cartographer/sensor/internal/ordered_multi_queue.cc
@@ -104,13 +104,16 @@ void OrderedMultiQueue::Dispatch() {
         CannotMakeProgress(it->first);
         return;
       }
+      if (last_dispatched_time_ > data->GetTime()) {
+        LOG(WARNING) << "Dropping non-sorted data on queue: '" << it->first << "'";
+        it->second.queue.Pop();
+        continue;
+      }
       if (next_data == nullptr || data->GetTime() < next_data->GetTime()) {
         next_data = data;
         next_queue = &it->second;
         next_queue_key = it->first;
       }
-      CHECK_LE(last_dispatched_time_, next_data->GetTime())
-          << "Non-sorted data added to queue: '" << it->first << "'";
       ++it;
     }
     if (next_data == nullptr) {

--- a/cartographer/sensor/internal/ordered_multi_queue.cc
+++ b/cartographer/sensor/internal/ordered_multi_queue.cc
@@ -105,7 +105,8 @@ void OrderedMultiQueue::Dispatch() {
         return;
       }
       if (last_dispatched_time_ > data->GetTime()) {
-        LOG(WARNING) << "Dropping non-sorted data on queue: '" << it->first << "'";
+        LOG(WARNING) << "Dropping non-sorted data on queue: '" << it->first
+                     << "'";
         it->second.queue.Pop();
         continue;
       }

--- a/cartographer/sensor/internal/ordered_multi_queue_test.cc
+++ b/cartographer/sensor/internal/ordered_multi_queue_test.cc
@@ -78,6 +78,25 @@ TEST_F(OrderedMultiQueueTest, Ordering) {
   }
 }
 
+TEST_F(OrderedMultiQueueTest, OutOfOrderIsDropped) {
+  queue_.Add(kFirst, MakeImu(0));
+  queue_.Add(kFirst, MakeImu(7));
+  queue_.Add(kFirst, MakeImu(6));
+  EXPECT_TRUE(values_.empty());
+  queue_.Add(kSecond, MakeImu(0));
+  queue_.Add(kSecond, MakeImu(1));
+  EXPECT_TRUE(values_.empty());
+  queue_.Add(kThird, MakeImu(0));
+  queue_.Add(kThird, MakeImu(2));
+  EXPECT_EQ(values_.size(), 4);
+  queue_.Flush();
+
+  EXPECT_EQ(6, values_.size());
+  for (size_t i = 0; i < values_.size() - 1; ++i) {
+    EXPECT_LE(values_[i]->GetTime(), values_[i + 1]->GetTime());
+  }
+}
+
 TEST_F(OrderedMultiQueueTest, MarkQueueAsFinished) {
   queue_.Add(kFirst, MakeImu(1));
   queue_.Add(kFirst, MakeImu(2));


### PR DESCRIPTION
This stops Cartographer from crashing when it gets occasionally bad data
from one of its sources.
