### PR TITLE
Fix Clang warnings.

### DIFF
--- a/cartographer/cloud/internal/client_server_test.cc
+++ b/cartographer/cloud/internal/client_server_test.cc
@@ -53,8 +53,6 @@ constexpr double kTimeStep = 0.1;        // Seconds.
 constexpr double kTravelDistance = 1.2;  // Meters.
 
 constexpr char kSerializationHeaderProtoString[] = "format_version: 1";
-constexpr char kUnsupportedSerializationHeaderProtoString[] =
-    "format_version: 123";
 constexpr char kPoseGraphProtoString[] = R"(pose_graph {
       trajectory: {
         trajectory_id: 0

--- a/cartographer/mapping/3d/submap_3d.h
+++ b/cartographer/mapping/3d/submap_3d.h
@@ -102,7 +102,6 @@ class ActiveSubmaps3D {
   void AddSubmap(const transform::Rigid3d& local_submap_pose);
 
   const proto::SubmapsOptions3D options_;
-  int matching_submap_index_ = 0;
   std::vector<std::shared_ptr<Submap3D>> submaps_;
   RangeDataInserter3D range_data_inserter_;
 };

--- a/cartographer/mapping/internal/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.cc
@@ -546,7 +546,7 @@ void PoseGraph3D::WaitForAllComputations() {
 
   // Now wait for any pending constraint computations to finish.
   common::MutexLocker locker(&mutex_);
-  bool notification GUARDED_BY(mutex_) = false;
+  bool notification = false;
   constraint_builder_.WhenDone(
       [this,
        &notification](const constraints::ConstraintBuilder3D::Result& result)


### PR DESCRIPTION
1) cartographer/cloud/internal/client_server_test.cc:56:16: warning: unused variable 'kUnsupportedSerializationHeaderProtoString' 
constexpr char kUnsupportedSerializationHeaderProtoString[] 

2) cartographer/mapping/3d/submap_3d.h:105:7: warning: private field 'matching_submap_index_' is not used [-Wunused-private-field]

3) pose_graph_3d.cc:549:21: warning: 'guarded_by' attribute only applies to fields and global variables
  bool notification GUARDED_BY(mutex_) = false;

