### PR TITLE
Tests were not linked against prometheus-cc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ foreach(ABS_FIL ${ALL_TESTS})
     target_link_libraries("${TEST_TARGET_NAME}" PUBLIC async_grpc)
   endif()
   if(${BUILD_PROMETHEUS})
-    target_link_libraries(${PROJECT_NAME} PUBLIC prometheus-cpp)
+    target_link_libraries("${TEST_TARGET_NAME}" PUBLIC prometheus-cpp)
   endif()
 endforeach()
 


### PR DESCRIPTION
Fixed typo in the CMakeLists file: tests were not linked against prometheus-cc 