### PR TITLE
fix: cartographer depends on libceres-dev

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -37,9 +37,9 @@
   <build_depend>python-sphinx</build_depend>
 
   <depend>boost</depend>
-  <depend>ceres-solver</depend>
   <depend>eigen</depend>
   <depend>libcairo2-dev</depend>
+  <depend>libceres-dev</depend>
   <depend>libgflags-dev</depend>
   <depend>libgoogle-glog-dev</depend>
   <depend>lua5.2-dev</depend>


### PR DESCRIPTION
The entry in the [rosdistro base file](https://github.com/ros/rosdistro/blob/f7a4e335f2db9827d701784cfa47ede954142f38/rosdep/base.yaml#L1501) is not `ceres-solver` but `libceres-dev`

This is needed when using rosdep and will allow detection of ceres provided by ubuntu