### PR TITLE
Increase gRPC timeout for AddTrajectory

### DIFF
--- a/cartographer/cloud/client/map_builder_stub.cc
+++ b/cartographer/cloud/client/map_builder_stub.cc
@@ -36,7 +36,10 @@ namespace cloud {
 namespace {
 
 using absl::make_unique;
-constexpr int kConnectionTimeoutInSeconds = 10;
+constexpr int kChannelTimeoutSeconds = 10;
+constexpr int kRetryBaseDelayMilliseconds = 500;
+constexpr float kRetryDelayFactor = 2.0;
+constexpr int kMaxRetries = 6;
 
 }  // namespace
 
@@ -50,7 +53,7 @@ MapBuilderStub::MapBuilderStub(const std::string& server_address,
             << " with client_id " << client_id;
   std::chrono::system_clock::time_point deadline(
       std::chrono::system_clock::now() +
-      std::chrono::seconds(kConnectionTimeoutInSeconds));
+      std::chrono::seconds(kChannelTimeoutSeconds));
   if (!client_channel_->WaitForConnected(deadline)) {
     LOG(FATAL) << "Failed to connect to " << server_address;
   }
@@ -67,9 +70,10 @@ int MapBuilderStub::AddTrajectoryBuilder(
     *request.add_expected_sensor_ids() = cloud::ToProto(sensor_id);
   }
   async_grpc::Client<handlers::AddTrajectorySignature> client(
-      client_channel_, common::FromSeconds(10),
-      async_grpc::CreateLimitedBackoffStrategy(common::FromMilliseconds(100),
-                                               2.f, 5));
+      client_channel_, common::FromSeconds(kChannelTimeoutSeconds),
+      async_grpc::CreateLimitedBackoffStrategy(
+          common::FromMilliseconds(kRetryBaseDelayMilliseconds),
+          kRetryDelayFactor, kMaxRetries));
   CHECK(client.Write(request));
 
   // Construct trajectory builder stub.

--- a/cartographer/cloud/client/map_builder_stub.cc
+++ b/cartographer/cloud/client/map_builder_stub.cc
@@ -39,7 +39,7 @@ using absl::make_unique;
 constexpr int kChannelTimeoutSeconds = 10;
 constexpr int kRetryBaseDelayMilliseconds = 500;
 constexpr float kRetryDelayFactor = 2.0;
-constexpr int kMaxRetries = 6;
+constexpr int kMaxRetries = 5;
 
 }  // namespace
 


### PR DESCRIPTION
A common use case is that a gRPC server and a gRPC--ROS bridge node
are started at the same time.
Setting the timeout of the stub higher ensures that these can connect
even when the gRPC server starts up slowly.
