### PR TITLE
Various Bazel improvements

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,3 +15,8 @@
 # Do an optimized build by default, or otherwise Cartographer cannot run
 # real-time and certain tests will timeout.
 build -c opt
+
+# By default, an optimized C++ build with Bazel will build each library twice,
+# with and without -fPIC. --force_pic avoids the unnecessary actions and
+# reduces build time.
+build --force_pic

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -18,11 +18,11 @@ def cartographer_repositories():
     _maybe(
         native.http_archive,
         name = "com_github_nelhage_rules_boost",
-        sha256 = "a55b00e0339b92fef1e0e0e4de3bbb856af206899d4c8ca77a498064290bb44c",
-        strip_prefix = "rules_boost-bd05f7b51d25396f30639d31fa78b55a3c1db182",
+        sha256 = "6de4d799373e25acd66ec681fba8ffeb13e7c501091d93afa3fadd26765b0f0d",
+        strip_prefix = "rules_boost-96ba810e48f4a28b85ee9c922f0b375274a97f98",
         urls = [
-            "https://mirror.bazel.build/github.com/nelhage/rules_boost/archive/bd05f7b51d25396f30639d31fa78b55a3c1db182.tar.gz",
-            "https://github.com/nelhage/rules_boost/archive/bd05f7b51d25396f30639d31fa78b55a3c1db182.tar.gz",
+            "https://mirror.bazel.build/github.com/nelhage/rules_boost/archive/96ba810e48f4a28b85ee9c922f0b375274a97f98.tar.gz",
+            "https://github.com/nelhage/rules_boost/archive/96ba810e48f4a28b85ee9c922f0b375274a97f98.tar.gz",
         ],
     )
 

--- a/cartographer/cloud/BUILD.bazel
+++ b/cartographer/cloud/BUILD.bazel
@@ -90,6 +90,7 @@ cc_binary(
     name = src.replace("/", "_").replace(".cc", ""),
     srcs = [src],
     data = ["//:configuration_files"],
+    flaky = True,  # :internal_client_server_test sometimes fails.
     # Tests cannot run concurrently as some of them open the same port.
     tags = ["exclusive"],
     deps = [


### PR DESCRIPTION
- `--force_pic` speeds up the build ~1.5x on my machine.
- Marking internal_client_server_test as flaky avoids misleading
  failures in some environments.
- Updating rules_boost avoids spamming stdout with configure script
  messages.

