### PR TITLE
use common::ToSeconds in local_trajectory_builder and rate_timer.h

### DIFF
--- a/cartographer/common/rate_timer.h
+++ b/cartographer/common/rate_timer.h
@@ -62,9 +62,7 @@ class RateTimer {
       return 0.;
     }
     return common::ToSeconds((events_.back().time - events_.front().time)) /
-           std::chrono::duration_cast<std::chrono::duration<double>>(
-               events_.back().wall_time - events_.front().wall_time)
-               .count();
+           common::ToSeconds(events_.back().wall_time - events_.front().wall_time);
   }
 
   // Records an event that will contribute to the computed rate.

--- a/cartographer/common/rate_timer.h
+++ b/cartographer/common/rate_timer.h
@@ -62,7 +62,8 @@ class RateTimer {
       return 0.;
     }
     return common::ToSeconds((events_.back().time - events_.front().time)) /
-           common::ToSeconds(events_.back().wall_time - events_.front().wall_time);
+           common::ToSeconds(events_.back().wall_time -
+                             events_.front().wall_time);
   }
 
   // Records an event that will contribute to the computed rate.

--- a/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
+++ b/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
@@ -240,7 +240,8 @@ LocalTrajectoryBuilder2D::AddAccumulatedRangeData(
   std::unique_ptr<InsertionResult> insertion_result = InsertIntoSubmap(
       time, range_data_in_local, filtered_gravity_aligned_point_cloud,
       pose_estimate, gravity_alignment.rotation());
-  const auto accumulation_duration = std::chrono::steady_clock::now() - accumulation_started_;
+  const auto accumulation_duration =
+      std::chrono::steady_clock::now() - accumulation_started_;
   kLocalSlamLatencyMetric->Set(common::ToSeconds(accumulation_duration));
   return common::make_unique<MatchingResult>(
       MatchingResult{time, pose_estimate, std::move(range_data_in_local),

--- a/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
+++ b/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
@@ -240,8 +240,8 @@ LocalTrajectoryBuilder2D::AddAccumulatedRangeData(
   std::unique_ptr<InsertionResult> insertion_result = InsertIntoSubmap(
       time, range_data_in_local, filtered_gravity_aligned_point_cloud,
       pose_estimate, gravity_alignment.rotation());
-  auto duration = std::chrono::steady_clock::now() - accumulation_started_;
-  kLocalSlamLatencyMetric->Set(common::ToSeconds(duration));
+  const auto accumulation_duration = std::chrono::steady_clock::now() - accumulation_started_;
+  kLocalSlamLatencyMetric->Set(common::ToSeconds(accumulation_duration));
   return common::make_unique<MatchingResult>(
       MatchingResult{time, pose_estimate, std::move(range_data_in_local),
                      std::move(insertion_result)});

--- a/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
+++ b/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
@@ -241,9 +241,7 @@ LocalTrajectoryBuilder2D::AddAccumulatedRangeData(
       time, range_data_in_local, filtered_gravity_aligned_point_cloud,
       pose_estimate, gravity_alignment.rotation());
   auto duration = std::chrono::steady_clock::now() - accumulation_started_;
-  kLocalSlamLatencyMetric->Set(
-      std::chrono::duration_cast<std::chrono::duration<double>>(duration)
-          .count());
+  kLocalSlamLatencyMetric->Set(common::ToSeconds(duration));
   return common::make_unique<MatchingResult>(
       MatchingResult{time, pose_estimate, std::move(range_data_in_local),
                      std::move(insertion_result)});

--- a/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
+++ b/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
@@ -177,9 +177,7 @@ LocalTrajectoryBuilder3D::AddRangeData(
 
     if (sensor_duration.has_value()) {
       const double voxel_filter_fraction =
-          std::chrono::duration_cast<std::chrono::duration<double>>(
-              voxel_filter_duration)
-              .count() /
+          common::ToSeconds(voxel_filter_duration)   /
           common::ToSeconds(sensor_duration.value());
       kLocalSlamVoxelFilterFraction->Set(voxel_filter_fraction);
     }
@@ -253,9 +251,7 @@ LocalTrajectoryBuilder3D::AddAccumulatedRangeData(
   const auto scan_matcher_duration = scan_matcher_stop - scan_matcher_start;
   if (sensor_duration.has_value()) {
     const double scan_matcher_fraction =
-        std::chrono::duration_cast<std::chrono::duration<double>>(
-            scan_matcher_duration)
-            .count() /
+        common::ToSeconds(scan_matcher_duration) /
         common::ToSeconds(sensor_duration.value());
     kLocalSlamScanMatcherFraction->Set(scan_matcher_fraction);
   }
@@ -289,17 +285,13 @@ LocalTrajectoryBuilder3D::AddAccumulatedRangeData(
       insert_into_submap_stop - insert_into_submap_start;
   if (sensor_duration.has_value()) {
     double insert_into_submap_fraction =
-        std::chrono::duration_cast<std::chrono::duration<double>>(
-            insert_into_submap_duration)
-            .count() /
+        common::ToSeconds(insert_into_submap_duration) /
         common::ToSeconds(sensor_duration.value());
     kLocalSlamInsertIntoSubmapFraction->Set(insert_into_submap_fraction);
   }
 
   auto duration = std::chrono::steady_clock::now() - accumulation_started_;
-  kLocalSlamLatencyMetric->Set(
-      std::chrono::duration_cast<std::chrono::duration<double>>(duration)
-          .count());
+  kLocalSlamLatencyMetric->Set(common::ToSeconds(duration));
   return common::make_unique<MatchingResult>(MatchingResult{
       time, pose_estimate, std::move(filtered_range_data_in_local),
       std::move(insertion_result)});

--- a/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
+++ b/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
@@ -284,14 +284,14 @@ LocalTrajectoryBuilder3D::AddAccumulatedRangeData(
   const auto insert_into_submap_duration =
       insert_into_submap_stop - insert_into_submap_start;
   if (sensor_duration.has_value()) {
-    double insert_into_submap_fraction =
+    const double insert_into_submap_fraction =
         common::ToSeconds(insert_into_submap_duration) /
         common::ToSeconds(sensor_duration.value());
     kLocalSlamInsertIntoSubmapFraction->Set(insert_into_submap_fraction);
   }
 
-  auto duration = std::chrono::steady_clock::now() - accumulation_started_;
-  kLocalSlamLatencyMetric->Set(common::ToSeconds(duration));
+  const auto accumulation_duration = std::chrono::steady_clock::now() - accumulation_started_;
+  kLocalSlamLatencyMetric->Set(common::ToSeconds(accumulation_duration));
   return common::make_unique<MatchingResult>(MatchingResult{
       time, pose_estimate, std::move(filtered_range_data_in_local),
       std::move(insertion_result)});

--- a/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
+++ b/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
@@ -290,7 +290,8 @@ LocalTrajectoryBuilder3D::AddAccumulatedRangeData(
     kLocalSlamInsertIntoSubmapFraction->Set(insert_into_submap_fraction);
   }
 
-  const auto accumulation_duration = std::chrono::steady_clock::now() - accumulation_started_;
+  const auto accumulation_duration =
+      std::chrono::steady_clock::now() - accumulation_started_;
   kLocalSlamLatencyMetric->Set(common::ToSeconds(accumulation_duration));
   return common::make_unique<MatchingResult>(MatchingResult{
       time, pose_estimate, std::move(filtered_range_data_in_local),

--- a/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
+++ b/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
@@ -177,7 +177,7 @@ LocalTrajectoryBuilder3D::AddRangeData(
 
     if (sensor_duration.has_value()) {
       const double voxel_filter_fraction =
-          common::ToSeconds(voxel_filter_duration)   /
+          common::ToSeconds(voxel_filter_duration) /
           common::ToSeconds(sensor_duration.value());
       kLocalSlamVoxelFilterFraction->Set(voxel_filter_fraction);
     }


### PR DESCRIPTION
use the new overload of ToSeconds (introduced in 
[PR1244](https://github.com/googlecartographer/cartographer/pull/1244/files)) in local_trajectory_builder.