### PR TITLE
Remove "_internal" from the metric family names.

### DIFF
--- a/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
+++ b/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
@@ -323,14 +323,14 @@ void LocalTrajectoryBuilder2D::RegisterMetrics(
   kLocalSlamLatencyMetric = latency->Add({});
   auto score_boundaries = metrics::Histogram::FixedWidth(0.05, 20);
   auto* scores = family_factory->NewHistogramFamily(
-      "mapping_2d_local_trajectory_builder_scores",
-      "Local scan matcher scores", score_boundaries);
+      "mapping_2d_local_trajectory_builder_scores", "Local scan matcher scores",
+      score_boundaries);
   kFastCorrelativeScanMatcherScoreMetric =
       scores->Add({{"scan_matcher", "fast_correlative"}});
   auto cost_boundaries = metrics::Histogram::ScaledPowersOf(2, 0.01, 100);
   auto* costs = family_factory->NewHistogramFamily(
-      "mapping_2d_local_trajectory_builder_costs",
-      "Local scan matcher costs", cost_boundaries);
+      "mapping_2d_local_trajectory_builder_costs", "Local scan matcher costs",
+      cost_boundaries);
   kCeresScanMatcherCostMetric = costs->Add({{"scan_matcher", "ceres"}});
   auto distance_boundaries = metrics::Histogram::ScaledPowersOf(2, 0.01, 10);
   auto* residuals = family_factory->NewHistogramFamily(

--- a/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
+++ b/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
@@ -317,24 +317,24 @@ void LocalTrajectoryBuilder2D::InitializeExtrapolator(const common::Time time) {
 void LocalTrajectoryBuilder2D::RegisterMetrics(
     metrics::FamilyFactory* family_factory) {
   auto* latency = family_factory->NewGaugeFamily(
-      "mapping_internal_2d_local_trajectory_builder_latency",
+      "mapping_2d_local_trajectory_builder_latency",
       "Duration from first incoming point cloud in accumulation to local slam "
       "result");
   kLocalSlamLatencyMetric = latency->Add({});
   auto score_boundaries = metrics::Histogram::FixedWidth(0.05, 20);
   auto* scores = family_factory->NewHistogramFamily(
-      "mapping_internal_2d_local_trajectory_builder_scores",
+      "mapping_2d_local_trajectory_builder_scores",
       "Local scan matcher scores", score_boundaries);
   kFastCorrelativeScanMatcherScoreMetric =
       scores->Add({{"scan_matcher", "fast_correlative"}});
   auto cost_boundaries = metrics::Histogram::ScaledPowersOf(2, 0.01, 100);
   auto* costs = family_factory->NewHistogramFamily(
-      "mapping_internal_2d_local_trajectory_builder_costs",
+      "mapping_2d_local_trajectory_builder_costs",
       "Local scan matcher costs", cost_boundaries);
   kCeresScanMatcherCostMetric = costs->Add({{"scan_matcher", "ceres"}});
   auto distance_boundaries = metrics::Histogram::ScaledPowersOf(2, 0.01, 10);
   auto* residuals = family_factory->NewHistogramFamily(
-      "mapping_internal_2d_local_trajectory_builder_residuals",
+      "mapping_2d_local_trajectory_builder_residuals",
       "Local scan matcher residuals", distance_boundaries);
   kScanMatcherResidualDistanceMetric =
       residuals->Add({{"component", "distance"}});

--- a/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
+++ b/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
@@ -307,14 +307,14 @@ void LocalTrajectoryBuilder3D::RegisterMetrics(
   kLocalSlamLatencyMetric = latency->Add({});
   auto score_boundaries = metrics::Histogram::FixedWidth(0.05, 20);
   auto* scores = family_factory->NewHistogramFamily(
-      "mapping_3d_local_trajectory_builder_scores",
-      "Local scan matcher scores", score_boundaries);
+      "mapping_3d_local_trajectory_builder_scores", "Local scan matcher scores",
+      score_boundaries);
   kRealTimeCorrelativeScanMatcherScoreMetric =
       scores->Add({{"scan_matcher", "real_time_correlative"}});
   auto cost_boundaries = metrics::Histogram::ScaledPowersOf(2, 0.01, 100);
   auto* costs = family_factory->NewHistogramFamily(
-      "mapping_3d_local_trajectory_builder_costs",
-      "Local scan matcher costs", cost_boundaries);
+      "mapping_3d_local_trajectory_builder_costs", "Local scan matcher costs",
+      cost_boundaries);
   kCeresScanMatcherCostMetric = costs->Add({{"scan_matcher", "ceres"}});
   auto distance_boundaries = metrics::Histogram::ScaledPowersOf(2, 0.01, 10);
   auto* residuals = family_factory->NewHistogramFamily(

--- a/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
+++ b/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
@@ -301,24 +301,24 @@ LocalTrajectoryBuilder3D::InsertIntoSubmap(
 void LocalTrajectoryBuilder3D::RegisterMetrics(
     metrics::FamilyFactory* family_factory) {
   auto* latency = family_factory->NewGaugeFamily(
-      "mapping_internal_3d_local_trajectory_builder_latency",
+      "mapping_3d_local_trajectory_builder_latency",
       "Duration from first incoming point cloud in accumulation to local slam "
       "result");
   kLocalSlamLatencyMetric = latency->Add({});
   auto score_boundaries = metrics::Histogram::FixedWidth(0.05, 20);
   auto* scores = family_factory->NewHistogramFamily(
-      "mapping_internal_3d_local_trajectory_builder_scores",
+      "mapping_3d_local_trajectory_builder_scores",
       "Local scan matcher scores", score_boundaries);
   kRealTimeCorrelativeScanMatcherScoreMetric =
       scores->Add({{"scan_matcher", "real_time_correlative"}});
   auto cost_boundaries = metrics::Histogram::ScaledPowersOf(2, 0.01, 100);
   auto* costs = family_factory->NewHistogramFamily(
-      "mapping_internal_3d_local_trajectory_builder_costs",
+      "mapping_3d_local_trajectory_builder_costs",
       "Local scan matcher costs", cost_boundaries);
   kCeresScanMatcherCostMetric = costs->Add({{"scan_matcher", "ceres"}});
   auto distance_boundaries = metrics::Histogram::ScaledPowersOf(2, 0.01, 10);
   auto* residuals = family_factory->NewHistogramFamily(
-      "mapping_internal_3d_local_trajectory_builder_residuals",
+      "mapping_3d_local_trajectory_builder_residuals",
       "Local scan matcher residuals", distance_boundaries);
   kScanMatcherResidualDistanceMetric =
       residuals->Add({{"component", "distance"}});

--- a/cartographer/mapping/internal/constraints/constraint_builder_2d.cc
+++ b/cartographer/mapping/internal/constraints/constraint_builder_2d.cc
@@ -317,8 +317,7 @@ void ConstraintBuilder2D::RegisterMetrics(metrics::FamilyFactory* factory) {
   kGlobalConstraintsFoundMetric =
       counts->Add({{"search_region", "global"}, {"matcher", "found"}});
   auto* queue_length = factory->NewGaugeFamily(
-      "mapping_constraints_constraint_builder_2d_queue_length",
-      "Queue length");
+      "mapping_constraints_constraint_builder_2d_queue_length", "Queue length");
   kQueueLengthMetric = queue_length->Add({});
   auto boundaries = metrics::Histogram::FixedWidth(0.05, 20);
   auto* scores = factory->NewHistogramFamily(

--- a/cartographer/mapping/internal/constraints/constraint_builder_2d.cc
+++ b/cartographer/mapping/internal/constraints/constraint_builder_2d.cc
@@ -306,7 +306,7 @@ void ConstraintBuilder2D::DeleteScanMatcher(const SubmapId& submap_id) {
 
 void ConstraintBuilder2D::RegisterMetrics(metrics::FamilyFactory* factory) {
   auto* counts = factory->NewCounterFamily(
-      "mapping_internal_constraints_constraint_builder_2d_constraints",
+      "mapping_constraints_constraint_builder_2d_constraints",
       "Constraints computed");
   kConstraintsSearchedMetric =
       counts->Add({{"search_region", "local"}, {"matcher", "searched"}});
@@ -317,12 +317,12 @@ void ConstraintBuilder2D::RegisterMetrics(metrics::FamilyFactory* factory) {
   kGlobalConstraintsFoundMetric =
       counts->Add({{"search_region", "global"}, {"matcher", "found"}});
   auto* queue_length = factory->NewGaugeFamily(
-      "mapping_internal_constraints_constraint_builder_2d_queue_length",
+      "mapping_constraints_constraint_builder_2d_queue_length",
       "Queue length");
   kQueueLengthMetric = queue_length->Add({});
   auto boundaries = metrics::Histogram::FixedWidth(0.05, 20);
   auto* scores = factory->NewHistogramFamily(
-      "mapping_internal_constraints_constraint_builder_2d_scores",
+      "mapping_constraints_constraint_builder_2d_scores",
       "Constraint scores built", boundaries);
   kConstraintScoresMetric = scores->Add({{"search_region", "local"}});
   kGlobalConstraintScoresMetric = scores->Add({{"search_region", "global"}});

--- a/cartographer/mapping/internal/constraints/constraint_builder_3d.cc
+++ b/cartographer/mapping/internal/constraints/constraint_builder_3d.cc
@@ -341,7 +341,7 @@ void ConstraintBuilder3D::DeleteScanMatcher(const SubmapId& submap_id) {
 
 void ConstraintBuilder3D::RegisterMetrics(metrics::FamilyFactory* factory) {
   auto* counts = factory->NewCounterFamily(
-      "mapping_internal_constraints_constraint_builder_3d_constraints",
+      "mapping_constraints_constraint_builder_3d_constraints",
       "Constraints computed");
   kConstraintsSearchedMetric =
       counts->Add({{"search_region", "local"}, {"matcher", "searched"}});
@@ -352,12 +352,12 @@ void ConstraintBuilder3D::RegisterMetrics(metrics::FamilyFactory* factory) {
   kGlobalConstraintsFoundMetric =
       counts->Add({{"search_region", "global"}, {"matcher", "found"}});
   auto* queue_length = factory->NewGaugeFamily(
-      "mapping_internal_constraints_constraint_builder_3d_queue_length",
+      "mapping_constraints_constraint_builder_3d_queue_length",
       "Queue length");
   kQueueLengthMetric = queue_length->Add({});
   auto boundaries = metrics::Histogram::FixedWidth(0.05, 20);
   auto* scores = factory->NewHistogramFamily(
-      "mapping_internal_constraints_constraint_builder_3d_scores",
+      "mapping_constraints_constraint_builder_3d_scores",
       "Constraint scores built", boundaries);
   kConstraintScoresMetric =
       scores->Add({{"search_region", "local"}, {"kind", "score"}});

--- a/cartographer/mapping/internal/constraints/constraint_builder_3d.cc
+++ b/cartographer/mapping/internal/constraints/constraint_builder_3d.cc
@@ -352,8 +352,7 @@ void ConstraintBuilder3D::RegisterMetrics(metrics::FamilyFactory* factory) {
   kGlobalConstraintsFoundMetric =
       counts->Add({{"search_region", "global"}, {"matcher", "found"}});
   auto* queue_length = factory->NewGaugeFamily(
-      "mapping_constraints_constraint_builder_3d_queue_length",
-      "Queue length");
+      "mapping_constraints_constraint_builder_3d_queue_length", "Queue length");
   kQueueLengthMetric = queue_length->Add({});
   auto boundaries = metrics::Histogram::FixedWidth(0.05, 20);
   auto* scores = factory->NewHistogramFamily(

--- a/cartographer/mapping/internal/global_trajectory_builder.cc
+++ b/cartographer/mapping/internal/global_trajectory_builder.cc
@@ -155,7 +155,7 @@ std::unique_ptr<TrajectoryBuilderInterface> CreateGlobalTrajectoryBuilder3D(
 
 void GlobalTrajectoryBuilderRegisterMetrics(metrics::FamilyFactory* factory) {
   auto* results = factory->NewCounterFamily(
-      "mapping_internal_global_trajectory_builder_local_slam_results",
+      "mapping_global_trajectory_builder_local_slam_results",
       "Local SLAM results");
   kLocalSlamMatchingResults = results->Add({{"type", "MatchingResult"}});
   kLocalSlamInsertionResults = results->Add({{"type", "InsertionResult"}});


### PR DESCRIPTION
As discussed and requested in #1218, this PR removes the substring "_internal" from all the metric family names.