### PR TITLE
Rename submap finished flags

### DIFF
--- a/cartographer/cloud/internal/map_builder_server.cc
+++ b/cartographer/cloud/internal/map_builder_server.cc
@@ -192,7 +192,7 @@ void MapBuilderServer::OnLocalSlamResult(
                                        time, starting_submap_index_,
                                        *insertion_result, sensor_data.get());
     // TODO(cschuet): Make this more robust.
-    if (insertion_result->insertion_submaps.front()->finished()) {
+    if (insertion_result->insertion_submaps.front()->insertion_finished()) {
       ++starting_submap_index_;
     }
     grpc_server_->GetUnsynchronizedContext<MapBuilderContextInterface>()

--- a/cartographer/cloud/internal/sensor/serialization.cc
+++ b/cartographer/cloud/internal/sensor/serialization.cc
@@ -92,7 +92,7 @@ void CreateSensorDataForLocalSlamResult(
   for (const auto& insertion_submap : insertion_result.insertion_submaps) {
     // We only send the probability grid up if the submap is finished.
     auto* submap = proto->mutable_local_slam_result_data()->add_submaps();
-    *submap = insertion_submap->ToProto(insertion_submap->finished());
+    *submap = insertion_submap->ToProto(insertion_submap->insertion_finished());
     submap->mutable_submap_id()->set_trajectory_id(trajectory_id);
     submap->mutable_submap_id()->set_submap_index(starting_submap_index);
     ++starting_submap_index;

--- a/cartographer/io/internal/mapping_state_serialization.cc
+++ b/cartographer/io/internal/mapping_state_serialization.cc
@@ -84,7 +84,7 @@ void SerializeSubmaps(
   // Next serialize all submaps.
   for (const auto& submap_id_data : submap_data) {
     if (!include_unfinished_submaps &&
-        !submap_id_data.data.submap->finished()) {
+        !submap_id_data.data.submap->insertion_finished()) {
       continue;
     }
     SerializedData proto;

--- a/cartographer/mapping/2d/submap_2d_test.cc
+++ b/cartographer/mapping/2d/submap_2d_test.cc
@@ -113,7 +113,7 @@ TEST(Submap2DTest, ToFromProto) {
   EXPECT_TRUE(expected.local_pose().rotation().isApprox(
       actual.local_pose().rotation(), 1e-6));
   EXPECT_EQ(expected.num_range_data(), actual.num_range_data());
-  EXPECT_EQ(expected.finished(), actual.finished());
+  EXPECT_EQ(expected.insertion_finished(), actual.insertion_finished());
   EXPECT_NEAR(expected.grid()->limits().resolution(),
               actual.grid()->limits().resolution(), 1e-6);
   EXPECT_TRUE(expected.grid()->limits().max().isApprox(

--- a/cartographer/mapping/3d/submap_3d_test.cc
+++ b/cartographer/mapping/3d/submap_3d_test.cc
@@ -38,7 +38,7 @@ TEST(SubmapsTest, ToFromProto) {
   EXPECT_TRUE(expected.local_pose().rotation().isApprox(
       actual.local_pose().rotation(), 1e-6));
   EXPECT_EQ(expected.num_range_data(), actual.num_range_data());
-  EXPECT_EQ(expected.finished(), actual.finished());
+  EXPECT_EQ(expected.insertion_finished(), actual.insertion_finished());
   EXPECT_NEAR(expected.high_resolution_hybrid_grid().resolution(), 0.05, 1e-6);
   EXPECT_NEAR(expected.low_resolution_hybrid_grid().resolution(), 0.25, 1e-6);
 }

--- a/cartographer/mapping/internal/2d/overlapping_submaps_trimmer_2d.cc
+++ b/cartographer/mapping/internal/2d/overlapping_submaps_trimmer_2d.cc
@@ -60,7 +60,7 @@ std::set<SubmapId> AddSubmapsToSubmapCoverageGrid2D(
   for (const auto& submap : submap_data) {
     auto freshness = submap_freshness.find(submap.id);
     if (freshness == submap_freshness.end()) continue;
-    if (!submap.data.submap->finished()) continue;
+    if (!submap.data.submap->insertion_finished()) continue;
     all_submap_ids.insert(submap.id);
     const Grid2D& grid =
         *std::static_pointer_cast<const Submap2D>(submap.data.submap)->grid();

--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -146,7 +146,8 @@ NodeId PoseGraph2D::AddNode(
                                     insertion_submaps, optimized_pose);
   // We have to check this here, because it might have changed by the time we
   // execute the lambda.
-  const bool newly_finished_submap = insertion_submaps.front()->finished();
+  const bool newly_finished_submap =
+      insertion_submaps.front()->insertion_finished();
   AddWorkItem([=]() LOCKS_EXCLUDED(mutex_) {
     return ComputeConstraintsForNode(node_id, insertion_submaps,
                                      newly_finished_submap);
@@ -242,7 +243,7 @@ void PoseGraph2D::ComputeConstraint(const NodeId& node_id,
   {
     absl::MutexLock locker(&mutex_);
     CHECK(data_.submap_data.at(submap_id).state == SubmapState::kFinished);
-    if (!data_.submap_data.at(submap_id).submap->finished()) {
+    if (!data_.submap_data.at(submap_id).submap->insertion_finished()) {
       // Uplink server only receives grids when they are finished, so skip
       // constraint search before that.
       return;
@@ -316,7 +317,8 @@ WorkItem::Result PoseGraph2D::ComputeConstraintsForNode(
       const SubmapId submap_id = submap_ids[i];
       // Even if this was the last node added to 'submap_id', the submap will
       // only be marked as finished in 'data_.submap_data' further below.
-      CHECK(data_.submap_data.at(submap_id).state == SubmapState::kActive);
+      CHECK(data_.submap_data.at(submap_id).state ==
+            SubmapState::kNoConstraintSearch);
       data_.submap_data.at(submap_id).node_ids.emplace(node_id);
       const transform::Rigid2d constraint_transform =
           constraints::ComputeSubmapPose(*insertion_submaps[i]).inverse() *
@@ -344,7 +346,7 @@ WorkItem::Result PoseGraph2D::ComputeConstraintsForNode(
       const SubmapId newly_finished_submap_id = submap_ids.front();
       InternalSubmapData& finished_submap_data =
           data_.submap_data.at(newly_finished_submap_id);
-      CHECK(finished_submap_data.state == SubmapState::kActive);
+      CHECK(finished_submap_data.state == SubmapState::kNoConstraintSearch);
       finished_submap_data.state = SubmapState::kFinished;
       newly_finished_submap_node_ids = finished_submap_data.node_ids;
     }

--- a/cartographer/mapping/internal/submap_controller.h
+++ b/cartographer/mapping/internal/submap_controller.h
@@ -47,7 +47,7 @@ class SubmapController {
 
     // If the submap was just finished by the recent update, remove it from
     // the list of unfinished submaps.
-    if (submap_ptr->finished()) {
+    if (submap_ptr->insertion_finished()) {
       unfinished_submaps_.Trim(submap_id);
     } else {
       // If the submap is unfinished set the 'num_range_data' to 0 since we

--- a/cartographer/mapping/pose_graph.cc
+++ b/cartographer/mapping/pose_graph.cc
@@ -134,7 +134,7 @@ proto::PoseGraph PoseGraph::ToProto(bool include_unfinished_submaps) const {
     proto::Trajectory* trajectory_proto =
         trajectory(submap_id_data.id.trajectory_id);
     if (!include_unfinished_submaps &&
-        !submap_id_data.data.submap->finished()) {
+        !submap_id_data.data.submap->insertion_finished()) {
       // Collect IDs of all unfinished submaps and skip them.
       unfinished_submaps.insert(submap_id_data.id);
       continue;

--- a/cartographer/mapping/pose_graph_data.h
+++ b/cartographer/mapping/pose_graph_data.h
@@ -31,10 +31,11 @@
 namespace cartographer {
 namespace mapping {
 
-// The current state of the submap in the background threads. When this
-// transitions to kFinished, all nodes are tried to match against this submap.
-// Likewise, all new nodes are matched against submaps which are finished.
-enum class SubmapState { kActive, kFinished };
+// The current state of the submap in the background threads. After this
+// transitions to 'kFinished', all nodes are tried to match
+// against this submap. Likewise, all new nodes are matched against submaps in
+// that state.
+enum class SubmapState { kNoConstraintSearch, kFinished };
 
 struct InternalTrajectoryState {
   enum class DeletionState {
@@ -50,11 +51,11 @@ struct InternalTrajectoryState {
 
 struct InternalSubmapData {
   std::shared_ptr<const Submap> submap;
-  SubmapState state = SubmapState::kActive;
+  SubmapState state = SubmapState::kNoConstraintSearch;
 
   // IDs of the nodes that were inserted into this map together with
   // constraints for them. They are not to be matched again when this submap
-  // becomes 'finished'.
+  // becomes 'kFinished'.
   std::set<NodeId> node_ids;
 };
 

--- a/cartographer/mapping/submaps.h
+++ b/cartographer/mapping/submaps.h
@@ -53,9 +53,9 @@ inline uint8 ProbabilityToLogOddsInteger(const float probability) {
 }
 
 // An individual submap, which has a 'local_pose' in the local map frame, keeps
-// track of how many range data were inserted into it, and sets the
-// 'finished_probability_grid' to be used for loop closing once the map no
-// longer changes.
+// track of how many range data were inserted into it, and sets
+// 'insertion_finished' when the map no longer changes and is ready for loop
+// closing.
 class Submap {
  public:
   Submap(const transform::Rigid3d& local_submap_pose)
@@ -79,14 +79,15 @@ class Submap {
     num_range_data_ = num_range_data;
   }
 
-  // Whether the submap is finished or not.
-  bool finished() const { return finished_; }
-  void set_finished(bool finished) { finished_ = finished; }
+  bool insertion_finished() const { return insertion_finished_; }
+  void set_insertion_finished(bool insertion_finished) {
+    insertion_finished_ = insertion_finished;
+  }
 
  private:
   const transform::Rigid3d local_pose_;
   int num_range_data_ = 0;
-  bool finished_ = false;
+  bool insertion_finished_ = false;
 };
 
 }  // namespace mapping


### PR DESCRIPTION
A submap has two separate bool finished states:
1. 'Submap::finished()' whether all range data has been inserted.
2. 'SubmapState', used by 'PoseGraph', which becomes true slightly
later after pose graph elements have been created and the submap
should take part in constraint search.

This is confusing. Serialization knows only one such state.

So, we rename
1. finished => insertion_finished
2. kActive => kNoConstraintSearch