### PR TITLE
Check for collated_fixed_frame_ for AddSensorData(FixedFramePoseData).

### DIFF
--- a/cartographer/mapping/internal/collated_trajectory_builder.h
+++ b/cartographer/mapping/internal/collated_trajectory_builder.h
@@ -70,7 +70,7 @@ class CollatedTrajectoryBuilder : public TrajectoryBuilderInterface {
   void AddSensorData(
       const std::string& sensor_id,
       const sensor::FixedFramePoseData& fixed_frame_pose_data) override {
-    if (collate_landmarks_) {
+    if (collate_fixed_frame_) {
       AddData(sensor::MakeDispatchable(sensor_id, fixed_frame_pose_data));
       return;
     }


### PR DESCRIPTION
PR #1224 introduced checks for `collate_landmarks` and `collate_fixed_frame` in the `CollatedTrajectoryBuilder`. However, it falsely checks for `collate_landmarks` in the `AddSensorData(FixedFramePoseData)` function. This PR fixes that.