### PR TITLE
Get rid of std::bind.

### DIFF
--- a/cartographer/cloud/internal/map_builder_server.cc
+++ b/cartographer/cloud/internal/map_builder_server.cc
@@ -110,8 +110,11 @@ MapBuilderServer::MapBuilderServer(
         << "Set either use_trajectory_builder_2d or use_trajectory_builder_3d";
   }
   map_builder_->pose_graph()->SetGlobalSlamOptimizationCallback(
-      std::bind(&MapBuilderServer::OnGlobalSlamOptimizations, this,
-                std::placeholders::_1, std::placeholders::_2));
+      [this](const std::map<int, mapping::SubmapId>& last_optimized_submap_ids,
+             const std::map<int, mapping::NodeId>& last_optimized_node_ids) {
+        OnGlobalSlamOptimizations(last_optimized_submap_ids,
+                                  last_optimized_node_ids);
+      });
 }
 
 void MapBuilderServer::Start() {

--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -331,7 +331,9 @@ void PoseGraph2D::DispatchOptimization() {
   if (work_queue_ == nullptr) {
     work_queue_ = common::make_unique<WorkQueue>();
     constraint_builder_.WhenDone(
-        std::bind(&PoseGraph2D::HandleWorkQueue, this, std::placeholders::_1));
+        [this](const constraints::ConstraintBuilder2D::Result& result) {
+          HandleWorkQueue(result);
+        });
   }
 }
 common::Time PoseGraph2D::GetLatestNodeTime(const NodeId& node_id,
@@ -437,7 +439,9 @@ void PoseGraph2D::HandleWorkQueue(
   LOG(INFO) << "Remaining work items in queue: " << work_queue_->size();
   // We have to optimize again.
   constraint_builder_.WhenDone(
-      std::bind(&PoseGraph2D::HandleWorkQueue, this, std::placeholders::_1));
+      [this](const constraints::ConstraintBuilder2D::Result& result) {
+        HandleWorkQueue(result);
+      });
 }
 
 void PoseGraph2D::WaitForAllComputations() {

--- a/cartographer/mapping/internal/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.cc
@@ -347,7 +347,9 @@ void PoseGraph3D::DispatchOptimization() {
   if (work_queue_ == nullptr) {
     work_queue_ = common::make_unique<WorkQueue>();
     constraint_builder_.WhenDone(
-        std::bind(&PoseGraph3D::HandleWorkQueue, this, std::placeholders::_1));
+        [this](const constraints::ConstraintBuilder3D::Result& result) {
+          HandleWorkQueue(result);
+        });
   }
 }
 
@@ -454,7 +456,9 @@ void PoseGraph3D::HandleWorkQueue(
   LOG(INFO) << "Remaining work items in queue: " << work_queue_->size();
   // We have to optimize again.
   constraint_builder_.WhenDone(
-      std::bind(&PoseGraph3D::HandleWorkQueue, this, std::placeholders::_1));
+      [this](const constraints::ConstraintBuilder3D::Result& result) {
+        HandleWorkQueue(result);
+      });
 }
 
 void PoseGraph3D::WaitForAllComputations() {

--- a/cartographer/mapping/internal/constraints/constraint_builder_2d_test.cc
+++ b/cartographer/mapping/internal/constraints/constraint_builder_2d_test.cc
@@ -60,7 +60,9 @@ TEST_F(ConstraintBuilder2DTest, CallsBack) {
   EXPECT_CALL(mock_, Run(::testing::IsEmpty()));
   constraint_builder_->NotifyEndOfNode();
   constraint_builder_->WhenDone(
-      std::bind(&MockCallback::Run, &mock_, std::placeholders::_1));
+      [this](const constraints::ConstraintBuilder2D::Result& result) {
+        mock_.Run(result);
+      });
   thread_pool_.WaitUntilIdle();
   EXPECT_EQ(constraint_builder_->GetNumFinishedNodes(), 1);
 }
@@ -98,7 +100,9 @@ TEST_F(ConstraintBuilder2DTest, FindsConstraints) {
                         &PoseGraphInterface::Constraint::tag,
                         PoseGraphInterface::Constraint::INTER_SUBMAP)))));
     constraint_builder_->WhenDone(
-        std::bind(&MockCallback::Run, &mock_, std::placeholders::_1));
+        [this](const constraints::ConstraintBuilder2D::Result& result) {
+          mock_.Run(result);
+        });
     thread_pool_.WaitUntilIdle();
     constraint_builder_->DeleteScanMatcher(submap_id);
   }

--- a/cartographer/mapping/internal/constraints/constraint_builder_3d_test.cc
+++ b/cartographer/mapping/internal/constraints/constraint_builder_3d_test.cc
@@ -63,7 +63,9 @@ TEST_F(ConstraintBuilder3DTest, CallsBack) {
   EXPECT_CALL(mock_, Run(::testing::IsEmpty()));
   constraint_builder_->NotifyEndOfNode();
   constraint_builder_->WhenDone(
-      std::bind(&MockCallback::Run, &mock_, std::placeholders::_1));
+      [this](const constraints::ConstraintBuilder3D::Result& result) {
+        mock_.Run(result);
+      });
   thread_pool_.WaitUntilIdle();
   EXPECT_EQ(constraint_builder_->GetNumFinishedNodes(), 1);
 }
@@ -108,7 +110,9 @@ TEST_F(ConstraintBuilder3DTest, FindsConstraints) {
                         &PoseGraphInterface::Constraint::tag,
                         PoseGraphInterface::Constraint::INTER_SUBMAP)))));
     constraint_builder_->WhenDone(
-        std::bind(&MockCallback::Run, &mock_, std::placeholders::_1));
+        [this](const constraints::ConstraintBuilder3D::Result& result) {
+          mock_.Run(result);
+        });
     thread_pool_.WaitUntilIdle();
     constraint_builder_->DeleteScanMatcher(submap_id);
   }


### PR DESCRIPTION
`std::bind` is bug prone and should be avoided.
Lambdas are a more general and safer replacement.