### PR TITLE
Replace token file with Google auth in MapBuilder.

### DIFF
--- a/cartographer/cloud/internal/local_trajectory_uploader.cc
+++ b/cartographer/cloud/internal/local_trajectory_uploader.cc
@@ -112,9 +112,9 @@ LocalTrajectoryUploader::LocalTrajectoryUploader(
   auto channel_creds =
       enable_google_auth
           ? grpc::GoogleDefaultCredentials()
-          : enable_ssl_encryption
-                ? ::grpc::SslCredentials(::grpc::SslCredentialsOptions())
-                : ::grpc::InsecureChannelCredentials();
+          : (enable_ssl_encryption
+                 ? ::grpc::SslCredentials(::grpc::SslCredentialsOptions())
+                 : ::grpc::InsecureChannelCredentials());
 
   client_channel_ = ::grpc::CreateChannel(uplink_server_address, channel_creds);
   std::chrono::system_clock::time_point deadline =

--- a/cartographer/cloud/internal/local_trajectory_uploader.cc
+++ b/cartographer/cloud/internal/local_trajectory_uploader.cc
@@ -21,7 +21,6 @@
 
 #include "absl/memory/memory.h"
 #include "async_grpc/client.h"
-#include "async_grpc/token_file_credentials.h"
 #include "cartographer/cloud/internal/handlers/add_sensor_data_batch_handler.h"
 #include "cartographer/cloud/internal/handlers/add_trajectory_handler.h"
 #include "cartographer/cloud/internal/handlers/finish_trajectory_handler.h"
@@ -68,7 +67,7 @@ class LocalTrajectoryUploader : public LocalTrajectoryUploaderInterface {
  public:
   LocalTrajectoryUploader(const std::string& uplink_server_address,
                           int batch_size, bool enable_ssl_encryption,
-                          const std::string& token_file_path);
+                          bool enable_google_auth);
   ~LocalTrajectoryUploader();
 
   // Starts the upload thread.
@@ -108,19 +107,15 @@ class LocalTrajectoryUploader : public LocalTrajectoryUploaderInterface {
 
 LocalTrajectoryUploader::LocalTrajectoryUploader(
     const std::string& uplink_server_address, int batch_size,
-    bool enable_ssl_encryption, const std::string& token_file_path)
+    bool enable_ssl_encryption, bool enable_google_auth)
     : batch_size_(batch_size) {
   auto channel_creds =
-      enable_ssl_encryption
+      enable_google_auth
+        ?  grpc::GoogleDefaultCredentials()
+        : enable_ssl_encryption
           ? ::grpc::SslCredentials(::grpc::SslCredentialsOptions())
           : ::grpc::InsecureChannelCredentials();
 
-  if (!token_file_path.empty()) {
-    auto call_creds = async_grpc::TokenFileCredentials(
-        token_file_path, std::chrono::seconds(kTokenRefreshIntervalInSeconds));
-    channel_creds =
-        grpc::CompositeChannelCredentials(channel_creds, call_creds);
-  }
   client_channel_ = ::grpc::CreateChannel(uplink_server_address, channel_creds);
   std::chrono::system_clock::time_point deadline =
       std::chrono::system_clock::now() +
@@ -332,10 +327,10 @@ void LocalTrajectoryUploader::EnqueueSensorData(
 
 std::unique_ptr<LocalTrajectoryUploaderInterface> CreateLocalTrajectoryUploader(
     const std::string& uplink_server_address, int batch_size,
-    bool enable_ssl_encryption, const std::string& token_file_path) {
+    bool enable_ssl_encryption, bool enable_google_auth) {
   return make_unique<LocalTrajectoryUploader>(uplink_server_address, batch_size,
                                               enable_ssl_encryption,
-                                              token_file_path);
+                                              enable_google_auth);
 }
 
 }  // namespace cloud

--- a/cartographer/cloud/internal/local_trajectory_uploader.cc
+++ b/cartographer/cloud/internal/local_trajectory_uploader.cc
@@ -111,10 +111,10 @@ LocalTrajectoryUploader::LocalTrajectoryUploader(
     : batch_size_(batch_size) {
   auto channel_creds =
       enable_google_auth
-        ?  grpc::GoogleDefaultCredentials()
-        : enable_ssl_encryption
-          ? ::grpc::SslCredentials(::grpc::SslCredentialsOptions())
-          : ::grpc::InsecureChannelCredentials();
+          ? grpc::GoogleDefaultCredentials()
+          : enable_ssl_encryption
+                ? ::grpc::SslCredentials(::grpc::SslCredentialsOptions())
+                : ::grpc::InsecureChannelCredentials();
 
   client_channel_ = ::grpc::CreateChannel(uplink_server_address, channel_creds);
   std::chrono::system_clock::time_point deadline =

--- a/cartographer/cloud/internal/local_trajectory_uploader.h
+++ b/cartographer/cloud/internal/local_trajectory_uploader.h
@@ -64,7 +64,7 @@ class LocalTrajectoryUploaderInterface {
 // Returns LocalTrajectoryUploader with the actual implementation.
 std::unique_ptr<LocalTrajectoryUploaderInterface> CreateLocalTrajectoryUploader(
     const std::string& uplink_server_address, int batch_size,
-    bool enable_ssl_encryption, const std::string& token_file_path);
+    bool enable_ssl_encryption, bool enable_google_auth);
 
 }  // namespace cloud
 }  // namespace cartographer

--- a/cartographer/cloud/internal/map_builder_server.cc
+++ b/cartographer/cloud/internal/map_builder_server.cc
@@ -68,7 +68,7 @@ MapBuilderServer::MapBuilderServer(
         map_builder_server_options.uplink_server_address(),
         map_builder_server_options.upload_batch_size(),
         map_builder_server_options.enable_ssl_encryption(),
-        map_builder_server_options.token_file_path());
+        map_builder_server_options.enable_google_auth());
   }
   server_builder.RegisterHandler<handlers::AddTrajectoryHandler>();
   server_builder.RegisterHandler<handlers::AddOdometryDataHandler>();

