### PR TITLE
Register MapBuilderServer metrics

### DIFF
--- a/cartographer/cloud/map_builder_server_interface.cc
+++ b/cartographer/cloud/map_builder_server_interface.cc
@@ -6,6 +6,10 @@
 namespace cartographer {
 namespace cloud {
 
+void MapBuilderServerInterface::RegisterMetrics(metrics::FamilyFactory* factory) {
+  MapBuilderServer::RegisterMetrics(factory);
+}
+
 std::unique_ptr<MapBuilderServerInterface> CreateMapBuilderServer(
     const proto::MapBuilderServerOptions& map_builder_server_options,
     std::unique_ptr<mapping::MapBuilderInterface> map_builder) {

--- a/cartographer/cloud/map_builder_server_interface.cc
+++ b/cartographer/cloud/map_builder_server_interface.cc
@@ -6,7 +6,7 @@
 namespace cartographer {
 namespace cloud {
 
-void RegisterMapBuilderServerMetrics(metrics::FamilyFactory *factory) {
+void RegisterMapBuilderServerMetrics(metrics::FamilyFactory* factory) {
   MapBuilderServer::RegisterMetrics(factory);
 }
 

--- a/cartographer/cloud/map_builder_server_interface.cc
+++ b/cartographer/cloud/map_builder_server_interface.cc
@@ -6,7 +6,7 @@
 namespace cartographer {
 namespace cloud {
 
-void MapBuilderServerInterface::RegisterMetrics(metrics::FamilyFactory* factory) {
+void RegisterMapBuilderServerMetrics(metrics::FamilyFactory *factory) {
   MapBuilderServer::RegisterMetrics(factory);
 }
 

--- a/cartographer/cloud/map_builder_server_interface.h
+++ b/cartographer/cloud/map_builder_server_interface.h
@@ -47,7 +47,7 @@ class MapBuilderServerInterface {
 };
 
 // Registers all metrics for the MapBuilderServer.
-void RegisterMapBuilderServerMetrics(metrics::FamilyFactory *factory);
+void RegisterMapBuilderServerMetrics(metrics::FamilyFactory* factory);
 
 // Returns MapBuilderServer with the actual implementation.
 std::unique_ptr<MapBuilderServerInterface> CreateMapBuilderServer(

--- a/cartographer/cloud/map_builder_server_interface.h
+++ b/cartographer/cloud/map_builder_server_interface.h
@@ -21,6 +21,7 @@
 
 #include "cartographer/cloud/proto/map_builder_server_options.pb.h"
 #include "cartographer/mapping/map_builder_interface.h"
+#include "cartographer/metrics/family_factory.h"
 
 namespace cartographer {
 namespace cloud {
@@ -43,6 +44,9 @@ class MapBuilderServerInterface {
   // Shuts down the gRPC server, the 'LocalTrajectoryUploader' and the SLAM
   // thread.
   virtual void Shutdown() = 0;
+
+  // Registers all metrics for the MapBuilderServer.
+  static void RegisterMetrics(metrics::FamilyFactory* factory);
 };
 
 // Returns MapBuilderServer with the actual implementation.

--- a/cartographer/cloud/map_builder_server_interface.h
+++ b/cartographer/cloud/map_builder_server_interface.h
@@ -44,10 +44,10 @@ class MapBuilderServerInterface {
   // Shuts down the gRPC server, the 'LocalTrajectoryUploader' and the SLAM
   // thread.
   virtual void Shutdown() = 0;
-
-  // Registers all metrics for the MapBuilderServer.
-  static void RegisterMetrics(metrics::FamilyFactory* factory);
 };
+
+// Registers all metrics for the MapBuilderServer.
+void RegisterMapBuilderServerMetrics(metrics::FamilyFactory *factory);
 
 // Returns MapBuilderServer with the actual implementation.
 std::unique_ptr<MapBuilderServerInterface> CreateMapBuilderServer(

--- a/cartographer/cloud/map_builder_server_main.cc
+++ b/cartographer/cloud/map_builder_server_main.cc
@@ -41,7 +41,7 @@ void Run(const std::string& configuration_directory,
 #if USE_PROMETHEUS
   metrics::prometheus::FamilyFactory registry;
   ::cartographer::metrics::RegisterAllMetrics(&registry);
-  MapBuilderServerInterface::RegisterMetrics(&registry);
+  RegisterMapBuilderServerMetrics(&registry);
   ::prometheus::Exposer exposer("0.0.0.0:9100");
   exposer.RegisterCollectable(registry.GetCollectable());
   LOG(INFO) << "Exposing metrics at http://localhost:9100/metrics";

--- a/cartographer/cloud/map_builder_server_main.cc
+++ b/cartographer/cloud/map_builder_server_main.cc
@@ -41,6 +41,7 @@ void Run(const std::string& configuration_directory,
 #if USE_PROMETHEUS
   metrics::prometheus::FamilyFactory registry;
   ::cartographer::metrics::RegisterAllMetrics(&registry);
+  MapBuilderServerInterface::RegisterMetrics(&registry);
   ::prometheus::Exposer exposer("0.0.0.0:9100");
   exposer.RegisterCollectable(registry.GetCollectable());
   LOG(INFO) << "Exposing metrics at http://localhost:9100/metrics";


### PR DESCRIPTION
I am not adding these registration calls to `cartographer/metrics/register.cc` because they are specific to cloud based mapping.