### PR TITLE
Check output stream in pbstream migration tool.

### DIFF
--- a/cartographer/io/internal/pbstream_migrate.cc
+++ b/cartographer/io/internal/pbstream_migrate.cc
@@ -48,6 +48,8 @@ int pbstream_migrate(int argc, char** argv) {
             << "\" to new serialization format in \"" << argv[3] << "\"";
   cartographer::io::MigrateStreamFormatToVersion1(&input, &output,
                                                   FLAGS_migrate_grid_format);
+  CHECK(output.Close()) << "Could not write migrated pbstream file to: "
+                        << argv[3];
 
   return EXIT_SUCCESS;
 }

--- a/cartographer/io/serialization_format_migration.cc
+++ b/cartographer/io/serialization_format_migration.cc
@@ -278,6 +278,7 @@ void SerializeToVersion1Format(
       SerializedData::kFixedFramePoseDataFieldNumber,
       SerializedData::kLandmarkDataFieldNumber};
 
+  LOG(INFO) << "Writing proto stream.";
   output->WriteProto(CreateSerializationHeader());
   for (auto field_index : kFieldSerializationOrder) {
     const auto proto_vector_it = deserialized_data.find(field_index);


### PR DESCRIPTION
Avoids failing silently, e.g. when file permissions are lacking.
