### PR TITLE
Add TSDF support for RealTimeCorrelativeScanMatcher.

### DIFF
--- a/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
+++ b/cartographer/mapping/internal/2d/local_trajectory_builder_2d.cc
@@ -75,12 +75,9 @@ std::unique_ptr<transform::Rigid2d> LocalTrajectoryBuilder2D::ScanMatch(
   transform::Rigid2d initial_ceres_pose = pose_prediction;
 
   if (options_.use_online_correlative_scan_matching()) {
-    CHECK_EQ(options_.submaps_options().grid_options_2d().grid_type(),
-             proto::GridOptions2D_GridType_PROBABILITY_GRID);
     const double score = real_time_correlative_scan_matcher_.Match(
         pose_prediction, filtered_gravity_aligned_point_cloud,
-        *static_cast<const ProbabilityGrid*>(matching_submap->grid()),
-        &initial_ceres_pose);
+        *matching_submap->grid(), &initial_ceres_pose);
     kRealTimeCorrelativeScanMatcherScoreMetric->Observe(score);
   }
 

--- a/cartographer/mapping/internal/2d/scan_matching/ceres_scan_matcher_2d.cc
+++ b/cartographer/mapping/internal/2d/scan_matching/ceres_scan_matcher_2d.cc
@@ -71,22 +71,23 @@ void CeresScanMatcher2D::Match(const Eigen::Vector2d& target_translation,
                                    initial_pose_estimate.rotation().angle()};
   ceres::Problem problem;
   CHECK_GT(options_.occupied_space_weight(), 0.);
-  if (grid.GetGridType() == GridType::PROBABILITY_GRID) {
-    problem.AddResidualBlock(
-        CreateOccupiedSpaceCostFunction2D(
-            options_.occupied_space_weight() /
-                std::sqrt(static_cast<double>(point_cloud.size())),
-            point_cloud, grid),
-        nullptr /* loss function */, ceres_pose_estimate);
-  } else if (grid.GetGridType() == GridType::TSDF) {
-    problem.AddResidualBlock(
-        CreateTSDFMatchCostFunction2D(
-            options_.occupied_space_weight() /
-                std::sqrt(static_cast<double>(point_cloud.size())),
-            point_cloud, static_cast<const TSDF2D&>(grid)),
-        nullptr /* loss function */, ceres_pose_estimate);
-  } else {
-    LOG(FATAL) << "Unknown GridType.";
+  switch (grid.GetGridType()) {
+    case GridType::PROBABILITY_GRID:
+      problem.AddResidualBlock(
+          CreateOccupiedSpaceCostFunction2D(
+              options_.occupied_space_weight() /
+                  std::sqrt(static_cast<double>(point_cloud.size())),
+              point_cloud, grid),
+          nullptr /* loss function */, ceres_pose_estimate);
+      break;
+    case GridType::TSDF:
+      problem.AddResidualBlock(
+          CreateTSDFMatchCostFunction2D(
+              options_.occupied_space_weight() /
+                  std::sqrt(static_cast<double>(point_cloud.size())),
+              point_cloud, static_cast<const TSDF2D&>(grid)),
+          nullptr /* loss function */, ceres_pose_estimate);
+      break;
   }
   CHECK_GT(options_.translation_weight(), 0.);
   problem.AddResidualBlock(

--- a/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d.cc
+++ b/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d.cc
@@ -165,6 +165,7 @@ void RealTimeCorrelativeScanMatcher2D::ScoreCandidates(
             static_cast<const TSDF2D&>(grid),
             discrete_scans[candidate.scan_index], candidate.x_index_offset,
             candidate.y_index_offset);
+        break;
     }
     candidate.score *=
         std::exp(-common::Pow2(std::hypot(candidate.x, candidate.y) *

--- a/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d.cc
+++ b/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d.cc
@@ -168,7 +168,7 @@ void RealTimeCorrelativeScanMatcher2D::ScoreCandidates(
                                    options_.translation_delta_cost_weight() +
                                std::abs(candidate.orientation) *
                                    options_.rotation_delta_cost_weight()));
-    CHECK_GT(candidate.score, 0.f);
+    CHECK_GE(candidate.score, 0.f);
   }
 }
 

