### PR TITLE
Skip the Collator for the landmark data.

### DIFF
--- a/cartographer/mapping/internal/collated_trajectory_builder.cc
+++ b/cartographer/mapping/internal/collated_trajectory_builder.cc
@@ -38,6 +38,8 @@ CollatedTrajectoryBuilder::CollatedTrajectoryBuilder(
       last_logging_time_(std::chrono::steady_clock::now()) {
   std::unordered_set<std::string> expected_sensor_id_strings;
   for (const auto& sensor_id : expected_sensor_ids) {
+    // Landmark data does not need to be collated.
+    if (sensor_id.type == SensorId::SensorType::LANDMARK) continue;
     expected_sensor_id_strings.insert(sensor_id.id);
   }
   sensor_collator_->AddTrajectory(

--- a/cartographer/mapping/internal/collated_trajectory_builder.h
+++ b/cartographer/mapping/internal/collated_trajectory_builder.h
@@ -74,7 +74,7 @@ class CollatedTrajectoryBuilder : public TrajectoryBuilderInterface {
 
   void AddSensorData(const std::string& sensor_id,
                      const sensor::LandmarkData& landmark_data) override {
-    AddData(sensor::MakeDispatchable(sensor_id, landmark_data));
+    wrapped_trajectory_builder_->AddSensorData(sensor_id, landmark_data);
   }
 
   void AddLocalSlamResultData(std::unique_ptr<mapping::LocalSlamResultData>


### PR DESCRIPTION
The landmark data does not need to be collated. It contains a timestamp that will be later used to find the neighboring trajectory nodes. We can directly pass the landmarks to the GlobalTrajectoryBuilder (for some reason called `wrapped_trajectory_builder` in code), which in turn will throw them to the pose graph.