### PR TITLE
fixed casting of high_resolution_max_range (SubmapsOptions3D)

### DIFF
--- a/cartographer/mapping/3d/submap_3d.cc
+++ b/cartographer/mapping/3d/submap_3d.cc
@@ -39,7 +39,7 @@ struct PixelData {
 // 'max_range' distance from the origin. Removes misses and reflectivity
 // information.
 sensor::RangeData FilterRangeDataByMaxRange(const sensor::RangeData& range_data,
-                                            const double max_range) {
+                                            const float max_range) {
   sensor::RangeData result{range_data.origin, {}, {}};
   for (const Eigen::Vector3f& hit : range_data.returns) {
     if ((hit - range_data.origin).norm() <= max_range) {
@@ -261,7 +261,7 @@ void Submap3D::ToResponseProto(
 
 void Submap3D::InsertRangeData(const sensor::RangeData& range_data,
                                const RangeDataInserter3D& range_data_inserter,
-                               const double high_resolution_max_range) {
+                               const float high_resolution_max_range) {
   CHECK(!finished());
   const sensor::RangeData transformed_range_data = sensor::TransformRangeData(
       range_data, local_pose().inverse().cast<float>());

--- a/cartographer/mapping/3d/submap_3d.cc
+++ b/cartographer/mapping/3d/submap_3d.cc
@@ -39,7 +39,7 @@ struct PixelData {
 // 'max_range' distance from the origin. Removes misses and reflectivity
 // information.
 sensor::RangeData FilterRangeDataByMaxRange(const sensor::RangeData& range_data,
-                                            const float max_range) {
+                                            const double max_range) {
   sensor::RangeData result{range_data.origin, {}, {}};
   for (const Eigen::Vector3f& hit : range_data.returns) {
     if ((hit - range_data.origin).norm() <= max_range) {
@@ -261,7 +261,7 @@ void Submap3D::ToResponseProto(
 
 void Submap3D::InsertRangeData(const sensor::RangeData& range_data,
                                const RangeDataInserter3D& range_data_inserter,
-                               const int high_resolution_max_range) {
+                               const double high_resolution_max_range) {
   CHECK(!finished());
   const sensor::RangeData transformed_range_data = sensor::TransformRangeData(
       range_data, local_pose().inverse().cast<float>());

--- a/cartographer/mapping/3d/submap_3d.h
+++ b/cartographer/mapping/3d/submap_3d.h
@@ -64,7 +64,7 @@ class Submap3D : public Submap {
   // submap must not be finished yet.
   void InsertRangeData(const sensor::RangeData& range_data,
                        const RangeDataInserter3D& range_data_inserter,
-                       double high_resolution_max_range);
+                       float high_resolution_max_range);
   void Finish();
 
  private:

--- a/cartographer/mapping/3d/submap_3d.h
+++ b/cartographer/mapping/3d/submap_3d.h
@@ -64,7 +64,7 @@ class Submap3D : public Submap {
   // submap must not be finished yet.
   void InsertRangeData(const sensor::RangeData& range_data,
                        const RangeDataInserter3D& range_data_inserter,
-                       int high_resolution_max_range);
+                       double high_resolution_max_range);
   void Finish();
 
  private:


### PR DESCRIPTION
Fixed unintentional casting of high_resolution_max_range from double to int, to float

In SubmapsOptions3D the parameter "high_resolution_max_range" is defined as double. In the code it gets casted to int when calling Submap3D::InsertRangeData and to float when calling FilterRangeDataByMaxRange.