### PR TITLE
Add function to query if metrics are registered.

### DIFF
--- a/cartographer/cloud/metrics/prometheus/metrics_test.cc
+++ b/cartographer/cloud/metrics/prometheus/metrics_test.cc
@@ -136,6 +136,7 @@ TEST(MetricsTest, RunExposerServer) {
   FamilyFactory registry;
   Algorithm::RegisterMetrics(&registry);
   ::cartographer::metrics::RegisterAllMetrics(&registry);
+  EXPECT_TRUE(::cartographer::metrics::MetricsRegistered());
   ::prometheus::Exposer exposer("0.0.0.0:9100");
   exposer.RegisterCollectable(registry.GetCollectable());
 

--- a/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
+++ b/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
@@ -21,6 +21,7 @@
 
 #include "cartographer/common/make_unique.h"
 #include "cartographer/metrics/family_factory.h"
+#include "cartographer/metrics/register.h"
 #include "cartographer/sensor/range_data.h"
 
 namespace cartographer {
@@ -88,7 +89,7 @@ std::unique_ptr<transform::Rigid2d> LocalTrajectoryBuilder2D::ScanMatch(
                             filtered_gravity_aligned_point_cloud,
                             *matching_submap->grid(), pose_observation.get(),
                             &summary);
-  if (pose_observation) {
+  if (pose_observation && metrics::MetricsRegistered()) {
     kCeresScanMatcherCostMetric->Observe(summary.final_cost);
     const double residual_distance =
         (pose_observation->translation() - pose_prediction.translation())

--- a/cartographer/metrics/register.cc
+++ b/cartographer/metrics/register.cc
@@ -28,8 +28,8 @@ namespace cartographer {
 namespace metrics {
 
 namespace {
-  bool kMetricsRegistered = false;
-}  // namespace 
+bool kMetricsRegistered = false;
+}  // namespace
 
 void RegisterAllMetrics(FamilyFactory* registry) {
   kMetricsRegistered = true;

--- a/cartographer/metrics/register.cc
+++ b/cartographer/metrics/register.cc
@@ -27,7 +27,12 @@
 namespace cartographer {
 namespace metrics {
 
+namespace {
+  bool kMetricsRegistered = false;
+}  // namespace 
+
 void RegisterAllMetrics(FamilyFactory* registry) {
+  kMetricsRegistered = true;
   mapping::constraints::ConstraintBuilder2D::RegisterMetrics(registry);
   mapping::constraints::ConstraintBuilder3D::RegisterMetrics(registry);
   mapping::GlobalTrajectoryBuilderRegisterMetrics(registry);
@@ -36,6 +41,8 @@ void RegisterAllMetrics(FamilyFactory* registry) {
   mapping::PoseGraph2D::RegisterMetrics(registry);
   mapping::PoseGraph3D::RegisterMetrics(registry);
 }
+
+bool MetricsRegistered() { return kMetricsRegistered; }
 
 }  // namespace metrics
 }  // namespace cartographer

--- a/cartographer/metrics/register.h
+++ b/cartographer/metrics/register.h
@@ -23,6 +23,7 @@ namespace cartographer {
 namespace metrics {
 
 void RegisterAllMetrics(FamilyFactory *registry);
+bool MetricsRegistered();
 
 }  // namespace metrics
 }  // namespace cartographer


### PR DESCRIPTION
Useful to decide whether to run code that's only relevant if metrics
were registered.