--- a/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d.cc
+++ b/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d.cc
@@ -53,6 +53,7 @@ float TSDFCandidateScore(const TSDF2D& tsdf,
     summed_weight += weight;
   }
   candidate_score /= summed_weight;
+  CHECK_GE(candidate_score, 0.f);
   return candidate_score;
 }
 
@@ -68,6 +69,7 @@ float ProbabilityGridCandidateScore(const ProbabilityGrid& probability_grid,
     candidate_score += probability;
   }
   candidate_score /= static_cast<float>(discrete_scan.size());
+  CHECK_GT(candidate_score, 0.f);
   return candidate_score;
 }
 
@@ -168,7 +170,6 @@ void RealTimeCorrelativeScanMatcher2D::ScoreCandidates(
                                    options_.translation_delta_cost_weight() +
                                std::abs(candidate.orientation) *
                                    options_.rotation_delta_cost_weight()));
-    CHECK_GE(candidate.score, 0.f);
   }
 }
 

--- a/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d.h
+++ b/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d.h
@@ -41,7 +41,7 @@
 #include <vector>
 
 #include "Eigen/Core"
-#include "cartographer/mapping/2d/probability_grid.h"
+#include "cartographer/mapping/2d/grid_2d.h"
 #include "cartographer/mapping/internal/2d/scan_matching/correlative_scan_matcher_2d.h"
 #include "cartographer/mapping/proto/scan_matching/real_time_correlative_scan_matcher_options.pb.h"
 
