### PR TITLE
[ABSL] Use absl::Substitute in rigid_transform debug messages.

### DIFF
--- a/cartographer/BUILD.bazel
+++ b/cartographer/BUILD.bazel
@@ -96,8 +96,9 @@ cc_library(
         ":cc_protos",
         "@boost//:iostreams",
         "@com_google_absl//absl/base",
-        "@com_google_absl//absl/types:optional",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/types:optional",
         "@com_google_glog//:glog",
         "@org_cairographics_cairo//:cairo",
         "@org_ceres_solver_ceres_solver//:ceres",
@@ -113,8 +114,8 @@ cc_library(
     deps = [
         ":cartographer",
         ":cartographer_test_library",
-        "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest_main",
     ],
 ) for src in glob(
     ["**/*_test.cc"],

--- a/cartographer/transform/rigid_transform.h
+++ b/cartographer/transform/rigid_transform.h
@@ -163,7 +163,7 @@ class Rigid3 {
   }
 
   std::string DebugString() const {
-    return absl::Substitute("{ t: [$0, $1, $2], r: [$3, $4, $5, $6] }",
+    return absl::Substitute("{ t: [$0, $1, $2], q: [$3, $4, $5, $6] }",
                             translation().x(), translation().y(),
                             translation().z(), rotation().w(), rotation().x(),
                             rotation().y(), rotation().z());

--- a/cartographer/transform/rigid_transform.h
+++ b/cartographer/transform/rigid_transform.h
@@ -23,6 +23,7 @@
 
 #include "Eigen/Core"
 #include "Eigen/Geometry"
+#include "absl/strings/substitute.h"
 #include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer/common/math.h"
 #include "cartographer/common/port.h"
@@ -77,15 +78,8 @@ class Rigid2 {
   }
 
   std::string DebugString() const {
-    std::string out;
-    out.append("{ t: [");
-    out.append(std::to_string(translation().x()));
-    out.append(", ");
-    out.append(std::to_string(translation().y()));
-    out.append("], r: [");
-    out.append(std::to_string(rotation().angle()));
-    out.append("] }");
-    return out;
+    return absl::Substitute("{ t: [$0, $1], r: [$2] }", translation().x(),
+                            translation().y(), rotation().angle());
   }
 
  private:
@@ -169,23 +163,10 @@ class Rigid3 {
   }
 
   std::string DebugString() const {
-    std::string out;
-    out.append("{ t: [");
-    out.append(std::to_string(translation().x()));
-    out.append(", ");
-    out.append(std::to_string(translation().y()));
-    out.append(", ");
-    out.append(std::to_string(translation().z()));
-    out.append("], q: [");
-    out.append(std::to_string(rotation().w()));
-    out.append(", ");
-    out.append(std::to_string(rotation().x()));
-    out.append(", ");
-    out.append(std::to_string(rotation().y()));
-    out.append(", ");
-    out.append(std::to_string(rotation().z()));
-    out.append("] }");
-    return out;
+    return absl::Substitute("{ t: [$0, $1, $2], r: [$3, $4, $5, $6] }",
+                            translation().x(), translation().y(),
+                            translation().z(), rotation().w(), rotation().x(),
+                            rotation().y(), rotation().z());
   }
 
   bool IsValid() const {

--- a/cmake/modules/FindAbseil.cmake
+++ b/cmake/modules/FindAbseil.cmake
@@ -29,6 +29,10 @@ if(NOT TARGET standalone_absl)
   set(ABSEIL_DEPENDENT_LIBRARIES
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/debugging/${prefix}absl_symbolize${suffix}"
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/time/${prefix}absl_time${suffix}"
+    "${ABSEIL_PROJECT_BUILD_DIR}/absl/strings/${prefix}absl_strings${suffix}"
+    "${ABSEIL_PROJECT_BUILD_DIR}/absl/strings/${prefix}str_format_internal${suffix}"
+    "${ABSEIL_PROJECT_BUILD_DIR}/absl/strings/${prefix}str_format_extension_internal${suffix}"
+    "${ABSEIL_PROJECT_BUILD_DIR}/absl/strings/${prefix}absl_str_format${suffix}"
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/algorithm/${prefix}absl_algorithm${suffix}"
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/base/${prefix}absl_base${suffix}"
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/base/${prefix}absl_dynamic_annotations${suffix}"
@@ -47,7 +51,6 @@ if(NOT TARGET standalone_absl)
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/meta/${prefix}absl_meta${suffix}"
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/numeric/${prefix}absl_int128${suffix}"
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/numeric/${prefix}absl_numeric${suffix}"
-    "${ABSEIL_PROJECT_BUILD_DIR}/absl/strings/${prefix}absl_strings${suffix}"
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/synchronization/${prefix}absl_synchronization${suffix}"
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/types/${prefix}absl_any${suffix}"
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/types/${prefix}absl_bad_any_cast${suffix}"
@@ -56,8 +59,7 @@ if(NOT TARGET standalone_absl)
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/types/${prefix}absl_span${suffix}"
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/types/${prefix}absl_variant${suffix}"
     "${ABSEIL_PROJECT_BUILD_DIR}/absl/utility/${prefix}absl_utility${suffix}"
-    )
-
+  )
   ExternalProject_Add(${ABSEIL_PROJECT_NAME}
     PREFIX ${ABSEIL_PROJECT_NAME}
     GIT_REPOSITORY   https://github.com/abseil/abseil-cpp.git


### PR DESCRIPTION
it is at least readable.