### PR TITLE
Fix Abseil build command

### DIFF
--- a/cmake/modules/FindAbseil.cmake
+++ b/cmake/modules/FindAbseil.cmake
@@ -57,19 +57,12 @@ if(NOT TARGET standalone_absl)
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/utility/${prefix}absl_utility${suffix}"
     )
 
-   if(CMAKE_GENERATOR MATCHES "Ninja")
-     set (ABSL_BUILD_COMMAND "ninja")
-   else()
-     set (ABSL_BUILD_COMMAND "make")
-   endif()
-
   ExternalProject_Add(${ABSEIL_PROJECT_NAME}
     PREFIX ${ABSEIL_PROJECT_NAME}
     GIT_REPOSITORY   https://github.com/abseil/abseil-cpp.git
     GIT_TAG          44aa275286baf97fc13529aca547a88b180beb08
     INSTALL_COMMAND  ""
-    BUILD_ALWAYS TRUE
-    BUILD_COMMAND ${ABSEIL_BUILD_COMMAND}
+    BUILD_COMMAND    ${CMAKE_COMMAND} --build "${ABSEIL_PROJECT_BUILD_DIR}"
     CMAKE_CACHE_ARGS "-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON;-DBUILD_TESTING:BOOL=OFF;-DCMAKE_BUILD_TYPE:STRING=Release"
     BUILD_BYPRODUCTS "${ABSEIL_LIBRARY_PATH};${ABSEIL_DEPENDENT_LIBRARIES}"
   )


### PR DESCRIPTION
@pifon2a I've noticed the `BUILD_COMMAND` is broken. You're setting `ABSL_BUILD_COMMAND`, but using `ABSEIL_BUILD_COMMAND` (effectively empty). Somehow this doesn't confuse newer CMakes, but the one you install on Trusty gets confused and interprets this as a no-op build step. This causes the indigo pipeline in cartographer_ros to fail.

Use the cross-platform build command instead: 
https://cmake.org/cmake/help/latest/module/ExternalProject.html#obtaining-project-properties (just above the linked paragraph)