### PR TITLE
Option for only local constraint search

### DIFF
--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -214,6 +214,7 @@ void PoseGraph2D::ComputeConstraint(const NodeId& node_id,
       data_.trajectory_connectivity_state.LastConnectionTime(
           node_id.trajectory_id, submap_id.trajectory_id);
   if (node_id.trajectory_id == submap_id.trajectory_id ||
+      options_.global_constraint_search_after_n_seconds() <= 0.0 ||
       node_time <
           last_connection_time +
               common::FromSeconds(

--- a/cartographer/mapping/internal/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.cc
@@ -235,6 +235,7 @@ void PoseGraph3D::ComputeConstraint(const NodeId& node_id,
       data_.trajectory_connectivity_state.LastConnectionTime(
           node_id.trajectory_id, submap_id.trajectory_id);
   if (node_id.trajectory_id == submap_id.trajectory_id ||
+      options_.global_constraint_search_after_n_seconds() <= 0.0 ||
       node_time <
           last_connection_time +
               common::FromSeconds(

--- a/cartographer/mapping/proto/pose_graph_options.proto
+++ b/cartographer/mapping/proto/pose_graph_options.proto
@@ -54,5 +54,6 @@ message PoseGraphOptions {
   // If for the duration specified by this option no global contraint has been
   // added between two trajectories, loop closure searches will be performed
   // globally rather than in a smaller search window.
+  // Set to <= 0.0 to disable.
   double global_constraint_search_after_n_seconds = 10;
 }


### PR DESCRIPTION
Quite often the starting point of the vehicle is known and the _"kidnapped robot"_ problem has not to be solved. 

When running with an existing trajectory (e.g. in `pure_localization` mode) a global constraint search is performed at start. The global search and continues until a constraint is found and the local search kicks in only afterwards. 
This behavior might be undesired if the starting position of the vehicle is known and the trajectory start pose is set close to the true pose.

This PR allows to specify `global_constraint_search_after_n_seconds` to `<= 0.0` to disable all global constraint search.