@@ -60,20 +60,19 @@ class RealTimeCorrelativeScanMatcher2D {
   RealTimeCorrelativeScanMatcher2D& operator=(
       const RealTimeCorrelativeScanMatcher2D&) = delete;
 
-  // Aligns 'point_cloud' within the 'probability_grid' given an
+  // Aligns 'point_cloud' within the 'grid' given an
   // 'initial_pose_estimate' then updates 'pose_estimate' with the result and
   // returns the score.
   double Match(const transform::Rigid2d& initial_pose_estimate,
-               const sensor::PointCloud& point_cloud,
-               const ProbabilityGrid& probability_grid,
+               const sensor::PointCloud& point_cloud, const Grid2D& grid,
                transform::Rigid2d* pose_estimate) const;
 
   // Computes the score for each Candidate2D in a collection. The cost is
-  // computed as the sum of probabilities, different from the Ceres
-  // CostFunctions: http://ceres-solver.org/modeling.html
+  // computed as the sum of probabilities or normalized TSD values, different
+  // from the Ceres CostFunctions: http://ceres-solver.org/modeling.html
   //
   // Visible for testing.
-  void ScoreCandidates(const ProbabilityGrid& probability_grid,
+  void ScoreCandidates(const Grid2D& grid,
                        const std::vector<DiscreteScan2D>& discrete_scans,
                        const SearchParameters& search_parameters,
                        std::vector<Candidate2D>* candidates) const;

--- a/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d_test.cc
+++ b/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d_test.cc
@@ -169,8 +169,7 @@ TEST_F(RealTimeCorrelativeScanMatcherTest,
   std::vector<Candidate2D> candidates;
   candidates.emplace_back(0, 0, 1, SearchParameters(0, 0, 0., 0.));
   real_time_correlative_scan_matcher_->ScoreCandidates(
-      *grid_, discrete_scans, SearchParameters(0, 0, 0., 0.),
-      &candidates);
+      *grid_, discrete_scans, SearchParameters(0, 0, 0., 0.), &candidates);
   EXPECT_EQ(0, candidates[0].scan_index);
   EXPECT_EQ(0, candidates[0].x_index_offset);
   EXPECT_EQ(1, candidates[0].y_index_offset);
@@ -189,8 +188,7 @@ TEST_F(RealTimeCorrelativeScanMatcherTest,
   std::vector<Candidate2D> candidates;
   candidates.emplace_back(0, 0, 1, SearchParameters(0, 0, 0., 0.));
   real_time_correlative_scan_matcher_->ScoreCandidates(
-      *grid_, discrete_scans, SearchParameters(0, 0, 0., 0.),
-      &candidates);
+      *grid_, discrete_scans, SearchParameters(0, 0, 0., 0.), &candidates);
   EXPECT_EQ(0, candidates[0].scan_index);
   EXPECT_EQ(0, candidates[0].x_index_offset);
   EXPECT_EQ(1, candidates[0].y_index_offset);

--- a/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d_test.cc
+++ b/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d_test.cc
@@ -24,6 +24,8 @@
 #include "cartographer/common/lua_parameter_dictionary_test_helpers.h"
 #include "cartographer/mapping/2d/probability_grid.h"
 #include "cartographer/mapping/2d/probability_grid_range_data_inserter_2d.h"
+#include "cartographer/mapping/2d/tsdf_2d.h"
+#include "cartographer/mapping/2d/tsdf_range_data_inserter_2d.h"
 #include "cartographer/mapping/internal/scan_matching/real_time_correlative_scan_matcher.h"
 #include "cartographer/sensor/point_cloud.h"
 #include "cartographer/transform/transform.h"
@@ -34,12 +36,66 @@ namespace mapping {
 namespace scan_matching {
 namespace {
 
-class RealTimeCorrelativeScanMatcherTest : public ::testing::Test {
+proto::RealTimeCorrelativeScanMatcherOptions
+CreateFastCorrelativeScanMatcherTestOptions2D() {
+  auto parameter_dictionary = common::MakeDictionary(
+      "return {"
+      "linear_search_window = 0.6, "
+      "angular_search_window = 0.16, "
+      "translation_delta_cost_weight = 0., "
+      "rotation_delta_cost_weight = 0., "
+      "}");
+  return CreateRealTimeCorrelativeScanMatcherOptions(
+      parameter_dictionary.get());
+}
+
+class RealTimeCorrelativeScanMatcherTest
+    : public ::testing::TestWithParam<::cartographer::mapping::GridType> {
  protected:
-  RealTimeCorrelativeScanMatcherTest()
-      : probability_grid_(
-            MapLimits(0.05, Eigen::Vector2d(0.05, 0.25), CellLimits(6, 6)),
-            &conversion_tables_) {
+  RealTimeCorrelativeScanMatcherTest() {
+    point_cloud_.emplace_back(0.025f, 0.175f, 0.f);
+    point_cloud_.emplace_back(-0.025f, 0.175f, 0.f);
+    point_cloud_.emplace_back(-0.075f, 0.175f, 0.f);
+    point_cloud_.emplace_back(-0.125f, 0.175f, 0.f);
+    point_cloud_.emplace_back(-0.125f, 0.125f, 0.f);
+    point_cloud_.emplace_back(-0.125f, 0.075f, 0.f);
+    point_cloud_.emplace_back(-0.125f, 0.025f, 0.f);
+    real_time_correlative_scan_matcher_ =
+        absl::make_unique<RealTimeCorrelativeScanMatcher2D>(
+            CreateFastCorrelativeScanMatcherTestOptions2D());
+  }
+
+  void SetUpTSDF() {
+    grid_ = absl::make_unique<TSDF2D>(
+        MapLimits(0.05, Eigen::Vector2d(0.3, 0.5), CellLimits(20, 20)), 0.3,
+        1.0, &conversion_tables_);
+    {
+      auto parameter_dictionary = common::MakeDictionary(R"text(
+      return {
+        truncation_distance = 0.3,
+        maximum_weight = 10.,
+        update_free_space = false,
+        normal_estimation_options = {
+          num_normal_samples = 4,
+          sample_radius = 0.5,
+        },
+        project_sdf_distance_to_scan_normal = true,
+        update_weight_range_exponent = 0,
+        update_weight_angle_scan_normal_to_ray_kernel_bandwith = 0.5,
+        update_weight_distance_cell_to_hit_kernel_bandwith = 0.5,
+      })text");
+      range_data_inserter_ = absl::make_unique<TSDFRangeDataInserter2D>(
+          CreateTSDFRangeDataInserterOptions2D(parameter_dictionary.get()));
+    }
+    range_data_inserter_->Insert(
+        sensor::RangeData{Eigen::Vector3f(0.5f, -0.5f, 0.f), point_cloud_, {}},
+        grid_.get());
+    grid_->FinishUpdate();
+  }
+  void SetUpProbabilityGrid() {
+    grid_ = absl::make_unique<ProbabilityGrid>(
+        MapLimits(0.05, Eigen::Vector2d(0.05, 0.25), CellLimits(6, 6)),
+        &conversion_tables_);
     {
       auto parameter_dictionary = common::MakeDictionary(
           "return { "
@@ -52,75 +108,89 @@ class RealTimeCorrelativeScanMatcherTest : public ::testing::Test {
               CreateProbabilityGridRangeDataInserterOptions2D(
                   parameter_dictionary.get()));
     }
-    point_cloud_.push_back({Eigen::Vector3f{0.025f, 0.175f, 0.f}});
-    point_cloud_.push_back({Eigen::Vector3f{-0.025f, 0.175f, 0.f}});
-    point_cloud_.push_back({Eigen::Vector3f{-0.075f, 0.175f, 0.f}});
-    point_cloud_.push_back({Eigen::Vector3f{-0.125f, 0.175f, 0.f}});
-    point_cloud_.push_back({Eigen::Vector3f{-0.125f, 0.125f, 0.f}});
-    point_cloud_.push_back({Eigen::Vector3f{-0.125f, 0.075f, 0.f}});
-    point_cloud_.push_back({Eigen::Vector3f{-0.125f, 0.025f, 0.f}});
+    point_cloud_.emplace_back(0.025f, 0.175f, 0.f);
+    point_cloud_.emplace_back(-0.025f, 0.175f, 0.f);
+    point_cloud_.emplace_back(-0.075f, 0.175f, 0.f);
+    point_cloud_.emplace_back(-0.125f, 0.175f, 0.f);
+    point_cloud_.emplace_back(-0.125f, 0.125f, 0.f);
+    point_cloud_.emplace_back(-0.125f, 0.075f, 0.f);
+    point_cloud_.emplace_back(-0.125f, 0.025f, 0.f);
     range_data_inserter_->Insert(
         sensor::RangeData{Eigen::Vector3f::Zero(), point_cloud_, {}},
-        &probability_grid_);
-    probability_grid_.FinishUpdate();
-    {
-      auto parameter_dictionary = common::MakeDictionary(
-          "return {"
-          "linear_search_window = 0.6, "
-          "angular_search_window = 0.16, "
-          "translation_delta_cost_weight = 0., "
-          "rotation_delta_cost_weight = 0., "
-          "}");
-      real_time_correlative_scan_matcher_ =
-          absl::make_unique<RealTimeCorrelativeScanMatcher2D>(
-              CreateRealTimeCorrelativeScanMatcherOptions(
-                  parameter_dictionary.get()));
-    }
+        grid_.get());
+    grid_->FinishUpdate();
   }
 
   ValueConversionTables conversion_tables_;
-  ProbabilityGrid probability_grid_;
-  std::unique_ptr<ProbabilityGridRangeDataInserter2D> range_data_inserter_;
+  std::unique_ptr<Grid2D> grid_;
+  std::unique_ptr<RangeDataInserterInterface> range_data_inserter_;
   sensor::PointCloud point_cloud_;
   std::unique_ptr<RealTimeCorrelativeScanMatcher2D>
       real_time_correlative_scan_matcher_;
 };
 
-TEST_F(RealTimeCorrelativeScanMatcherTest,
+INSTANTIATE_TEST_CASE_P(
+    RealTimeCorrelativeScanMatcherTest, RealTimeCorrelativeScanMatcherTest,
+    ::testing::Values(::cartographer::mapping::GridType::PROBABILITY_GRID,
+                      ::cartographer::mapping::GridType::TSDF));
+
+TEST_P(RealTimeCorrelativeScanMatcherTest,
        ScorePerfectHighResolutionCandidate) {
+  if (GetParam() == ::cartographer::mapping::GridType::PROBABILITY_GRID) {
+    SetUpProbabilityGrid();
+  } else if (GetParam() == ::cartographer::mapping::GridType::TSDF) {
+    SetUpTSDF();
+  }
   const std::vector<sensor::PointCloud> scans =
       GenerateRotatedScans(point_cloud_, SearchParameters(0, 0, 0., 0.));
-  const std::vector<DiscreteScan2D> discrete_scans = DiscretizeScans(
-      probability_grid_.limits(), scans, Eigen::Translation2f::Identity());
+  const std::vector<DiscreteScan2D> discrete_scans =
+      DiscretizeScans(grid_->limits(), scans, Eigen::Translation2f::Identity());
   std::vector<Candidate2D> candidates;
   candidates.emplace_back(0, 0, 0, SearchParameters(0, 0, 0., 0.));
   real_time_correlative_scan_matcher_->ScoreCandidates(
-      probability_grid_, discrete_scans, SearchParameters(0, 0, 0., 0.),
+      *grid_.get(), discrete_scans, SearchParameters(0, 0, 0., 0.),
       &candidates);
   EXPECT_EQ(0, candidates[0].scan_index);
   EXPECT_EQ(0, candidates[0].x_index_offset);
   EXPECT_EQ(0, candidates[0].y_index_offset);
   // Every point should align perfectly.
-  EXPECT_NEAR(0.7, candidates[0].score, 1e-2);
+  if (GetParam() == ::cartographer::mapping::GridType::PROBABILITY_GRID) {
+    EXPECT_NEAR(0.7, candidates[0].score, 1e-2);
+  } else if (GetParam() == ::cartographer::mapping::GridType::TSDF) {
+    EXPECT_NEAR(1.0, candidates[0].score, 1e-1);
+    EXPECT_LT(0.95, candidates[0].score);
+  }
 }
 
-TEST_F(RealTimeCorrelativeScanMatcherTest,
+TEST_P(RealTimeCorrelativeScanMatcherTest,
        ScorePartiallyCorrectHighResolutionCandidate) {
+  if (GetParam() == ::cartographer::mapping::GridType::PROBABILITY_GRID) {
+    SetUpProbabilityGrid();
+  } else if (GetParam() == ::cartographer::mapping::GridType::TSDF) {
+    SetUpTSDF();
+  }
   const std::vector<sensor::PointCloud> scans =
       GenerateRotatedScans(point_cloud_, SearchParameters(0, 0, 0., 0.));
-  const std::vector<DiscreteScan2D> discrete_scans = DiscretizeScans(
-      probability_grid_.limits(), scans, Eigen::Translation2f::Identity());
+  const std::vector<DiscreteScan2D> discrete_scans =
+      DiscretizeScans(grid_->limits(), scans, Eigen::Translation2f::Identity());
   std::vector<Candidate2D> candidates;
   candidates.emplace_back(0, 0, 1, SearchParameters(0, 0, 0., 0.));
   real_time_correlative_scan_matcher_->ScoreCandidates(
-      probability_grid_, discrete_scans, SearchParameters(0, 0, 0., 0.),
+      *grid_.get(), discrete_scans, SearchParameters(0, 0, 0., 0.),
       &candidates);
   EXPECT_EQ(0, candidates[0].scan_index);
   EXPECT_EQ(0, candidates[0].x_index_offset);
   EXPECT_EQ(1, candidates[0].y_index_offset);
   // 3 points should align perfectly.
-  EXPECT_LT(0.7 * 3. / 7., candidates[0].score);
-  EXPECT_GT(0.7, candidates[0].score);
+  if (GetParam() == ::cartographer::mapping::GridType::PROBABILITY_GRID) {
+    EXPECT_LT(0.7 * 3. / 7., candidates[0].score);
+    EXPECT_GT(0.7, candidates[0].score);
+  }
+  // 3 points should align perfectly, 4 points are at 1/6th truncation distance.
+  else if (GetParam() == ::cartographer::mapping::GridType::TSDF) {
+    EXPECT_LT(1.0 - 4. / (7. * 6.), candidates[0].score);
+    EXPECT_GT(1.0, candidates[0].score);
+  }
 }
 
 }  // namespace

--- a/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d_test.cc
+++ b/cartographer/mapping/internal/2d/scan_matching/real_time_correlative_scan_matcher_2d_test.cc
@@ -52,13 +52,13 @@ CreateRealTimeCorrelativeScanMatcherTestOptions2D() {
 class RealTimeCorrelativeScanMatcherTest : public ::testing::Test {
  protected:
   RealTimeCorrelativeScanMatcherTest() {
-    point_cloud_.emplace_back(0.025f, 0.175f, 0.f);
-    point_cloud_.emplace_back(-0.025f, 0.175f, 0.f);
-    point_cloud_.emplace_back(-0.075f, 0.175f, 0.f);
-    point_cloud_.emplace_back(-0.125f, 0.175f, 0.f);
-    point_cloud_.emplace_back(-0.125f, 0.125f, 0.f);
-    point_cloud_.emplace_back(-0.125f, 0.075f, 0.f);
-    point_cloud_.emplace_back(-0.125f, 0.025f, 0.f);
+    point_cloud_.push_back({Eigen::Vector3f{0.025f, 0.175f, 0.f}});
+    point_cloud_.push_back({Eigen::Vector3f{-0.025f, 0.175f, 0.f}});
+    point_cloud_.push_back({Eigen::Vector3f{-0.075f, 0.175f, 0.f}});
+    point_cloud_.push_back({Eigen::Vector3f{-0.125f, 0.175f, 0.f}});
+    point_cloud_.push_back({Eigen::Vector3f{-0.125f, 0.125f, 0.f}});
+    point_cloud_.push_back({Eigen::Vector3f{-0.125f, 0.075f, 0.f}});
+    point_cloud_.push_back({Eigen::Vector3f{-0.125f, 0.025f, 0.f}});
     real_time_correlative_scan_matcher_ =
         absl::make_unique<RealTimeCorrelativeScanMatcher2D>(
             CreateRealTimeCorrelativeScanMatcherTestOptions2D());
@@ -108,13 +108,6 @@ class RealTimeCorrelativeScanMatcherTest : public ::testing::Test {
               CreateProbabilityGridRangeDataInserterOptions2D(
                   parameter_dictionary.get()));
     }
-    point_cloud_.emplace_back(0.025f, 0.175f, 0.f);
-    point_cloud_.emplace_back(-0.025f, 0.175f, 0.f);
-    point_cloud_.emplace_back(-0.075f, 0.175f, 0.f);
-    point_cloud_.emplace_back(-0.125f, 0.175f, 0.f);
-    point_cloud_.emplace_back(-0.125f, 0.125f, 0.f);
-    point_cloud_.emplace_back(-0.125f, 0.075f, 0.f);
-    point_cloud_.emplace_back(-0.125f, 0.025f, 0.f);
     range_data_inserter_->Insert(
         sensor::RangeData{Eigen::Vector3f::Zero(), point_cloud_, {}},
         grid_.get());
@@ -176,7 +169,7 @@ TEST_F(RealTimeCorrelativeScanMatcherTest,
   std::vector<Candidate2D> candidates;
   candidates.emplace_back(0, 0, 1, SearchParameters(0, 0, 0., 0.));
   real_time_correlative_scan_matcher_->ScoreCandidates(
-      *grid_.get(), discrete_scans, SearchParameters(0, 0, 0., 0.),
+      *grid_, discrete_scans, SearchParameters(0, 0, 0., 0.),
       &candidates);
   EXPECT_EQ(0, candidates[0].scan_index);
   EXPECT_EQ(0, candidates[0].x_index_offset);
@@ -196,7 +189,7 @@ TEST_F(RealTimeCorrelativeScanMatcherTest,
   std::vector<Candidate2D> candidates;
   candidates.emplace_back(0, 0, 1, SearchParameters(0, 0, 0., 0.));
   real_time_correlative_scan_matcher_->ScoreCandidates(
-      *grid_.get(), discrete_scans, SearchParameters(0, 0, 0., 0.),
+      *grid_, discrete_scans, SearchParameters(0, 0, 0., 0.),
       &candidates);
   EXPECT_EQ(0, candidates[0].scan_index);
   EXPECT_EQ(0, candidates[0].x_index_offset);


### PR DESCRIPTION
Continues https://github.com/googlecartographer/cartographer/pull/1376.
[RFC=0019](https://github.com/googlecartographer/rfcs/blob/master/text/0019-probability-grid-and-submap2d-restructuring.md)