### PR TITLE
Clone that contains prometheus version

### DIFF
--- a/scripts/install_prometheus_cpp.sh
+++ b/scripts/install_prometheus_cpp.sh
@@ -19,7 +19,7 @@ set -o verbose
 
 COMMIT="4e0814ee3f93b796356a51a4795a332568940a72"
 
-git clone --depth 1 https://github.com/jupp0r/prometheus-cpp.git
+git clone https://github.com/jupp0r/prometheus-cpp.git
 cd prometheus-cpp
 git checkout ${COMMIT}
 git submodule update --init


### PR DESCRIPTION
This silently worked when it was written, but in order 
to check out a specific commit we cannot have a shallow
clone of the master.
