### PR TITLE
Recover gRPC channel from connection dropouts.

### DIFF
--- a/cartographer/cloud/internal/local_trajectory_uploader.cc
+++ b/cartographer/cloud/internal/local_trajectory_uploader.cc
@@ -203,7 +203,7 @@ void LocalTrajectoryUploader::TryRecovery() {
       if (get_channel_state() == grpc_connectivity_state::GRPC_CHANNEL_READY) {
         // TODO: Channel state can be ready even if there's no network.
         // Could it be that the TCP socket still alive?
-        LOG(WARN) << "Request failed, but uplink channel claims to be ready."
+        LOG(WARNING) << "Request failed, but uplink channel claims to be ready."
       }
       LOG(ERROR) << "Failed to create trajectory. Aborting recovery attempt. "
                  << status.error_message();

--- a/cartographer/cloud/internal/local_trajectory_uploader.cc
+++ b/cartographer/cloud/internal/local_trajectory_uploader.cc
@@ -44,7 +44,9 @@ const common::Duration kPopTimeout = common::FromMilliseconds(100);
 // This defines the '::grpc::StatusCode's that are considered unrecoverable
 // errors and hence no retries will be attempted by the client.
 const std::set<::grpc::StatusCode> kUnrecoverableStatusCodes = {
-    ::grpc::DEADLINE_EXCEEDED, ::grpc::NOT_FOUND, ::grpc::UNAVAILABLE,
+    ::grpc::DEADLINE_EXCEEDED,
+    ::grpc::NOT_FOUND,
+    ::grpc::UNAVAILABLE,
     ::grpc::UNKNOWN,
 };
 

--- a/cartographer/cloud/internal/local_trajectory_uploader.cc
+++ b/cartographer/cloud/internal/local_trajectory_uploader.cc
@@ -156,7 +156,7 @@ void LocalTrajectoryUploader::Shutdown() {
 }
 
 void LocalTrajectoryUploader::TryRecovery() {
-  auto get_channel_state = [this](bool try_to_connect) {
+  auto get_channel_state = [this]() {
     return client_channel_->GetState(false /* try_to_connect */);
   };
   if (get_channel_state() != grpc_connectivity_state::GRPC_CHANNEL_READY) {
@@ -205,7 +205,8 @@ void LocalTrajectoryUploader::TryRecovery() {
       if (get_channel_state() == grpc_connectivity_state::GRPC_CHANNEL_READY) {
         // TODO: Channel state can be ready even if there's no network.
         // Could it be that the TCP socket still alive?
-        LOG(WARNING) << "Request failed, but uplink channel claims to be ready."
+        LOG(WARNING)
+            << "Request failed, but uplink channel claims to be ready.";
       }
       LOG(ERROR) << "Failed to create trajectory. Aborting recovery attempt. "
                  << status.error_message();


### PR DESCRIPTION
- check and recover channel connection in `TryRecovery()`
- fixes an infinite loop in the unlimited retry strategy by adding `grpc::UNAVAILABLE`,
  `DEADLINE_EXCEEDED` to the unrecoverable status codes.
  - server restart leads to `UNAVAILABLE`
  - connection loss leads to `DEADLINE_EXCEEDED`
- fixes repeated recovery attempts
