### PR TITLE
Use collate_by_trajectory lua option in server

### DIFF
--- a/cartographer/cloud/map_builder_server_main.cc
+++ b/cartographer/cloud/map_builder_server_main.cc
@@ -50,10 +50,6 @@ void Run(const std::string& configuration_directory,
   proto::MapBuilderServerOptions map_builder_server_options =
       LoadMapBuilderServerOptions(configuration_directory,
                                   configuration_basename);
-  // TODO(gaschler): Remove this override when parameter is imported from lua
-  // config.
-  map_builder_server_options.mutable_map_builder_options()
-      ->set_collate_by_trajectory(true);
   auto map_builder = absl::make_unique<mapping::MapBuilder>(
       map_builder_server_options.map_builder_options());
   std::unique_ptr<MapBuilderServerInterface> map_builder_server =

--- a/configuration_files/map_builder_server.lua
+++ b/configuration_files/map_builder_server.lua
@@ -24,3 +24,5 @@ MAP_BUILDER_SERVER = {
   enable_ssl_encryption = false,
   enable_google_auth = false,
 }
+
+MAP_BUILDER.collate_by_trajectory = true


### PR DESCRIPTION
This removes the hardcoded value of `collate_by_trajectory` in the cloud
map builder server and permits to configure `collate_by_trajectory`
option with lua.