### PR TITLE
remove duplicate code for deserialization of Submap3D from proto

### DIFF
--- a/cartographer/mapping/3d/submap_3d.cc
+++ b/cartographer/mapping/3d/submap_3d.cc
@@ -204,13 +204,8 @@ Submap3D::Submap3D(const float high_resolution, const float low_resolution,
           common::make_unique<HybridGrid>(low_resolution)) {}
 
 Submap3D::Submap3D(const proto::Submap3D& proto)
-    : Submap(transform::ToRigid3(proto.local_pose())),
-      high_resolution_hybrid_grid_(
-          common::make_unique<HybridGrid>(proto.high_resolution_hybrid_grid())),
-      low_resolution_hybrid_grid_(
-          common::make_unique<HybridGrid>(proto.low_resolution_hybrid_grid())) {
-  set_num_range_data(proto.num_range_data());
-  set_finished(proto.finished());
+    : Submap(transform::ToRigid3(proto.local_pose())) {
+  UpdateFromProto(proto);
 }
 
 proto::Submap Submap3D::ToProto(
@@ -231,7 +226,10 @@ proto::Submap Submap3D::ToProto(
 
 void Submap3D::UpdateFromProto(const proto::Submap& proto) {
   CHECK(proto.has_submap_3d());
-  const auto& submap_3d = proto.submap_3d();
+  UpdateFromProto(proto.submap_3d());
+}
+
+void Submap3D::UpdateFromProto(const proto::Submap3D& submap_3d) {
   set_num_range_data(submap_3d.num_range_data());
   set_finished(submap_3d.finished());
   if (submap_3d.has_high_resolution_hybrid_grid()) {

--- a/cartographer/mapping/3d/submap_3d.h
+++ b/cartographer/mapping/3d/submap_3d.h
@@ -67,6 +67,7 @@ class Submap3D : public Submap {
   void Finish();
 
  private:
+  void UpdateFromProto(const proto::Submap3D& proto);
   std::unique_ptr<HybridGrid> high_resolution_hybrid_grid_;
   std::unique_ptr<HybridGrid> low_resolution_hybrid_grid_;
 };

--- a/cartographer/mapping/3d/submap_3d.h
+++ b/cartographer/mapping/3d/submap_3d.h
@@ -67,7 +67,8 @@ class Submap3D : public Submap {
   void Finish();
 
  private:
-  void UpdateFromProto(const proto::Submap3D& proto);
+  void UpdateFromProto(const proto::Submap3D& submap_3d);
+
   std::unique_ptr<HybridGrid> high_resolution_hybrid_grid_;
   std::unique_ptr<HybridGrid> low_resolution_hybrid_grid_;
 };


### PR DESCRIPTION
This PR removes the duplicate code for deserialization/updating Submap3Ds from a proto.