### PR TITLE
Add `collate_by_trajectory` support in lua config

### DIFF
--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -82,6 +82,8 @@ proto::MapBuilderOptions CreateMapBuilderOptions(
       parameter_dictionary->GetBool("use_trajectory_builder_3d"));
   options.set_num_background_threads(
       parameter_dictionary->GetNonNegativeInt("num_background_threads"));
+  options.set_collate_by_trajectory(
+      parameter_dictionary->GetBool("collate_by_trajectory"));
   *options.mutable_pose_graph_options() = CreatePoseGraphOptions(
       parameter_dictionary->GetDictionary("pose_graph").get());
   CHECK_NE(options.use_trajectory_builder_2d(),

--- a/configuration_files/map_builder.lua
+++ b/configuration_files/map_builder.lua
@@ -19,4 +19,5 @@ MAP_BUILDER = {
   use_trajectory_builder_3d = false,
   num_background_threads = 4,
   pose_graph = POSE_GRAPH,
+  collate_by_trajectory = false,
 }


### PR DESCRIPTION
This commit add support of specifying the option to collate data by
trajectory introduced in #828 in the lua configuration files.
The value is set to false as when a boolean option is not specified it
is initialized to false.