### PR TITLE
Add CSV export to the evaluation tool

### DIFF
--- a/cartographer/ground_truth/autogenerate_ground_truth_main.cc
+++ b/cartographer/ground_truth/autogenerate_ground_truth_main.cc
@@ -121,9 +121,10 @@ proto::GroundTruth GenerateGroundTruth(
         submap_to_node_index.at(constraint.submap_id().submap_index());
 
     // Covered distance between the two should not be too small.
-    if (std::abs(covered_distance.at(matched_node) -
-                 covered_distance.at(representative_node)) <
-        min_covered_distance) {
+    double covered_distance_in_constraint =
+        covered_distance.at(matched_node) -
+        covered_distance.at(representative_node);
+    if (covered_distance_in_constraint < min_covered_distance) {
       continue;
     }
 
@@ -157,6 +158,7 @@ proto::GroundTruth GenerateGroundTruth(
         trajectory.node(representative_node).timestamp());
     new_relation->set_timestamp2(trajectory.node(matched_node).timestamp());
     *new_relation->mutable_expected() = transform::ToProto(expected);
+    new_relation->set_covered_distance(covered_distance_in_constraint);
   }
   LOG(INFO) << "Generated " << ground_truth.relation_size()
             << " relations and ignored " << num_outliers << " outliers.";

--- a/cartographer/ground_truth/autogenerate_ground_truth_main.cc
+++ b/cartographer/ground_truth/autogenerate_ground_truth_main.cc
@@ -122,8 +122,8 @@ proto::GroundTruth GenerateGroundTruth(
 
     // Covered distance between the two should not be too small.
     double covered_distance_in_constraint =
-        covered_distance.at(matched_node) -
-        covered_distance.at(representative_node);
+        std::abs(covered_distance.at(matched_node) -
+                 covered_distance.at(representative_node));
     if (covered_distance_in_constraint < min_covered_distance) {
       continue;
     }

--- a/cartographer/ground_truth/compute_relations_metrics_main.cc
+++ b/cartographer/ground_truth/compute_relations_metrics_main.cc
@@ -122,7 +122,7 @@ void WriteRelationMetricsToFile(const std::vector<Error>& errors,
   std::vector<double> rotational_errors_degrees;
   std::vector<double> squared_rotational_errors_degrees;
   CHECK_EQ(errors.size(), ground_truth.relation_size());
-  size_t n = errors.size();
+  size_t num_errors = errors.size();
   std::ofstream relation_errors_file;
   std::string log_file_path;
   LOG(INFO) << "Writing relation metrics to '" + relation_metrics_filename +
@@ -134,9 +134,10 @@ void WriteRelationMetricsToFile(const std::vector<Error>& errors,
          "expected_translation_x,expected_translation_y,expected_"
          "translation_z,expected_rotation_w,expected_rotation_x,"
          "expected_rotation_y,expected_rotation_z,covered_distance\n";
-  for (size_t i = 0; i < n; ++i) {
-    const Error& error = errors[i];
-    const proto::Relation& relation = ground_truth.relation(i);
+  for (size_t relation_index = 0; relation_index < num_errors;
+       ++relation_index) {
+    const Error& error = errors[relation_index];
+    const proto::Relation& relation = ground_truth.relation(relation_index);
     double translational_error = std::sqrt(error.translational_squared);
     double squared_translational_error = error.translational_squared;
     double rotational_errors_degree =

--- a/cartographer/ground_truth/proto/relations.proto
+++ b/cartographer/ground_truth/proto/relations.proto
@@ -25,6 +25,7 @@ message Relation {
   // The 'expected' relative transform of the tracking frame from 'timestamp2'
   // to 'timestamp1'.
   transform.proto.Rigid3d expected = 3;
+  double covered_distance = 4;
 }
 
 message GroundTruth {


### PR DESCRIPTION
- adds `covered_distance` to the ground truth relations
- the flags `write_relation_metrics` and `relation_metrics_filename` control whether and where to write the relations metrics as comma-separated values
