### PR TITLE
expose internal velocities of cartographer

### DIFF
--- a/cartographer/mapping/pose_extrapolator.cc
+++ b/cartographer/mapping/pose_extrapolator.cc
@@ -51,6 +51,14 @@ std::unique_ptr<PoseExtrapolator> PoseExtrapolator::InitializeWithImu(
   return extrapolator;
 }
 
+Eigen::Vector3d PoseExtrapolator::LinearVelocity() {
+  return linear_velocity_from_poses_;
+}
+
+Eigen::Vector3d PoseExtrapolator::AngularVelocity() {
+  return angular_velocity_from_poses_;
+}
+
 common::Time PoseExtrapolator::GetLastPoseTime() const {
   if (timed_pose_queue_.empty()) {
     return common::Time::min();

--- a/cartographer/mapping/pose_extrapolator.h
+++ b/cartographer/mapping/pose_extrapolator.h
@@ -48,6 +48,8 @@ class PoseExtrapolator {
   // yet.
   common::Time GetLastPoseTime() const;
   common::Time GetLastExtrapolatedTime() const;
+  Eigen::Vector3d LinearVelocity();
+  Eigen::Vector3d AngularVelocity();
 
   void AddPose(common::Time time, const transform::Rigid3d& pose);
   void AddImuData(const sensor::ImuData& imu_data);


### PR DESCRIPTION
Found the linear and angular velocities kept in PoseExtrapolator useful for downstream planning tasks. This PR is just exposing these private class members. I'm thinking they could be useful for others as well. 