### PR TITLE
Fix the name of real_time_correlative metric in 2D.

### DIFF
--- a/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
+++ b/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
@@ -78,7 +78,7 @@ std::unique_ptr<transform::Rigid2d> LocalTrajectoryBuilder2D::ScanMatch(
   if (options_.use_online_correlative_scan_matching()) {
     CHECK_EQ(options_.submaps_options().grid_options_2d().grid_type(),
              proto::GridOptions2D_GridType_PROBABILITY_GRID);
-    double score = real_time_correlative_scan_matcher_.Match(
+    const double score = real_time_correlative_scan_matcher_.Match(
         pose_prediction, filtered_gravity_aligned_point_cloud,
         *static_cast<const ProbabilityGrid*>(matching_submap->grid()),
         &initial_ceres_pose);
@@ -93,12 +93,13 @@ std::unique_ptr<transform::Rigid2d> LocalTrajectoryBuilder2D::ScanMatch(
                             &summary);
   if (pose_observation) {
     kCeresScanMatcherCostMetric->Observe(summary.final_cost);
-    double residual_distance =
+    const double residual_distance =
         (pose_observation->translation() - pose_prediction.translation())
             .norm();
     kScanMatcherResidualDistanceMetric->Observe(residual_distance);
-    double residual_angle = std::abs(pose_observation->rotation().angle() -
-                                     pose_prediction.rotation().angle());
+    const double residual_angle =
+        std::abs(pose_observation->rotation().angle() -
+                 pose_prediction.rotation().angle());
     kScanMatcherResidualAngleMetric->Observe(residual_angle);
   }
   return pose_observation;

--- a/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
+++ b/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
@@ -27,7 +27,7 @@ namespace cartographer {
 namespace mapping {
 
 static auto* kLocalSlamLatencyMetric = metrics::Gauge::Null();
-static auto* kFastCorrelativeScanMatcherScoreMetric =
+static auto* kRealTimeCorrelativeScanMatcherScoreMetric =
     metrics::Histogram::Null();
 static auto* kCeresScanMatcherCostMetric = metrics::Histogram::Null();
 static auto* kScanMatcherResidualDistanceMetric = metrics::Histogram::Null();
@@ -82,7 +82,7 @@ std::unique_ptr<transform::Rigid2d> LocalTrajectoryBuilder2D::ScanMatch(
         pose_prediction, filtered_gravity_aligned_point_cloud,
         *static_cast<const ProbabilityGrid*>(matching_submap->grid()),
         &initial_ceres_pose);
-    kFastCorrelativeScanMatcherScoreMetric->Observe(score);
+    kRealTimeCorrelativeScanMatcherScoreMetric->Observe(score);
   }
 
   auto pose_observation = common::make_unique<transform::Rigid2d>();
@@ -325,8 +325,8 @@ void LocalTrajectoryBuilder2D::RegisterMetrics(
   auto* scores = family_factory->NewHistogramFamily(
       "mapping_2d_local_trajectory_builder_scores", "Local scan matcher scores",
       score_boundaries);
-  kFastCorrelativeScanMatcherScoreMetric =
-      scores->Add({{"scan_matcher", "fast_correlative"}});
+  kRealTimeCorrelativeScanMatcherScoreMetric =
+      scores->Add({{"scan_matcher", "real_time_correlative"}});
   auto cost_boundaries = metrics::Histogram::ScaledPowersOf(2, 0.01, 100);
   auto* costs = family_factory->NewHistogramFamily(
       "mapping_2d_local_trajectory_builder_costs", "Local scan matcher costs",


### PR DESCRIPTION
This was called fast_correlative before, but the metric was about
the score of the real-time correlative scan matcher in local SLAM.