### PR TITLE
Defining new serialization proto

### DIFF
--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -25,6 +25,7 @@
 #include "cartographer/mapping/internal/3d/pose_graph_3d.h"
 #include "cartographer/mapping/internal/collated_trajectory_builder.h"
 #include "cartographer/mapping/internal/global_trajectory_builder.h"
+#include "cartographer/mapping/proto/internal/legacy_serialized_data.pb.h"
 #include "cartographer/sensor/internal/collator.h"
 #include "cartographer/sensor/internal/trajectory_collator.h"
 #include "cartographer/sensor/internal/voxel_filter.h"
@@ -212,7 +213,7 @@ void MapBuilder::SerializeState(io::ProtoStreamWriterInterface* const writer) {
   // Next we serialize all submap data.
   {
     for (const auto& submap_id_data : pose_graph_->GetAllSubmapData()) {
-      proto::SerializedData proto;
+      proto::LegacySerializedData proto;
       auto* const submap_proto = proto.mutable_submap();
       submap_proto->mutable_submap_id()->set_trajectory_id(
           submap_id_data.id.trajectory_id);
@@ -226,7 +227,7 @@ void MapBuilder::SerializeState(io::ProtoStreamWriterInterface* const writer) {
   // Next we serialize all node data.
   {
     for (const auto& node_id_data : pose_graph_->GetTrajectoryNodes()) {
-      proto::SerializedData proto;
+      proto::LegacySerializedData proto;
       auto* const node_proto = proto.mutable_node();
       node_proto->mutable_node_id()->set_trajectory_id(
           node_id_data.id.trajectory_id);
@@ -241,7 +242,7 @@ void MapBuilder::SerializeState(io::ProtoStreamWriterInterface* const writer) {
     const auto all_imu_data = pose_graph_->GetImuData();
     for (const int trajectory_id : all_imu_data.trajectory_ids()) {
       for (const auto& imu_data : all_imu_data.trajectory(trajectory_id)) {
-        proto::SerializedData proto;
+        proto::LegacySerializedData proto;
         auto* const imu_data_proto = proto.mutable_imu_data();
         imu_data_proto->set_trajectory_id(trajectory_id);
         *imu_data_proto->mutable_imu_data() = sensor::ToProto(imu_data);
@@ -255,7 +256,7 @@ void MapBuilder::SerializeState(io::ProtoStreamWriterInterface* const writer) {
     for (const int trajectory_id : all_odometry_data.trajectory_ids()) {
       for (const auto& odometry_data :
            all_odometry_data.trajectory(trajectory_id)) {
-        proto::SerializedData proto;
+        proto::LegacySerializedData proto;
         auto* const odometry_data_proto = proto.mutable_odometry_data();
         odometry_data_proto->set_trajectory_id(trajectory_id);
         *odometry_data_proto->mutable_odometry_data() =
@@ -270,7 +271,7 @@ void MapBuilder::SerializeState(io::ProtoStreamWriterInterface* const writer) {
     for (const int trajectory_id : all_fixed_frame_pose_data.trajectory_ids()) {
       for (const auto& fixed_frame_pose_data :
            all_fixed_frame_pose_data.trajectory(trajectory_id)) {
-        proto::SerializedData proto;
+        proto::LegacySerializedData proto;
         auto* const fixed_frame_pose_data_proto =
             proto.mutable_fixed_frame_pose_data();
         fixed_frame_pose_data_proto->set_trajectory_id(trajectory_id);
@@ -284,7 +285,7 @@ void MapBuilder::SerializeState(io::ProtoStreamWriterInterface* const writer) {
   {
     const auto all_trajectory_data = pose_graph_->GetTrajectoryData();
     for (const auto& trajectory_data : all_trajectory_data) {
-      proto::SerializedData proto;
+      proto::LegacySerializedData proto;
       auto* const trajectory_data_proto = proto.mutable_trajectory_data();
       trajectory_data_proto->set_trajectory_id(trajectory_data.first);
       trajectory_data_proto->set_gravity_constant(
@@ -308,7 +309,7 @@ void MapBuilder::SerializeState(io::ProtoStreamWriterInterface* const writer) {
         all_landmark_nodes = pose_graph_->GetLandmarkNodes();
     for (const auto& node : all_landmark_nodes) {
       for (const auto& observation : node.second.landmark_observations) {
-        proto::SerializedData proto;
+        proto::LegacySerializedData proto;
         auto* landmark_data_proto = proto.mutable_landmark_data();
         landmark_data_proto->set_trajectory_id(observation.trajectory_id);
         landmark_data_proto->mutable_landmark_data()->set_timestamp(
@@ -389,7 +390,7 @@ void MapBuilder::LoadState(io::ProtoStreamReaderInterface* const reader,
   }
 
   for (;;) {
-    proto::SerializedData proto;
+    proto::LegacySerializedData proto;
     if (!reader->ReadProto(&proto)) {
       break;
     }

--- a/cartographer/mapping/proto/internal/legacy_serialized_data.proto
+++ b/cartographer/mapping/proto/internal/legacy_serialized_data.proto
@@ -1,0 +1,29 @@
+// Copyright 2018 The Cartographer Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cartographer.mapping.proto;
+
+import "cartographer/mapping/proto/serialization.proto";
+
+message LegacySerializedData {
+  Submap submap = 1;
+  Node node = 2;
+  ImuData imu_data = 3;
+  OdometryData odometry_data = 4;
+  FixedFramePoseData fixed_frame_pose_data = 5;
+  TrajectoryData trajectory_data = 6;
+  LandmarkData landmark_data = 7;
+}

--- a/cartographer/mapping/proto/serialization.proto
+++ b/cartographer/mapping/proto/serialization.proto
@@ -20,6 +20,7 @@ import "cartographer/mapping/proto/pose_graph.proto";
 import "cartographer/mapping/proto/submap.proto";
 import "cartographer/mapping/proto/trajectory_node_data.proto";
 import "cartographer/sensor/proto/sensor.proto";
+import "cartographer/mapping/proto/trajectory_builder_options.proto";
 import "cartographer/transform/proto/transform.proto";
 
 message Submap {
@@ -60,18 +61,28 @@ message TrajectoryData {
   transform.proto.Rigid3d fixed_frame_origin_in_map = 4;
 }
 
-message SerializedData {
-  Submap submap = 1;
-  Node node = 2;
-  ImuData imu_data = 3;
-  OdometryData odometry_data = 4;
-  FixedFramePoseData fixed_frame_pose_data = 5;
-  TrajectoryData trajectory_data = 6;
-  LandmarkData landmark_data = 7;
-}
-
 message LocalSlamResultData {
   int64 timestamp = 1;
   TrajectoryNodeData node_data = 2;
   repeated Submap submaps = 3;
+}
+
+// Header of the serialization format. At the moment it only contains the
+// version of the format.
+message SerializationHeader {
+  uint32 format_version = 1;
+}
+
+message SerializedData {
+  oneof data {
+    PoseGraph pose_graph = 1;
+    AllTrajectoryBuilderOptions all_trajectory_builder_options = 2;
+    Submap submap = 3;
+    Node node = 4;
+    TrajectoryData trajectory_data = 5;
+    ImuData imu_data = 6;
+    OdometryData odometry_data = 7;
+    FixedFramePoseData fixed_frame_pose_data = 8;
+    LandmarkData landmark_data = 9;
+  }
 }


### PR DESCRIPTION
Definition of new serialization protos as defined in [RFC 0021](https://github.com/sebastianklose/rfcs/blob/serialization_format/text/0021-serialization-format.md)

The "old" proto definition is moved to an internal legacy_serialized_data.proto and still the ones being used for now.
