### PR TITLE
Read missing option field fix_z_in_3d in OptimizationProblemOptions.

### DIFF
--- a/cartographer/mapping/internal/2d/pose_graph_2d_test.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d_test.cc
@@ -144,6 +144,7 @@ class PoseGraph2DTest : public ::testing::Test {
               fixed_frame_pose_rotation_weight = 1e2,
               log_solver_summary = true,
               use_online_imu_extrinsics_in_3d = true,
+              fix_z_in_3d = false,
               ceres_solver_options = {
                 use_nonmonotonic_steps = false,
                 max_num_iterations = 200,

--- a/cartographer/mapping/internal/optimization/optimization_problem_3d_test.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_3d_test.cc
@@ -50,6 +50,7 @@ class OptimizationProblem3DTest : public ::testing::Test {
           fixed_frame_pose_rotation_weight = 1e2,
           log_solver_summary = true,
           use_online_imu_extrinsics_in_3d = true,
+          fix_z_in_3d = false,
           ceres_solver_options = {
             use_nonmonotonic_steps = false,
             max_num_iterations = 200,

--- a/cartographer/mapping/internal/optimization/optimization_problem_options.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_options.cc
@@ -46,6 +46,7 @@ proto::OptimizationProblemOptions CreateOptimizationProblemOptions(
       parameter_dictionary->GetBool("log_solver_summary"));
   options.set_use_online_imu_extrinsics_in_3d(
       parameter_dictionary->GetBool("use_online_imu_extrinsics_in_3d"));
+  options.set_fix_z_in_3d(parameter_dictionary->GetBool("fix_z_in_3d"));
   *options.mutable_ceres_solver_options() =
       common::CreateCeresSolverOptionsProto(
           parameter_dictionary->GetDictionary("ceres_solver_options").get());

--- a/configuration_files/pose_graph.lua
+++ b/configuration_files/pose_graph.lua
@@ -73,6 +73,7 @@ POSE_GRAPH = {
     fixed_frame_pose_rotation_weight = 1e2,
     log_solver_summary = false,
     use_online_imu_extrinsics_in_3d = true,
+    fix_z_in_3d = false,
     ceres_solver_options = {
       use_nonmonotonic_steps = false,
       max_num_iterations = 50,


### PR DESCRIPTION
`OptimizationProblemOptions` contains the field `fix_z_in_3d` which is currently not read in `CreateOptimizationProblemOptions` and therefore defaults to `false`. This PR adds reading `fix_z_in_3d` from the configuration in `CreateOptimizationProblemOptions`.