### PR TITLE
Fix regression in Protobuf find_package logic.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,8 @@ find_package(Eigen3 REQUIRED)
 find_package(LuaGoogle REQUIRED)
 # On Windows, Protobuf is incorrectly found by the bundled CMake module. Prefer native CMake config, if possible.
 set(protobuf_MODULE_COMPATIBLE TRUE CACHE INTERNAL "")
-find_package(Protobuf 3.0.0 CONFIG)
-if (NOT Protobuf_FOUND)
+find_package(Protobuf 3.0.0 CONFIG QUIET)
+if (NOT PROTOBUF_FOUND)
   find_package(Protobuf 3.0.0 REQUIRED)
 endif()
 
@@ -142,7 +142,7 @@ foreach(ABS_FIL ${ALL_PROTOS})
   add_custom_command(
     OUTPUT "${PROJECT_BINARY_DIR}/${DIR}/${FIL_WE}.pb.cc"
            "${PROJECT_BINARY_DIR}/${DIR}/${FIL_WE}.pb.h"
-    COMMAND  ${Protobuf_PROTOC_EXECUTABLE}
+    COMMAND  ${PROTOBUF_PROTOC_EXECUTABLE}
     ARGS --cpp_out  ${PROJECT_BINARY_DIR} -I
       ${PROJECT_SOURCE_DIR} ${ABS_FIL}
     DEPENDS ${ABS_FIL}
@@ -168,7 +168,7 @@ if(${BUILD_GRPC})
     add_custom_command(
       OUTPUT "${PROJECT_BINARY_DIR}/${DIR}/${FIL_WE}.pb.cc"
              "${PROJECT_BINARY_DIR}/${DIR}/${FIL_WE}.pb.h"
-      COMMAND  ${Protobuf_PROTOC_EXECUTABLE}
+      COMMAND  ${PROTOBUF_PROTOC_EXECUTABLE}
       ARGS --cpp_out  ${PROJECT_BINARY_DIR}
         -I ${PROJECT_SOURCE_DIR}
         ${ABS_FIL}


### PR DESCRIPTION
The introduced changes are not compatible with CMake < 3.6 if the
FindProtobuf.cmake bundled with CMake is used.
Since our minimum required version is 3.2, I consider this to be a bug.
Issues reported in #1481 are probably related.

- camel-case variables names weren't used before 3.6
  (upper-case is lowered in CMake > 3.6 for backwards compatibility)
- the `CONFIG` search added for the Windows build logs a warning even if the
`REQUIRED` search succeeds, should be quiet