--- a/cartographer/cloud/map_builder_server_options.cc
+++ b/cartographer/cloud/map_builder_server_options.cc
@@ -41,8 +41,8 @@ proto::MapBuilderServerOptions CreateMapBuilderServerOptions(
       lua_parameter_dictionary->GetInt("upload_batch_size"));
   map_builder_server_options.set_enable_ssl_encryption(
       lua_parameter_dictionary->GetBool("enable_ssl_encryption"));
-  map_builder_server_options.set_token_file_path(
-      lua_parameter_dictionary->GetString("token_file_path"));
+  map_builder_server_options.set_enable_google_auth(
+      lua_parameter_dictionary->GetBool("enable_google_auth"));
   return map_builder_server_options;
 }
 

--- a/cartographer/cloud/proto/map_builder_server_options.proto
+++ b/cartographer/cloud/proto/map_builder_server_options.proto
@@ -26,5 +26,5 @@ message MapBuilderServerOptions {
   string uplink_server_address = 5;
   int32 upload_batch_size = 6;
   bool enable_ssl_encryption = 7;
-  string token_file_path = 8;
+  bool enable_google_auth = 9;
 }

--- a/configuration_files/map_builder_server.lua
+++ b/configuration_files/map_builder_server.lua
@@ -22,5 +22,5 @@ MAP_BUILDER_SERVER = {
   uplink_server_address = "",
   upload_batch_size = 100,
   enable_ssl_encryption = false,
-  token_file_path = "",
+  enable_google_auth = false,
 }


### PR DESCRIPTION
This allows Cartographer to use normal Application Default Credentials
(ADC) instead of a hand-generated format.

Google-internally, we'll only use ADC going forward. At your option, I
can keep the old code for the token files around if you think it would
be generally useful. Many OSS programs follow the same approach.