### PR TITLE
Add git dependency to package.xml (for Abseil build).

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -36,6 +36,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>git</build_depend>
   <build_depend>g++-static</build_depend>
   <build_depend>google-mock</build_depend>
   <build_depend>python-sphinx</build_depend>


### PR DESCRIPTION
Otherwise, building on a ROS buildfarm (with bloom) fails with:
`error: could not find git for clone of abseil`
