### PR TITLE
Limit `bazel test` parallelism more precisely

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,8 +3,5 @@ platforms:
   ubuntu1604:
     build_targets:
     - "..."
-    # Tests cannot run concurrently as some of them open the same port.
-    test_flags:
-    - "--jobs=1"
     test_targets:
     - "..."

--- a/cartographer/cloud/BUILD.bazel
+++ b/cartographer/cloud/BUILD.bazel
@@ -89,6 +89,8 @@ cc_binary(
     name = src.replace("/", "_").replace(".cc", ""),
     srcs = [src],
     data = ["//:configuration_files"],
+    # Tests cannot run concurrently as some of them open the same port.
+    tags = ["exclusive"],
     deps = [
         ":cartographer_grpc",
         "@com_google_googletest//:gtest_main",


### PR DESCRIPTION
Since it is only the tests in cartographer/cloud that cannot run
concurrently with each other, use `tags = ["exclusive"]` to say that
they should not be run at the same time as other tests.

This works locally, not just in CI, and should speed up the CI job by
2-3 minutes.
