### PR TITLE
Revert of Fix writing state of trajectories with unfinished submaps. #1286

### DIFF
--- a/cartographer/cloud/internal/handlers/add_sensor_data_batch_handler.cc
+++ b/cartographer/cloud/internal/handlers/add_sensor_data_batch_handler.cc
@@ -21,6 +21,7 @@
 #include "cartographer/cloud/proto/map_builder_service.pb.h"
 #include "cartographer/common/make_unique.h"
 #include "cartographer/mapping/local_slam_result_data.h"
+#include "cartographer/metrics/counter.h"
 #include "cartographer/sensor/internal/dispatchable.h"
 #include "cartographer/sensor/timed_point_cloud_data.h"
 #include "google/protobuf/empty.pb.h"
@@ -29,12 +30,15 @@ namespace cartographer {
 namespace cloud {
 namespace handlers {
 
+cartographer::metrics::Family<metrics::Counter>
+    * AddSensorDataBatchHandler::counter_metrics_family_ = nullptr;
+
 void AddSensorDataBatchHandler::OnRequest(
     const proto::AddSensorDataBatchRequest& request) {
   for (const proto::SensorData& sensor_data : request.sensor_data()) {
     if (!GetContext<MapBuilderContextInterface>()->CheckClientIdForTrajectory(
-            sensor_data.sensor_metadata().client_id(),
-            sensor_data.sensor_metadata().trajectory_id())) {
+        sensor_data.sensor_metadata().client_id(),
+        sensor_data.sensor_metadata().trajectory_id())) {
       LOG(ERROR) << "Unknown trajectory with ID "
                  << sensor_data.sensor_metadata().trajectory_id()
                  << " and client_id "
@@ -42,6 +46,9 @@ void AddSensorDataBatchHandler::OnRequest(
       Finish(::grpc::Status(::grpc::NOT_FOUND, "Unknown trajectory"));
       return;
     }
+    ClientMetrics* const metrics =
+        GetOrCreateClientMetrics(sensor_data.sensor_metadata().client_id(),
+                                 sensor_data.sensor_metadata().trajectory_id());
     switch (sensor_data.sensor_data_case()) {
       case proto::SensorData::kOdometryData:
         GetUnsynchronizedContext<MapBuilderContextInterface>()
@@ -50,6 +57,7 @@ void AddSensorDataBatchHandler::OnRequest(
                 sensor::MakeDispatchable(
                     sensor_data.sensor_metadata().sensor_id(),
                     sensor::FromProto(sensor_data.odometry_data())));
+        metrics->odometry_sensor_counter->Increment();
         break;
       case proto::SensorData::kImuData:
         GetUnsynchronizedContext<MapBuilderContextInterface>()
@@ -57,6 +65,7 @@ void AddSensorDataBatchHandler::OnRequest(
                                 sensor::MakeDispatchable(
                                     sensor_data.sensor_metadata().sensor_id(),
                                     sensor::FromProto(sensor_data.imu_data())));
+        metrics->imu_sensor_counter->Increment();
         break;
       case proto::SensorData::kTimedPointCloudData:
         GetUnsynchronizedContext<MapBuilderContextInterface>()
@@ -65,6 +74,7 @@ void AddSensorDataBatchHandler::OnRequest(
                 sensor::MakeDispatchable(
                     sensor_data.sensor_metadata().sensor_id(),
                     sensor::FromProto(sensor_data.timed_point_cloud_data())));
+        metrics->timed_point_cloud_counter->Increment();
         break;
       case proto::SensorData::kFixedFramePoseData:
         GetUnsynchronizedContext<MapBuilderContextInterface>()
@@ -73,6 +83,7 @@ void AddSensorDataBatchHandler::OnRequest(
                 sensor::MakeDispatchable(
                     sensor_data.sensor_metadata().sensor_id(),
                     sensor::FromProto(sensor_data.fixed_frame_pose_data())));
+        metrics->fixed_frame_pose_counter->Increment();
         break;
       case proto::SensorData::kLandmarkData:
         GetUnsynchronizedContext<MapBuilderContextInterface>()
@@ -81,12 +92,14 @@ void AddSensorDataBatchHandler::OnRequest(
                 sensor::MakeDispatchable(
                     sensor_data.sensor_metadata().sensor_id(),
                     sensor::FromProto(sensor_data.landmark_data())));
+        metrics->landmark_counter->Increment();
         break;
       case proto::SensorData::kLocalSlamResultData:
         GetContext<MapBuilderContextInterface>()->EnqueueLocalSlamResultData(
             sensor_data.sensor_metadata().trajectory_id(),
             sensor_data.sensor_metadata().sensor_id(),
             sensor_data.local_slam_result_data());
+        metrics->local_slam_result_counter->Increment();
         break;
       default:
         LOG(FATAL) << "Unknown sensor data type: "
@@ -94,6 +107,60 @@ void AddSensorDataBatchHandler::OnRequest(
     }
   }
   Send(common::make_unique<google::protobuf::Empty>());
+}
+
+void
+AddSensorDataBatchHandler::RegisterMetrics(metrics::FamilyFactory* family_factory) {
+  counter_metrics_family_ = family_factory->NewCounterFamily(
+      "cartographer_sensor_data_total",
+      "Sensor data received");
+}
+
+AddSensorDataBatchHandler::ClientMetrics*
+AddSensorDataBatchHandler::GetOrCreateClientMetrics(const std::string& client_id,
+                                                    int trajectory_id) {
+  const std::string map_key = client_id + std::to_string(trajectory_id);
+  auto client_metric_map_itr = client_metric_map_.find(map_key);
+  if (client_metric_map_itr != client_metric_map_.end()) {
+    return client_metric_map_itr->second.get();
+  }
+
+  auto new_metrics = common::make_unique<ClientMetrics>();
+  new_metrics->odometry_sensor_counter =
+      counter_metrics_family_->Add(
+          {{"client_id", client_id},
+           {"trajectory_id", std::to_string(trajectory_id)},
+           {"sensor", "odometry"}});
+  new_metrics->imu_sensor_counter =
+      counter_metrics_family_->Add(
+          {{"client_id", client_id},
+           {"trajectory_id", std::to_string(trajectory_id)},
+           {"sensor", "imu"}});
+  new_metrics->fixed_frame_pose_counter =
+      counter_metrics_family_->Add(
+          {{"client_id", client_id},
+           {"trajectory_id", std::to_string(trajectory_id)},
+           {"sensor", "fixed_frame_pose"}});
+  new_metrics->landmark_counter =
+      counter_metrics_family_->Add(
+          {{"client_id", client_id},
+           {"trajectory_id", std::to_string(trajectory_id)},
+           {"sensor", "landmark"}});
+  new_metrics->local_slam_result_counter =
+      counter_metrics_family_->Add(
+          {{"client_id", client_id},
+           {"trajectory_id", std::to_string(trajectory_id)},
+           {"sensor", "local_slam_result"}});
+  new_metrics->timed_point_cloud_counter =
+      counter_metrics_family_->Add(
+          {{"client_id", client_id},
+           {"trajectory_id", std::to_string(trajectory_id)},
+           {"sensor", "timed_point_cloud"}});
+
+  // Obtain pointer before ownership is transferred.
+  auto* new_metrics_ptr = new_metrics.get();
+  client_metric_map_[map_key] = std::move(new_metrics);
+  return new_metrics_ptr;
 }
 
 }  // namespace handlers

--- a/cartographer/cloud/internal/handlers/add_sensor_data_batch_handler.h
+++ b/cartographer/cloud/internal/handlers/add_sensor_data_batch_handler.h
@@ -17,8 +17,13 @@
 #ifndef CARTOGRAPHER_CLOUD_INTERNAL_HANDLERS_ADD_SENSOR_DATA_BATCH_HANDLER_H
 #define CARTOGRAPHER_CLOUD_INTERNAL_HANDLERS_ADD_SENSOR_DATA_BATCH_HANDLER_H
 
+#include <memory>
+#include <string>
+
 #include "async_grpc/rpc_handler.h"
 #include "cartographer/cloud/proto/map_builder_service.pb.h"
+#include "cartographer/metrics/counter.h"
+#include "cartographer/metrics/family_factory.h"
 #include "google/protobuf/empty.pb.h"
 
 namespace cartographer {
@@ -34,6 +39,26 @@ class AddSensorDataBatchHandler
     : public async_grpc::RpcHandler<AddSensorDataBatchSignature> {
  public:
   void OnRequest(const proto::AddSensorDataBatchRequest& request) override;
+
+  static void RegisterMetrics(metrics::FamilyFactory* family_factory);
+
+ private:
+  struct ClientMetrics {
+    metrics::Counter* odometry_sensor_counter;
+    metrics::Counter* imu_sensor_counter;
+    metrics::Counter* timed_point_cloud_counter;
+    metrics::Counter* fixed_frame_pose_counter;
+    metrics::Counter* landmark_counter;
+    metrics::Counter* local_slam_result_counter ;
+  };
+
+  ClientMetrics* GetOrCreateClientMetrics(const std::string& client_id,
+                                          int trajectory_id);
+
+  static cartographer::metrics::Family<metrics::Counter>* counter_metrics_family_;
+
+  // Holds individual metrics for each client.
+  std::unordered_map<std::string, std::unique_ptr<ClientMetrics>> client_metric_map_;
 };
 
 }  // namespace handlers

--- a/cartographer/io/internal/mapping_state_serialization.cc
+++ b/cartographer/io/internal/mapping_state_serialization.cc
@@ -85,8 +85,7 @@ void SerializeSubmaps(
     SerializedData proto;
     auto* const submap_proto = proto.mutable_submap();
     *submap_proto = submap_id_data.data.submap->ToProto(
-        /*include_probability_grid_data=*/submap_id_data.data.submap
-            ->finished());
+        /*include_probability_grid_data=*/true);
     submap_proto->mutable_submap_id()->set_trajectory_id(
         submap_id_data.id.trajectory_id);
     submap_proto->mutable_submap_id()->set_submap_index(

--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -636,12 +636,10 @@ void PoseGraph2D::AddSubmapFromProto(
     data_.global_submap_poses_2d.Insert(
         submap_id, optimization::SubmapSpec2D{global_submap_pose_2d});
   }
-  const bool finished = submap.submap_2d().finished();
   AddWorkItem(
       [this, submap_id, global_submap_pose_2d, finished]() EXCLUDES(mutex_) {
         common::MutexLocker locker(&mutex_);
-        data_.submap_data.at(submap_id).state =
-            finished ? SubmapState::kFinished : SubmapState::kActive;
+        data_.submap_data.at(submap_id).state = SubmapState::kFinished;
         optimization_problem_->InsertSubmap(submap_id, global_submap_pose_2d);
         return WorkItem::Result::kDoNotRunOptimization;
       });

--- a/cartographer/mapping/internal/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.cc
@@ -648,12 +648,10 @@ void PoseGraph3D::AddSubmapFromProto(
     data_.global_submap_poses_3d.Insert(
         submap_id, optimization::SubmapSpec3D{global_submap_pose});
   }
-  bool finished = submap.submap_3d().finished();
   AddWorkItem(
       [this, submap_id, global_submap_pose, finished]() EXCLUDES(mutex_) {
         common::MutexLocker locker(&mutex_);
-        data_.submap_data.at(submap_id).state =
-            finished ? SubmapState::kFinished : SubmapState::kActive;
+        data_.submap_data.at(submap_id).state = SubmapState::kFinished;
         optimization_problem_->InsertSubmap(submap_id, global_submap_pose);
         return WorkItem::Result::kDoNotRunOptimization;
       });

--- a/cartographer/mapping/internal/testing/test_helpers.cc
+++ b/cartographer/mapping/internal/testing/test_helpers.cc
@@ -85,7 +85,6 @@ proto::Submap CreateFakeSubmap3D(int trajectory_id, int submap_index) {
   proto.mutable_submap_3d()->set_num_range_data(1);
   *proto.mutable_submap_3d()->mutable_local_pose() =
       transform::ToProto(transform::Rigid3d::Identity());
-  proto.mutable_submap_3d()->set_finished(true);
   return proto;
 }
 

--- a/cartographer/mapping/map_builder_test.cc
+++ b/cartographer/mapping/map_builder_test.cc
@@ -417,7 +417,7 @@ TEST_F(MapBuilderTest, LocalizationOnFrozenTrajectory2D) {
       ++num_cross_trajectory_constraints;
     }
   }
-  EXPECT_EQ(num_cross_trajectory_constraints, 3);
+  EXPECT_GT(num_cross_trajectory_constraints, 3);
   // TODO(gaschler): Subscribe global slam callback, verify that all nodes are
   // optimized.
   EXPECT_THAT(constraints, ::testing::Contains(::testing::Field(


### PR DESCRIPTION
Reason: Break rviz visualization for submaps loaded from pbstreams.