### PR TITLE
Fix gravity alignment of 3D submaps in local SLAM

### DIFF
--- a/cartographer/mapping/3d/submap_3d.h
+++ b/cartographer/mapping/3d/submap_3d.h
@@ -90,12 +90,12 @@ class ActiveSubmaps3D {
   ActiveSubmaps3D(const ActiveSubmaps3D&) = delete;
   ActiveSubmaps3D& operator=(const ActiveSubmaps3D&) = delete;
 
-  // Inserts 'range_data' into the Submap collection. 'gravity_alignment' is
-  // used for the orientation of new submaps so that the z axis approximately
-  // aligns with gravity.
+  // Inserts 'range_data_in_local' into the Submap collection.
+  // 'local_from_gravity_aligned' is used for the orientation of new submaps so
+  // that the z axis approximately aligns with gravity.
   std::vector<std::shared_ptr<const Submap3D>> InsertRangeData(
-      const sensor::RangeData& range_data,
-      const Eigen::Quaterniond& gravity_alignment);
+      const sensor::RangeData& range_data_in_local,
+      const Eigen::Quaterniond& local_from_gravity_aligned);
 
   std::vector<std::shared_ptr<const Submap3D>> submaps() const;
 

--- a/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
+++ b/cartographer/mapping/internal/3d/local_trajectory_builder_3d.cc
@@ -352,9 +352,13 @@ LocalTrajectoryBuilder3D::InsertIntoSubmap(
   if (motion_filter_.IsSimilar(time, pose_estimate)) {
     return nullptr;
   }
+  const auto local_from_gravity_aligned =
+      pose_estimate.rotation() * gravity_alignment.inverse();
+
   std::vector<std::shared_ptr<const mapping::Submap3D>> insertion_submaps =
       active_submaps_.InsertRangeData(filtered_range_data_in_local,
-                                      gravity_alignment);
+                                      local_from_gravity_aligned);
+
   const Eigen::VectorXf rotational_scan_matcher_histogram =
       scan_matching::RotationalScanMatcher::ComputeHistogram(
           sensor::TransformPointCloud(

--- a/cartographer/mapping/pose_extrapolator.h
+++ b/cartographer/mapping/pose_extrapolator.h
@@ -54,7 +54,8 @@ class PoseExtrapolator {
   void AddOdometryData(const sensor::OdometryData& odometry_data);
   transform::Rigid3d ExtrapolatePose(common::Time time);
 
-  // Gravity alignment estimate.
+  // Returns the current gravity alignment estimate as a rotation from
+  // the tracking frame into a gravity aligned frame.
   Eigen::Quaterniond EstimateGravityOrientation(common::Time time);
 
  private:


### PR DESCRIPTION
We were passing the gravity estimate of the current tracking frame
to intialize the local submap pose. Fixing this improves the alignment
of submaps in the global (and approx. gravity-aligned) frame.