### PR TITLE
Fixing 846 without tests.

### DIFF
--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -397,14 +397,17 @@ void PoseGraph2D::WaitForAllComputations() {
                 !work_queue_);
       },
       common::FromSeconds(1.))) {
-    std::ostringstream progress_info;
-    progress_info << "Optimizing: " << std::fixed << std::setprecision(1)
-                  << 100. *
-                         (constraint_builder_.GetNumFinishedNodes() -
-                          num_finished_nodes_at_start) /
-                         (num_trajectory_nodes_ - num_finished_nodes_at_start)
-                  << "%...";
-    std::cout << "\r\x1b[K" << progress_info.str() << std::flush;
+      // Log progress on nodes only when we are actually processing nodes.
+      if (num_trajectory_nodes_ != num_finished_nodes_at_start) {
+          std::ostringstream progress_info;
+          progress_info << "Optimizing: " << std::fixed << std::setprecision(1)
+                        << 100. *
+                              (constraint_builder_.GetNumFinishedNodes() -
+                                num_finished_nodes_at_start) /
+                              (num_trajectory_nodes_ - num_finished_nodes_at_start)
+                        << "%...";
+          std::cout << "\r\x1b[K" << progress_info.str() << std::flush;
+      }
   }
   std::cout << "\r\x1b[KOptimizing: Done.     " << std::endl;
   constraint_builder_.WhenDone(

--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -397,17 +397,17 @@ void PoseGraph2D::WaitForAllComputations() {
                 !work_queue_);
       },
       common::FromSeconds(1.))) {
-      // Log progress on nodes only when we are actually processing nodes.
-      if (num_trajectory_nodes_ != num_finished_nodes_at_start) {
-          std::ostringstream progress_info;
-          progress_info << "Optimizing: " << std::fixed << std::setprecision(1)
-                        << 100. *
-                              (constraint_builder_.GetNumFinishedNodes() -
-                                num_finished_nodes_at_start) /
-                              (num_trajectory_nodes_ - num_finished_nodes_at_start)
-                        << "%...";
-          std::cout << "\r\x1b[K" << progress_info.str() << std::flush;
-      }
+    // Log progress on nodes only when we are actually processing nodes.
+    if (num_trajectory_nodes_ != num_finished_nodes_at_start) {
+      std::ostringstream progress_info;
+      progress_info << "Optimizing: " << std::fixed << std::setprecision(1)
+                    << 100. *
+                           (constraint_builder_.GetNumFinishedNodes() -
+                            num_finished_nodes_at_start) /
+                           (num_trajectory_nodes_ - num_finished_nodes_at_start)
+                    << "%...";
+      std::cout << "\r\x1b[K" << progress_info.str() << std::flush;
+    }
   }
   std::cout << "\r\x1b[KOptimizing: Done.     " << std::endl;
   constraint_builder_.WhenDone(

--- a/cartographer/mapping/internal/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.cc
@@ -412,17 +412,17 @@ void PoseGraph3D::WaitForAllComputations() {
                 !work_queue_);
       },
       common::FromSeconds(1.))) {
-      // Log progress on nodes only when we are actually processing nodes.
-      if (num_trajectory_nodes_ != num_finished_nodes_at_start) {
-          std::ostringstream progress_info;
-          progress_info << "Optimizing: " << std::fixed << std::setprecision(1)
-                        << 100. *
-                              (constraint_builder_.GetNumFinishedNodes() -
-                                num_finished_nodes_at_start) /
-                              (num_trajectory_nodes_ - num_finished_nodes_at_start)
-                        << "%...";
-          std::cout << "\r\x1b[K" << progress_info.str() << std::flush;
-      }
+    // Log progress on nodes only when we are actually processing nodes.
+    if (num_trajectory_nodes_ != num_finished_nodes_at_start) {
+      std::ostringstream progress_info;
+      progress_info << "Optimizing: " << std::fixed << std::setprecision(1)
+                    << 100. *
+                           (constraint_builder_.GetNumFinishedNodes() -
+                            num_finished_nodes_at_start) /
+                           (num_trajectory_nodes_ - num_finished_nodes_at_start)
+                    << "%...";
+      std::cout << "\r\x1b[K" << progress_info.str() << std::flush;
+    }
   }
   std::cout << "\r\x1b[KOptimizing: Done.     " << std::endl;
   constraint_builder_.WhenDone(

--- a/cartographer/mapping/internal/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.cc
@@ -412,14 +412,17 @@ void PoseGraph3D::WaitForAllComputations() {
                 !work_queue_);
       },
       common::FromSeconds(1.))) {
-    std::ostringstream progress_info;
-    progress_info << "Optimizing: " << std::fixed << std::setprecision(1)
-                  << 100. *
-                         (constraint_builder_.GetNumFinishedNodes() -
-                          num_finished_nodes_at_start) /
-                         (num_trajectory_nodes_ - num_finished_nodes_at_start)
-                  << "%...";
-    std::cout << "\r\x1b[K" << progress_info.str() << std::flush;
+      // Log progress on nodes only when we are actually processing nodes.
+      if (num_trajectory_nodes_ != num_finished_nodes_at_start) {
+          std::ostringstream progress_info;
+          progress_info << "Optimizing: " << std::fixed << std::setprecision(1)
+                        << 100. *
+                              (constraint_builder_.GetNumFinishedNodes() -
+                                num_finished_nodes_at_start) /
+                              (num_trajectory_nodes_ - num_finished_nodes_at_start)
+                        << "%...";
+          std::cout << "\r\x1b[K" << progress_info.str() << std::flush;
+      }
   }
   std::cout << "\r\x1b[KOptimizing: Done.     " << std::endl;
   constraint_builder_.WhenDone(


### PR DESCRIPTION
Fixing "Optimizing: -nan%... #846" https://github.com/googlecartographer/cartographer/issues/846.
The issue was triggered in a multithreaded execution, when all nodes were processed, but the working queue was still non empty (having other kind of jobs).
Unfortunately I failed to reproduce the bug in tests, so no new tests were added.