### PR TITLE
Remove warning at the beginning of localization.

### DIFF
--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -773,9 +773,6 @@ void PoseGraph2D::RunOptimization() {
 bool PoseGraph2D::CanAddWorkItemModifying(int trajectory_id) {
   auto it = data_.trajectories_state.find(trajectory_id);
   if (it == data_.trajectories_state.end()) {
-    LOG(WARNING) << "trajectory_id:" << trajectory_id
-                 << " has not been added "
-                    "but modification is requested.";
     return true;
   }
   if (it->second.state == TrajectoryState::FINISHED) {

--- a/cartographer/mapping/internal/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.cc
@@ -856,9 +856,6 @@ void PoseGraph3D::RunOptimization() {
 bool PoseGraph3D::CanAddWorkItemModifying(int trajectory_id) {
   auto it = data_.trajectories_state.find(trajectory_id);
   if (it == data_.trajectories_state.end()) {
-    LOG(WARNING) << "trajectory_id:" << trajectory_id
-                 << " has not been added "
-                    "but modification is requested.";
     return true;
   }
   if (it->second.state == TrajectoryState::FINISHED) {


### PR DESCRIPTION
Currently, Cartographer logs multiple warnings during startup. When you have IMU data, this is expected behavior (see also 3D example of Cartographer). In our case, we see literally thousands of them.

Since this warning is expected and doesn't provide any actual information, this PR removes it entirely.