### PR TITLE
Configurable miss_per_hit_limit in outlier removing processor.

### DIFF
--- a/cartographer/io/outlier_removing_points_processor.h
+++ b/cartographer/io/outlier_removing_points_processor.h
@@ -31,7 +31,8 @@ class OutlierRemovingPointsProcessor : public PointsProcessor {
   constexpr static const char* kConfigurationFileActionName =
       "voxel_filter_and_remove_moving_objects";
 
-  OutlierRemovingPointsProcessor(double voxel_size, PointsProcessor* next);
+  OutlierRemovingPointsProcessor(double voxel_size, double miss_per_hit_limit,
+                                 PointsProcessor* next);
 
   static std::unique_ptr<OutlierRemovingPointsProcessor> FromDictionary(
       common::LuaParameterDictionary* dictionary, PointsProcessor* next);
@@ -76,6 +77,7 @@ class OutlierRemovingPointsProcessor : public PointsProcessor {
   void ProcessInPhaseThree(std::unique_ptr<PointsBatch> batch);
 
   const double voxel_size_;
+  const double miss_per_hit_limit_;
   PointsProcessor* const next_;
   State state_;
   mapping::HybridGridBase<VoxelData> voxels_;


### PR DESCRIPTION
Was hardcoded to 3 before, but it makes sense to make this a parameter.