### PR TITLE
Preparation for #1277: refactor rotation scan matcher

### DIFF
--- a/cartographer/mapping/internal/3d/scan_matching/rotational_scan_matcher.h
+++ b/cartographer/mapping/internal/3d/scan_matching/rotational_scan_matcher.h
@@ -28,9 +28,17 @@ namespace scan_matching {
 
 class RotationalScanMatcher {
  public:
+  // Rotates the given 'histogram' by the given 'angle'. This might lead to
+  // rotations of a fractional bucket which is handled by linearly
+  // interpolating.
+  static Eigen::VectorXf RotateHistogram(const Eigen::VectorXf& histogram,
+                                         float angle);
+
   // Computes the histogram for a gravity aligned 'point_cloud'.
   static Eigen::VectorXf ComputeHistogram(const sensor::PointCloud& point_cloud,
                                           int histogram_size);
+
+  explicit RotationalScanMatcher(const Eigen::VectorXf& histogram);
 
   // Creates a matcher from the given histograms rotated by the given angles.
   // The angles should be chosen to bring the histograms into approximately the

--- a/cartographer/mapping/internal/3d/scan_matching/rotational_scan_matcher_test.cc
+++ b/cartographer/mapping/internal/3d/scan_matching/rotational_scan_matcher_test.cc
@@ -28,7 +28,9 @@ namespace {
 TEST(RotationalScanMatcher3DTest, OnlySameHistogramIsScoreOne) {
   Eigen::VectorXf histogram(7);
   histogram << 1.f, 43.f, 0.5f, 0.3123f, 23.f, 42.f, 0.f;
-  RotationalScanMatcher matcher({{histogram, 0.f}});
+  const std::vector<std::pair<Eigen::VectorXf, float>> histogram_at_angle = {
+      {histogram, 0.f}};
+  RotationalScanMatcher matcher(histogram_at_angle);
   const auto scores = matcher.Match(histogram, 0.f, {0.f, 1.f});
   ASSERT_EQ(2, scores.size());
   EXPECT_NEAR(1.f, scores[0], 1e-6);
@@ -39,8 +41,9 @@ TEST(RotationalScanMatcher3DTest, InterpolatesAsExpected) {
   constexpr int kNumBuckets = 10;
   constexpr float kAnglePerBucket = M_PI / kNumBuckets;
   constexpr float kNoInitialRotation = 0.f;
-  RotationalScanMatcher matcher(
-      {{Eigen::VectorXf::Unit(kNumBuckets, 3), kNoInitialRotation}});
+  const std::vector<std::pair<Eigen::VectorXf, float>> histogram_at_angle = {
+      {Eigen::VectorXf::Unit(kNumBuckets, 3), kNoInitialRotation}};
+  RotationalScanMatcher matcher(histogram_at_angle);
   for (float t = 0.f; t < 1.f; t += 0.1f) {
     // 't' is the fraction of overlap and we have to divide by the norm of the
     // histogram to get the expected score.

--- a/cartographer/mapping/internal/3d/scan_matching/rotational_scan_matcher_test.cc
+++ b/cartographer/mapping/internal/3d/scan_matching/rotational_scan_matcher_test.cc
@@ -28,7 +28,8 @@ namespace {
 TEST(RotationalScanMatcher3DTest, OnlySameHistogramIsScoreOne) {
   Eigen::VectorXf histogram(7);
   histogram << 1.f, 43.f, 0.5f, 0.3123f, 23.f, 42.f, 0.f;
-  RotationalScanMatcher matcher({{histogram, 0.f}});
+  RotationalScanMatcher matcher(
+      RotationalScanMatcher::RotateHistogram(histogram, 0.f));
   const auto scores = matcher.Match(histogram, 0.f, {0.f, 1.f});
   ASSERT_EQ(2, scores.size());
   EXPECT_NEAR(1.f, scores[0], 1e-6);
@@ -39,8 +40,8 @@ TEST(RotationalScanMatcher3DTest, InterpolatesAsExpected) {
   constexpr int kNumBuckets = 10;
   constexpr float kAnglePerBucket = M_PI / kNumBuckets;
   constexpr float kNoInitialRotation = 0.f;
-  RotationalScanMatcher matcher(
-      {{Eigen::VectorXf::Unit(kNumBuckets, 3), kNoInitialRotation}});
+  const Eigen::VectorXf histogram = Eigen::VectorXf::Unit(kNumBuckets, 3);
+  RotationalScanMatcher matcher(histogram);
   for (float t = 0.f; t < 1.f; t += 0.1f) {
     // 't' is the fraction of overlap and we have to divide by the norm of the
     // histogram to get the expected score.

--- a/cartographer/mapping/internal/3d/scan_matching/rotational_scan_matcher_test.cc
+++ b/cartographer/mapping/internal/3d/scan_matching/rotational_scan_matcher_test.cc
@@ -40,7 +40,8 @@ TEST(RotationalScanMatcher3DTest, InterpolatesAsExpected) {
   constexpr int kNumBuckets = 10;
   constexpr float kAnglePerBucket = M_PI / kNumBuckets;
   constexpr float kNoInitialRotation = 0.f;
-  const Eigen::VectorXf histogram = Eigen::VectorXf::Unit(kNumBuckets, 3);
+  const Eigen::VectorXf histogram = RotationalScanMatcher::RotateHistogram(
+      Eigen::VectorXf::Unit(kNumBuckets, 3), kNoInitialRotation);
   RotationalScanMatcher matcher(histogram);
   for (float t = 0.f; t < 1.f; t += 0.1f) {
     // 't' is the fraction of overlap and we have to divide by the norm of the

--- a/cartographer/mapping/internal/3d/scan_matching/rotational_scan_matcher_test.cc
+++ b/cartographer/mapping/internal/3d/scan_matching/rotational_scan_matcher_test.cc
@@ -28,8 +28,7 @@ namespace {
 TEST(RotationalScanMatcher3DTest, OnlySameHistogramIsScoreOne) {
   Eigen::VectorXf histogram(7);
   histogram << 1.f, 43.f, 0.5f, 0.3123f, 23.f, 42.f, 0.f;
-  RotationalScanMatcher matcher(
-      RotationalScanMatcher::RotateHistogram(histogram, 0.f));
+  RotationalScanMatcher matcher({{histogram, 0.f}});
   const auto scores = matcher.Match(histogram, 0.f, {0.f, 1.f});
   ASSERT_EQ(2, scores.size());
   EXPECT_NEAR(1.f, scores[0], 1e-6);
@@ -40,9 +39,8 @@ TEST(RotationalScanMatcher3DTest, InterpolatesAsExpected) {
   constexpr int kNumBuckets = 10;
   constexpr float kAnglePerBucket = M_PI / kNumBuckets;
   constexpr float kNoInitialRotation = 0.f;
-  const Eigen::VectorXf histogram = RotationalScanMatcher::RotateHistogram(
-      Eigen::VectorXf::Unit(kNumBuckets, 3), kNoInitialRotation);
-  RotationalScanMatcher matcher(histogram);
+  RotationalScanMatcher matcher(
+      {{Eigen::VectorXf::Unit(kNumBuckets, 3), kNoInitialRotation}});
   for (float t = 0.f; t < 1.f; t += 0.1f) {
     // 't' is the fraction of overlap and we have to divide by the norm of the
     // histogram to get the expected score.


### PR DESCRIPTION
Added new constructor for `RotationalScanMatcher` and exposed `RotateHistogram`.

This PR prepares for PR #1277 where the constructor 
`RotationalScanMatcher(const std::vector<std::pair<Eigen::VectorXf, float>>& histograms_at_angles)`
will be removed and only the new constructor
`RotationalScanMatcher(const Eigen::VectorXf& histogram)`
will remain. The unit tests will be updated to use the new constructor in #1277.