### PR TITLE
Fix virtual destructors

### DIFF
--- a/cartographer/mapping/grid_interface.h
+++ b/cartographer/mapping/grid_interface.h
@@ -25,6 +25,8 @@ namespace mapping {
 
 class GridInterface {
   // todo(kdaun) move mutual functions of Grid2D/3D here
+ public:
+  virtual ~GridInterface() {}
 };
 
 }  // namespace mapping

--- a/cartographer/mapping/range_data_inserter_interface.h
+++ b/cartographer/mapping/range_data_inserter_interface.h
@@ -32,6 +32,8 @@ proto::RangeDataInserterOptions CreateRangeDataInserterOptions(
 
 class RangeDataInserterInterface {
  public:
+  virtual ~RangeDataInserterInterface() {}
+
   // Inserts 'range_data' into 'grid'.
   virtual void Insert(const sensor::RangeData& range_data,
                       GridInterface* grid) const = 0;


### PR DESCRIPTION
This is necessary because otherwise derived classes
are potentially deleted incompletely, using the destructor
of the interface.