### PR TITLE
Fully delete trajectory

### DIFF
--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -359,20 +359,45 @@ void PoseGraph2D::UpdateTrajectoryConnectivity(const Constraint& constraint) {
 }
 
 void PoseGraph2D::DeleteTrajectoriesIfNeeded() {
-  TrimmingHandle trimming_handle(this);
   for (auto& it : data_.trajectories_state) {
     if (it.second.deletion_state ==
         InternalTrajectoryState::DeletionState::WAIT_FOR_DELETION) {
-      // TODO(gaschler): Consider directly deleting from data_, which may be
-      // more complete.
-      auto submap_ids = trimming_handle.GetSubmapIds(it.first);
-      for (auto& submap_id : submap_ids) {
-        trimming_handle.TrimSubmap(submap_id);
-      }
+      DeleteTrajectoryData(it.first);
       it.second.state = TrajectoryState::DELETED;
       it.second.deletion_state = InternalTrajectoryState::DeletionState::NORMAL;
     }
   }
+}
+
+void PoseGraph2D::DeleteTrajectoryData(int trajectory_id) {
+  std::vector<SubmapId> submaps_to_delete;
+  for (const auto& submap_it :
+       optimization_problem_->submap_data().trajectory(trajectory_id)) {
+    submaps_to_delete.push_back(submap_it.id);
+  }
+  for (const SubmapId& submap_id : submaps_to_delete) {
+    data_.submap_data.Trim(submap_id);
+    constraint_builder_.DeleteScanMatcher(submap_id);
+    optimization_problem_->TrimSubmap(submap_id);
+  }
+  std::vector<NodeId> nodes_to_delete;
+  for (const auto& node_it :
+       optimization_problem_->node_data().trajectory(trajectory_id)) {
+    nodes_to_delete.push_back(node_it.id);
+  }
+  for (const NodeId& node_id : nodes_to_delete) {
+    optimization_problem_->TrimTrajectoryNode(node_id);
+    data_.trajectory_nodes.Trim(node_id);
+  }
+  std::vector<PoseGraphInterface::Constraint> constraints_to_keep;
+  for (const Constraint& constraint : data_.constraints) {
+    if (constraint.submap_id.trajectory_id == trajectory_id ||
+        constraint.node_id.trajectory_id == trajectory_id)
+      continue;
+    constraints_to_keep.push_back(constraint);
+  }
+  data_.constraints = std::move(constraints_to_keep);
+  // TODO(gaschler): Decide whether to delete global_submap_poses.
 }
 
 void PoseGraph2D::HandleWorkQueue(
@@ -928,6 +953,7 @@ transform::Rigid3d PoseGraph2D::ComputeLocalToGlobalTransform(
     }
   }
   const SubmapId last_optimized_submap_id = std::prev(end_it)->id;
+  CHECK(data_.submap_data.Contains(last_optimized_submap_id));
   // Accessing 'local_pose' in Submap is okay, since the member is const.
   return transform::Embed3D(
              global_submap_poses.at(last_optimized_submap_id).global_pose) *

--- a/cartographer/mapping/internal/2d/pose_graph_2d.h
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.h
@@ -188,6 +188,9 @@ class PoseGraph2D : public PoseGraph {
   // constraint search.
   void DeleteTrajectoriesIfNeeded() REQUIRES(mutex_);
 
+  // Deletes all data of a trajectory.
+  void DeleteTrajectoryData(int trajectory_id) REQUIRES(mutex_);
+
   // Runs the optimization, executes the trimmers and processes the work queue.
   void HandleWorkQueue(const constraints::ConstraintBuilder2D::Result& result)
       REQUIRES(mutex_);

--- a/cartographer/mapping/internal/3d/pose_graph_3d.h
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.h
@@ -191,6 +191,9 @@ class PoseGraph3D : public PoseGraph {
   // constraint search.
   void DeleteTrajectoriesIfNeeded() REQUIRES(mutex_);
 
+  // Deletes all data of a trajectory.
+  void DeleteTrajectoryData(int trajectory_id) REQUIRES(mutex_);
+
   // Runs the optimization, executes the trimmers and processes the work queue.
   void HandleWorkQueue(const constraints::ConstraintBuilder3D::Result& result)
       REQUIRES(mutex_);


### PR DESCRIPTION
Previously, constraints across trajectories (and some nodes)
were not deleted because the trimmer interface was used,
which resulted in an inconsistent pose graph and a MapById
out-of-range exception.
Deleting cross-trajectory constraints is now covered by an integration
test.
