### PR TITLE
Adding short description of pbstream migration tool

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,7 @@ Cartographer
    evaluation
    terminology
    cost_functions
+   pbstream_migration
 
 `Cartographer`_ is a system that provides real-time simultaneous localization
 and mapping (`SLAM`_) in 2D and 3D across multiple platforms and sensor

--- a/docs/source/pbstream_migration.rst
+++ b/docs/source/pbstream_migration.rst
@@ -1,0 +1,39 @@
+.. Copyright 2018 The Cartographer Authors
+
+.. Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+..      http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=================================
+Migration tool for pbstream files
+=================================
+
+With the update of the pbstream serialization format as discussed in
+`RFC-0021`_, previously serialized pbstream files are not loadable in
+Cartographer 1.0 anymore.
+
+In order to enable users to reuse previously generated pbstream files, we
+provide a migration tool which converts pbstreams from Cartographer 0.3 to the
+new serialization format used in Cartographer 1.0.
+
+The tool is shipped as part of Cartographer (`source`_) and once built can be
+invoked as follows:::
+
+  cartographer_migrate_serialization_format \
+        --original_pbstream_file=old.pbstream \
+        --output_pbstream_file=new.pbstream
+
+The tool assumes that the pbstream provided via the ``--original_pbstream_file``
+argument, follows the serialization format of Cartographer 0.3. The resulting
+1.0 pbstream will be saved to the ``--output_pbstream_file`` location.
+
+.. _RFC-0021: https://github.com/googlecartographer/rfcs/blob/master/text/0021-serialization-format.md
+.. _source: https://github.com/googlecartographer/cartographer/blob/master/cartographer/io/migrate_serialization_format_main.cc


### PR DESCRIPTION
Adding a section to the docs, describing the existence and usage of the serialization migration tool.