### PR TITLE
Store histogram in submaps: prepare for backward compatiblity

### DIFF
--- a/cartographer/io/internal/mapping_state_serialization.h
+++ b/cartographer/io/internal/mapping_state_serialization.h
@@ -26,6 +26,8 @@ namespace io {
 
 // The current serialization format version.
 static constexpr int kMappingStateSerializationFormatVersion = 1;
+static constexpr int kFormatVersionWithoutSubmapHistograms =
+    kMappingStateSerializationFormatVersion;
 
 // Serialize mapping state to a pbstream.
 void WritePbStream(

--- a/cartographer/io/serialization_format_migration.cc
+++ b/cartographer/io/serialization_format_migration.cc
@@ -329,11 +329,12 @@ MigrateSubmapFormatVersion1ToVersion2(
 
       mapping::proto::Submap3D* submap_3d_proto =
           migrated_submap_proto.mutable_submap_3d();
-
-      const double submap_yaw_from_gravity = transform::GetYaw(
-          transform::ToRigid3(submap_3d_proto->local_pose()).rotation() *
-          node_data.local_pose.rotation() *
-          node_data.gravity_alignment.inverse());
+      const double submap_yaw_from_gravity =
+          transform::GetYaw(transform::ToRigid3(submap_3d_proto->local_pose())
+                                .inverse()
+                                .rotation() *
+                            node_data.local_pose.rotation() *
+                            node_data.gravity_alignment.inverse());
       const Eigen::VectorXf rotational_scan_matcher_histogram_in_submap =
           scan_matching::RotationalScanMatcher::RotateHistogram(
               rotational_scan_matcher_histogram_in_gravity,

--- a/cartographer/io/serialization_format_migration.cc
+++ b/cartographer/io/serialization_format_migration.cc
@@ -303,7 +303,7 @@ MigrateSubmapFormatVersion1ToVersion2(
         submap_id_to_submap,
     mapping::MapById<mapping::NodeId, mapping::proto::Node>& node_id_to_node,
     const mapping::proto::PoseGraph& pose_graph_proto) {
-  using namespace cartographer::mapping;
+  using namespace mapping;
   if (submap_id_to_submap.empty() ||
       submap_id_to_submap.begin()->data.has_submap_2d()) {
     return submap_id_to_submap;
@@ -316,8 +316,8 @@ MigrateSubmapFormatVersion1ToVersion2(
       NodeId node_id{constraint_proto.node_id().trajectory_id(),
                      constraint_proto.node_id().node_index()};
       CHECK(node_id_to_node.Contains(node_id));
-      const TrajectoryNode::Data& node_data =
-          mapping::FromProto(node_id_to_node.at(node_id).node_data());
+      const TrajectoryNode::Data node_data =
+          FromProto(node_id_to_node.at(node_id).node_data());
       const Eigen::VectorXf& rotational_scan_matcher_histogram_in_gravity =
           node_data.rotational_scan_matcher_histogram;
 
@@ -327,7 +327,7 @@ MigrateSubmapFormatVersion1ToVersion2(
       proto::Submap& migrated_submap_proto = migrated_submaps.at(submap_id);
       CHECK(migrated_submap_proto.has_submap_3d());
 
-      mapping::proto::Submap3D* submap_3d_proto =
+      proto::Submap3D* submap_3d_proto =
           migrated_submap_proto.mutable_submap_3d();
       const double submap_yaw_from_gravity =
           transform::GetYaw(transform::ToRigid3(submap_3d_proto->local_pose())

--- a/cartographer/io/serialization_format_migration.cc
+++ b/cartographer/io/serialization_format_migration.cc
@@ -300,13 +300,13 @@ void MigrateStreamFormatToVersion1(
 mapping::MapById<mapping::SubmapId, mapping::proto::Submap>
 MigrateSubmapFormatVersion1ToVersion2(
     const mapping::MapById<mapping::SubmapId, mapping::proto::Submap>&
-        submap_id_to_submaps,
-    mapping::MapById<mapping::NodeId, mapping::proto::Node>& node_id_to_nodes,
+        submap_id_to_submap,
+    mapping::MapById<mapping::NodeId, mapping::proto::Node>& node_id_to_node,
     const mapping::proto::PoseGraph& pose_graph_proto) {
   using namespace cartographer::mapping;
-  if (submap_id_to_submaps.empty() ||
-      submap_id_to_submaps.begin()->data.has_submap_2d()) {
-    return submap_id_to_submaps;
+  if (submap_id_to_submap.empty() ||
+      submap_id_to_submap.begin()->data.has_submap_2d()) {
+    return submap_id_to_submap;
   }
 
   std::map<SubmapId, std::unique_ptr<Submap3D>> deserialized_submaps;
@@ -316,7 +316,7 @@ MigrateSubmapFormatVersion1ToVersion2(
       NodeId node_id{constraint_proto.node_id().trajectory_id(),
                      constraint_proto.node_id().node_index()};
       const TrajectoryNode::Data& node_data =
-          mapping::FromProto(node_id_to_nodes.at(node_id).node_data());
+          mapping::FromProto(node_id_to_node.at(node_id).node_data());
       const Eigen::VectorXf& rotational_scan_matcher_histogram_in_gravity =
           node_data.rotational_scan_matcher_histogram;
 
@@ -330,7 +330,7 @@ MigrateSubmapFormatVersion1ToVersion2(
 
       SubmapId submap_id{constraint_proto.submap_id().trajectory_id(),
                          constraint_proto.submap_id().submap_index()};
-      const proto::Submap& submap = submap_id_to_submaps.at(submap_id);
+      const proto::Submap& submap = submap_id_to_submap.at(submap_id);
       CHECK(submap.has_submap_3d());
       if (deserialized_submaps.find(submap_id) == deserialized_submaps.end()) {
         std::unique_ptr<Submap3D> submap3d =
@@ -341,9 +341,9 @@ MigrateSubmapFormatVersion1ToVersion2(
       submap_3d->AddScanHistogram(rotational_scan_matcher_histogram_in_local);
     }
   }
-  MapById<SubmapId, proto::Submap> migrated_submaps = submap_id_to_submaps;
+  MapById<SubmapId, proto::Submap> migrated_submaps = submap_id_to_submap;
   for (const auto& submap : deserialized_submaps) {
-    migrated_submaps.at(submap.first) = std::move(submap.second->ToProto(true));
+    migrated_submaps.at(submap.first) = submap.second->ToProto(true);
   }
   return migrated_submaps;
 }

--- a/cartographer/io/serialization_format_migration.h
+++ b/cartographer/io/serialization_format_migration.h
@@ -18,6 +18,8 @@
 #define CARTOGRAPHER_IO_SERIALIZATION_FORMAT_MIGRATION_H_
 
 #include "cartographer/io/proto_stream_interface.h"
+#include "cartographer/mapping/id.h"
+#include "cartographer/mapping/proto/serialization.pb.h"
 
 namespace cartographer {
 namespace io {
@@ -30,6 +32,13 @@ void MigrateStreamFormatToVersion1(
     cartographer::io::ProtoStreamReaderInterface* const input,
     cartographer::io::ProtoStreamWriterInterface* const output,
     bool migrate_grid_format);
+
+mapping::MapById<mapping::SubmapId, mapping::proto::Submap>
+MigrateSubmapFormatVersion1ToVersion2(
+    const mapping::MapById<mapping::SubmapId, mapping::proto::Submap>&
+        submap_id_to_submaps,
+    mapping::MapById<mapping::NodeId, mapping::proto::Node>& node_id_to_nodes,
+    const mapping::proto::PoseGraph& pose_graph_proto);
 
 }  // namespace io
 }  // namespace cartographer

--- a/cartographer/io/serialization_format_migration_test.cc
+++ b/cartographer/io/serialization_format_migration_test.cc
@@ -114,8 +114,6 @@ class SubmapHistogramMigrationTest : public ::testing::Test {
  private:
   void CreateSubmap() {
     submap_ = mapping::testing::CreateFakeSubmap3D();
-    submap_.mutable_submap_3d()->mutable_low_resolution_hybrid_grid();
-    submap_.mutable_submap_3d()->mutable_high_resolution_hybrid_grid();
     submap_.mutable_submap_3d()->clear_rotational_scan_matcher_histogram();
   }
 

--- a/cartographer/io/serialization_format_migration_test.cc
+++ b/cartographer/io/serialization_format_migration_test.cc
@@ -19,13 +19,13 @@
 #include <functional>
 #include <memory>
 
-#include "cartographer/transform/transform.h"
 #include "cartographer/io/internal/in_memory_proto_stream.h"
 #include "cartographer/mapping/proto/internal/legacy_serialized_data.pb.h"
 #include "cartographer/mapping/proto/pose_graph.pb.h"
 #include "cartographer/mapping/proto/serialization.pb.h"
 #include "cartographer/mapping/proto/trajectory_builder_options.pb.h"
 #include "cartographer/mapping/trajectory_node.h"
+#include "cartographer/transform/transform.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
@@ -237,23 +237,23 @@ TEST_F(MigrationTest, SerializedDataOrderAfterGridMigrationIsCorrect) {
 TEST_F(SubmapHistogramMigrationTest,
        SubmapHistogramGenerationFromTrajectoryNodes) {
   mapping::MapById<mapping::SubmapId, mapping::proto::Submap>
-      submap_id_to_submaps;
+      submap_id_to_submap;
   mapping::SubmapId submap_id(submap_.submap_id().trajectory_id(),
                               submap_.submap_id().submap_index());
-  submap_id_to_submaps.Insert(submap_id, submap_);
+  submap_id_to_submap.Insert(submap_id, submap_);
 
-  mapping::MapById<mapping::NodeId, mapping::proto::Node> node_id_to_nodes;
+  mapping::MapById<mapping::NodeId, mapping::proto::Node> node_id_to_node;
   mapping::NodeId node_id(node_.node_id().trajectory_id(),
                           node_.node_id().node_index());
-  node_id_to_nodes.Insert(node_id, node_);
+  node_id_to_node.Insert(node_id, node_);
 
-  const auto submap_ids_to_submap_migrated =
-      MigrateSubmapFormatVersion1ToVersion2(submap_id_to_submaps,
-                                            node_id_to_nodes, pose_graph_);
+  const auto submap_id_to_submap_migrated =
+      MigrateSubmapFormatVersion1ToVersion2(submap_id_to_submap,
+                                            node_id_to_node, pose_graph_);
 
-  EXPECT_EQ(submap_ids_to_submap_migrated.size(), submap_id_to_submaps.size());
+  EXPECT_EQ(submap_id_to_submap_migrated.size(), submap_id_to_submap.size());
   const mapping::proto::Submap& migrated_submap =
-      submap_ids_to_submap_migrated.at(submap_id);
+      submap_id_to_submap_migrated.at(submap_id);
   EXPECT_FALSE(migrated_submap.has_submap_2d());
   EXPECT_TRUE(migrated_submap.has_submap_3d());
 

--- a/cartographer/io/serialization_format_migration_test.cc
+++ b/cartographer/io/serialization_format_migration_test.cc
@@ -72,7 +72,7 @@ class MigrationTest : public ::testing::Test {
   }
 
  protected:
-  void SetUp() {
+  void SetUp() override {
     AddLegacyDataToReader<mapping::proto::LegacySerializedData>(reader_);
     AddLegacyDataToReader<mapping::proto::LegacySerializedDataLegacySubmap>(
         reader_for_migrating_grid_);
@@ -105,7 +105,7 @@ class MigrationTest : public ::testing::Test {
 
 class SubmapHistogramMigrationTest : public ::testing::Test {
  protected:
-  void SetUp() {
+  void SetUp() override {
     CreateSubmap();
     CreateNode();
     CreatePoseGraphWithNodeToSubmapConstraint();

--- a/cartographer/mapping/3d/submap_3d.cc
+++ b/cartographer/mapping/3d/submap_3d.cc
@@ -282,18 +282,6 @@ void Submap3D::InsertRangeData(const sensor::RangeData& range_data_in_local,
   set_num_range_data(num_range_data() + 1);
 }
 
-void Submap3D::AddScanHistogram(
-    const Eigen::VectorXf& scan_histogram_in_local) {
-  if (rotational_scan_matcher_histogram_.size() == 0) {
-    rotational_scan_matcher_histogram_ =
-        Eigen::VectorXf::Zero(scan_histogram_in_local.rows());
-  }
-  const float submap_yaw_from_local = transform::GetYaw(local_pose().inverse());
-  rotational_scan_matcher_histogram_ +=
-      scan_matching::RotationalScanMatcher::RotateHistogram(
-          scan_histogram_in_local, submap_yaw_from_local);
-}
-
 void Submap3D::Finish() {
   CHECK(!insertion_finished());
   set_insertion_finished(true);

--- a/cartographer/mapping/3d/submap_3d.h
+++ b/cartographer/mapping/3d/submap_3d.h
@@ -58,12 +58,16 @@ class Submap3D : public Submap {
   const HybridGrid& low_resolution_hybrid_grid() const {
     return *low_resolution_hybrid_grid_;
   }
+  const Eigen::VectorXf& rotational_scan_matcher_histogram() const {
+    return rotational_scan_matcher_histogram_;
+  }
 
   // Insert 'range_data' into this submap using 'range_data_inserter'. The
   // submap must not be finished yet.
   void InsertRangeData(const sensor::RangeData& range_data,
                        const RangeDataInserter3D& range_data_inserter,
                        float high_resolution_max_range);
+  void AddScanHistogram(const Eigen::VectorXf& scan_histogram_in_local);
   void Finish();
 
  private:
@@ -71,6 +75,7 @@ class Submap3D : public Submap {
 
   std::unique_ptr<HybridGrid> high_resolution_hybrid_grid_;
   std::unique_ptr<HybridGrid> low_resolution_hybrid_grid_;
+  Eigen::VectorXf rotational_scan_matcher_histogram_;
 };
 
 // The first active submap will be created on the insertion of the first range

--- a/cartographer/mapping/3d/submap_3d.h
+++ b/cartographer/mapping/3d/submap_3d.h
@@ -67,7 +67,6 @@ class Submap3D : public Submap {
   void InsertRangeData(const sensor::RangeData& range_data,
                        const RangeDataInserter3D& range_data_inserter,
                        float high_resolution_max_range);
-  void AddScanHistogram(const Eigen::VectorXf& scan_histogram_in_local);
   void Finish();
 
  private:

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -366,9 +366,8 @@ std::map<int, int> MapBuilder::LoadState(
 
   // TODO(schwoere): Remove backwards compatibility once the pbstream format
   // version 2 is established.
-  constexpr uint32_t kFormatVersionWithoutSubmapHistograms = 1;
   if (deserializer.header().format_version() ==
-      kFormatVersionWithoutSubmapHistograms) {
+      io::kFormatVersionWithoutSubmapHistograms) {
     submap_id_to_submap =
         cartographer::io::MigrateSubmapFormatVersion1ToVersion2(
             submap_id_to_submap, node_id_to_node, pose_graph_proto);

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -21,6 +21,7 @@
 #include "cartographer/io/internal/mapping_state_serialization.h"
 #include "cartographer/io/proto_stream.h"
 #include "cartographer/io/proto_stream_deserializer.h"
+#include "cartographer/io/serialization_format_migration.h"
 #include "cartographer/mapping/internal/2d/local_trajectory_builder_2d.h"
 #include "cartographer/mapping/internal/2d/overlapping_submaps_trimmer_2d.h"
 #include "cartographer/mapping/internal/2d/pose_graph_2d.h"
@@ -287,6 +288,8 @@ std::map<int, int> MapBuilder::LoadState(
                                  transform::ToRigid3(landmark.global_pose()));
   }
 
+  MapById<SubmapId, mapping::proto::Submap> submap_id_to_submap;
+  MapById<NodeId, mapping::proto::Node> node_id_to_node;
   SerializedData proto;
   while (deserializer.ReadNextSerializedData(&proto)) {
     switch (proto.data_case()) {
@@ -303,19 +306,20 @@ std::map<int, int> MapBuilder::LoadState(
         proto.mutable_submap()->mutable_submap_id()->set_trajectory_id(
             trajectory_remapping.at(
                 proto.submap().submap_id().trajectory_id()));
-        const transform::Rigid3d& submap_pose = submap_poses.at(
+        submap_id_to_submap.Insert(
             SubmapId{proto.submap().submap_id().trajectory_id(),
-                     proto.submap().submap_id().submap_index()});
-        pose_graph_->AddSubmapFromProto(submap_pose, proto.submap());
+                     proto.submap().submap_id().submap_index()},
+            proto.submap());
         break;
       }
       case SerializedData::kNode: {
         proto.mutable_node()->mutable_node_id()->set_trajectory_id(
             trajectory_remapping.at(proto.node().node_id().trajectory_id()));
-        const transform::Rigid3d& node_pose =
-            node_poses.at(NodeId{proto.node().node_id().trajectory_id(),
-                                 proto.node().node_id().node_index()});
+        const NodeId node_id(proto.node().node_id().trajectory_id(),
+                             proto.node().node_id().node_index());
+        const transform::Rigid3d& node_pose = node_poses.at(node_id);
         pose_graph_->AddNodeFromProto(node_pose, proto.node());
+        node_id_to_node.Insert(node_id, proto.node());
         break;
       }
       case SerializedData::kTrajectoryData: {
@@ -358,6 +362,21 @@ std::map<int, int> MapBuilder::LoadState(
         LOG(WARNING) << "Skipping unknown message type in stream: "
                      << proto.GetTypeName();
     }
+  }
+
+  // TODO(schwoere): Remove backwards compatibility once the pbstream format
+  // version 2 is established.
+  constexpr uint32_t kFormatVersionWithoutSubmapHistograms = 1;
+  if (deserializer.header().format_version() ==
+      kFormatVersionWithoutSubmapHistograms) {
+    submap_id_to_submap =
+        cartographer::io::MigrateSubmapFormatVersion1ToVersion2(
+            submap_id_to_submap, node_id_to_node, pose_graph_proto);
+  }
+
+  for (const auto& submap_id_submap : submap_id_to_submap) {
+    pose_graph_->AddSubmapFromProto(submap_poses.at(submap_id_submap.id),
+                                    submap_id_submap.data);
   }
 
   if (load_frozen_state) {

--- a/cartographer/mapping/proto/submap.proto
+++ b/cartographer/mapping/proto/submap.proto
@@ -35,4 +35,5 @@ message Submap3D {
   bool finished = 3;
   HybridGrid high_resolution_hybrid_grid = 4;
   HybridGrid low_resolution_hybrid_grid = 5;
+  repeated float rotational_scan_matcher_histogram = 6;
 }


### PR DESCRIPTION
This makes the map builder backwards compatible to the current map pbstream (version 1). The PR prepares for #1277, where pbstream version 2 will be introduced. Backwards compatibility was discussed in #1277.

When a map with pbstream version 1 is loaded, a rotational scan matcher histogram is generated for each submap using the histograms of all nodes that were inserted to the submap during local SLAM. Once this backwards compatibility is in place, I would like to introduce the new format with #1277.