### PR TITLE
Update clang-format to new Google style.

### DIFF
--- a/cartographer/cloud/internal/client/pose_graph_stub.cc
+++ b/cartographer/cloud/internal/client/pose_graph_stub.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/cloud/internal/client/pose_graph_stub.h"
+
 #include "async_grpc/client.h"
 #include "cartographer/cloud/internal/handlers/delete_trajectory_handler.h"
 #include "cartographer/cloud/internal/handlers/get_all_submap_poses.h"

--- a/cartographer/cloud/internal/handlers/add_fixed_frame_pose_data_handler_test.cc
+++ b/cartographer/cloud/internal/handlers/add_fixed_frame_pose_data_handler_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/cloud/internal/handlers/add_fixed_frame_pose_data_handler.h"
+
 #include "cartographer/cloud/internal/testing/handler_test.h"
 #include "cartographer/cloud/internal/testing/test_helpers.h"
 #include "google/protobuf/text_format.h"

--- a/cartographer/cloud/internal/handlers/add_imu_data_handler_test.cc
+++ b/cartographer/cloud/internal/handlers/add_imu_data_handler_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/cloud/internal/handlers/add_imu_data_handler.h"
+
 #include "cartographer/cloud/internal/testing/handler_test.h"
 #include "cartographer/cloud/internal/testing/test_helpers.h"
 #include "google/protobuf/text_format.h"

--- a/cartographer/cloud/internal/handlers/add_landmark_data_handler_test.cc
+++ b/cartographer/cloud/internal/handlers/add_landmark_data_handler_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/cloud/internal/handlers/add_landmark_data_handler.h"
+
 #include "cartographer/cloud/internal/testing/handler_test.h"
 #include "cartographer/cloud/internal/testing/test_helpers.h"
 #include "google/protobuf/text_format.h"

--- a/cartographer/cloud/internal/handlers/add_odometry_data_handler_test.cc
+++ b/cartographer/cloud/internal/handlers/add_odometry_data_handler_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/cloud/internal/handlers/add_odometry_data_handler.h"
+
 #include "cartographer/cloud/internal/testing/handler_test.h"
 #include "cartographer/cloud/internal/testing/test_helpers.h"
 #include "google/protobuf/text_format.h"

--- a/cartographer/cloud/internal/handlers/add_rangefinder_data_handler_test.cc
+++ b/cartographer/cloud/internal/handlers/add_rangefinder_data_handler_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/cloud/internal/handlers/add_rangefinder_data_handler.h"
+
 #include "cartographer/cloud/internal/testing/handler_test.h"
 #include "cartographer/cloud/internal/testing/test_helpers.h"
 #include "google/protobuf/text_format.h"

--- a/cartographer/cloud/internal/handlers/add_trajectory_handler_test.cc
+++ b/cartographer/cloud/internal/handlers/add_trajectory_handler_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/cloud/internal/handlers/add_trajectory_handler.h"
+
 #include "cartographer/cloud/internal/sensor/serialization.h"
 #include "cartographer/cloud/internal/testing/handler_test.h"
 #include "cartographer/cloud/internal/testing/test_helpers.h"

--- a/cartographer/cloud/internal/handlers/get_landmark_poses_handler_test.cc
+++ b/cartographer/cloud/internal/handlers/get_landmark_poses_handler_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/cloud/internal/handlers/get_landmark_poses_handler.h"
+
 #include "cartographer/cloud/internal/testing/handler_test.h"
 #include "cartographer/cloud/internal/testing/test_helpers.h"
 #include "google/protobuf/text_format.h"

--- a/cartographer/cloud/internal/handlers/set_landmark_pose_handler_test.cc
+++ b/cartographer/cloud/internal/handlers/set_landmark_pose_handler_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/cloud/internal/handlers/set_landmark_pose_handler.h"
+
 #include "cartographer/cloud/internal/testing/handler_test.h"
 #include "cartographer/cloud/internal/testing/test_helpers.h"
 #include "cartographer/transform/rigid_transform_test_helpers.h"

--- a/cartographer/cloud/internal/map_builder_context_impl.cc
+++ b/cartographer/cloud/internal/map_builder_context_impl.cc
@@ -15,8 +15,6 @@
  */
 
 #include "cartographer/cloud/internal/map_builder_server.h"
-
-#include "cartographer/cloud/internal/map_builder_server.h"
 #include "cartographer/mapping/internal/2d/local_slam_result_2d.h"
 #include "cartographer/mapping/internal/3d/local_slam_result_3d.h"
 

--- a/cartographer/common/lockless_queue_test.cc
+++ b/cartographer/common/lockless_queue_test.cc
@@ -1,4 +1,5 @@
 #include "cartographer/common/lockless_queue.h"
+
 #include "gtest/gtest.h"
 
 namespace cartographer {

--- a/cartographer/common/port.h
+++ b/cartographer/common/port.h
@@ -17,13 +17,12 @@
 #ifndef CARTOGRAPHER_COMMON_PORT_H_
 #define CARTOGRAPHER_COMMON_PORT_H_
 
-#include <cinttypes>
-#include <cmath>
-#include <string>
-
 #include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
+#include <cinttypes>
+#include <cmath>
+#include <string>
 
 namespace cartographer {
 

--- a/cartographer/common/time.cc
+++ b/cartographer/common/time.cc
@@ -17,6 +17,7 @@
 #include "cartographer/common/time.h"
 
 #include <time.h>
+
 #include <cerrno>
 #include <cstring>
 #include <string>

--- a/cartographer/io/fake_file_writer_test.cc
+++ b/cartographer/io/fake_file_writer_test.cc
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+#include "cartographer/io/fake_file_writer.h"
+
 #include <vector>
 
-#include "cartographer/io/fake_file_writer.h"
 #include "glog/logging.h"
 #include "gtest/gtest.h"
 

--- a/cartographer/io/internal/in_memory_proto_stream_test.cc
+++ b/cartographer/io/internal/in_memory_proto_stream_test.cc
@@ -15,9 +15,9 @@
  */
 
 #include "cartographer/io/internal/in_memory_proto_stream.h"
+
 #include "cartographer/mapping/proto/pose_graph.pb.h"
 #include "cartographer/mapping/proto/serialization.pb.h"
-
 #include "gtest/gtest.h"
 
 namespace cartographer {

--- a/cartographer/io/internal/mapping_state_serialization.cc
+++ b/cartographer/io/internal/mapping_state_serialization.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/io/internal/mapping_state_serialization.h"
+
 #include "cartographer/mapping/proto/serialization.pb.h"
 #include "cartographer/transform/transform.h"
 

--- a/cartographer/io/probability_grid_points_processor_test.cc
+++ b/cartographer/io/probability_grid_points_processor_test.cc
@@ -17,6 +17,7 @@
 #include "cartographer/io/probability_grid_points_processor.h"
 
 #include <string>
+
 #include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer/common/lua_parameter_dictionary_test_helpers.h"
 #include "cartographer/common/port.h"

--- a/cartographer/io/proto_stream.cc
+++ b/cartographer/io/proto_stream.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/io/proto_stream.h"
+
 #include "glog/logging.h"
 
 namespace cartographer {

--- a/cartographer/io/proto_stream_deserializer_test.cc
+++ b/cartographer/io/proto_stream_deserializer_test.cc
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+#include "cartographer/io/proto_stream_deserializer.h"
+
 #include <memory>
 
 #include "cartographer/io/internal/in_memory_proto_stream.h"
-#include "cartographer/io/proto_stream_deserializer.h"
 #include "cartographer/io/testing/test_helpers.h"
 #include "glog/logging.h"
 #include "gmock/gmock.h"

--- a/cartographer/io/testing/test_helpers.cc
+++ b/cartographer/io/testing/test_helpers.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/io/testing/test_helpers.h"
+
 #include "cartographer/mapping/proto/serialization.pb.h"
 
 namespace cartographer {

--- a/cartographer/mapping/2d/range_data_inserter_2d_test.cc
+++ b/cartographer/mapping/2d/range_data_inserter_2d_test.cc
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-#include "cartographer/mapping/2d/probability_grid_range_data_inserter_2d.h"
-
 #include <memory>
 
 #include "absl/memory/memory.h"
 #include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer/common/lua_parameter_dictionary_test_helpers.h"
 #include "cartographer/mapping/2d/probability_grid.h"
+#include "cartographer/mapping/2d/probability_grid_range_data_inserter_2d.h"
 #include "cartographer/mapping/probability_values.h"
 #include "gmock/gmock.h"
 

--- a/cartographer/mapping/2d/submap_2d_test.cc
+++ b/cartographer/mapping/2d/submap_2d_test.cc
@@ -15,7 +15,6 @@
  */
 
 #include "cartographer/mapping/2d/submap_2d.h"
-#include "cartographer/mapping/2d/probability_grid.h"
 
 #include <map>
 #include <memory>
@@ -25,6 +24,7 @@
 #include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer/common/lua_parameter_dictionary_test_helpers.h"
 #include "cartographer/common/port.h"
+#include "cartographer/mapping/2d/probability_grid.h"
 #include "cartographer/transform/transform.h"
 #include "gmock/gmock.h"
 

--- a/cartographer/mapping/detect_floors.h
+++ b/cartographer/mapping/detect_floors.h
@@ -17,9 +17,8 @@
 #ifndef CARTOGRAPHER_MAPPING_DETECT_FLOORS_H_
 #define CARTOGRAPHER_MAPPING_DETECT_FLOORS_H_
 
-#include "cartographer/mapping/proto/trajectory.pb.h"
-
 #include "cartographer/common/time.h"
+#include "cartographer/mapping/proto/trajectory.pb.h"
 
 namespace cartographer {
 namespace mapping {

--- a/cartographer/mapping/internal/2d/local_slam_result_2d.cc
+++ b/cartographer/mapping/internal/2d/local_slam_result_2d.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/mapping/internal/2d/local_slam_result_2d.h"
+
 #include "cartographer/mapping/internal/2d/pose_graph_2d.h"
 
 namespace cartographer {

--- a/cartographer/mapping/internal/2d/normal_estimation_2d.h
+++ b/cartographer/mapping/internal/2d/normal_estimation_2d.h
@@ -18,6 +18,7 @@
 #define CARTOGRAPHER_MAPPING_INTERNAL_NORMAL_ESTIMATION_2D_H_
 
 #include <vector>
+
 #include "cartographer/mapping/proto/2d/normal_estimation_options_2d.pb.h"
 #include "cartographer/sensor/point_cloud.h"
 #include "cartographer/sensor/range_data.h"

--- a/cartographer/mapping/internal/2d/scan_matching/correlative_scan_matcher_test.cc
+++ b/cartographer/mapping/internal/2d/scan_matching/correlative_scan_matcher_test.cc
@@ -15,7 +15,6 @@
  */
 
 #include "cartographer/mapping/internal/2d/scan_matching/correlative_scan_matcher_2d.h"
-
 #include "cartographer/sensor/point_cloud.h"
 #include "gtest/gtest.h"
 

--- a/cartographer/mapping/internal/2d/scan_matching/occupied_space_cost_function_2d.cc
+++ b/cartographer/mapping/internal/2d/scan_matching/occupied_space_cost_function_2d.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/mapping/internal/2d/scan_matching/occupied_space_cost_function_2d.h"
+
 #include "cartographer/mapping/probability_values.h"
 #include "ceres/cubic_interpolation.h"
 

--- a/cartographer/mapping/internal/2d/scan_matching/occupied_space_cost_function_2d_test.cc
+++ b/cartographer/mapping/internal/2d/scan_matching/occupied_space_cost_function_2d_test.cc
@@ -18,7 +18,6 @@
 
 #include "cartographer/mapping/2d/probability_grid.h"
 #include "cartographer/mapping/probability_values.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/cartographer/mapping/internal/2d/scan_matching/tsdf_match_cost_function_2d_test.cc
+++ b/cartographer/mapping/internal/2d/scan_matching/tsdf_match_cost_function_2d_test.cc
@@ -20,7 +20,6 @@
 #include "cartographer/common/lua_parameter_dictionary_test_helpers.h"
 #include "cartographer/mapping/2d/tsdf_2d.h"
 #include "cartographer/mapping/2d/tsdf_range_data_inserter_2d.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/cartographer/mapping/internal/3d/local_slam_result_3d.cc
+++ b/cartographer/mapping/internal/3d/local_slam_result_3d.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/mapping/internal/3d/local_slam_result_3d.h"
+
 #include "cartographer/mapping/internal/3d/pose_graph_3d.h"
 
 namespace cartographer {

--- a/cartographer/mapping/internal/constraints/constraint_builder_2d_test.cc
+++ b/cartographer/mapping/internal/constraints/constraint_builder_2d_test.cc
@@ -15,11 +15,11 @@
  */
 
 #include "cartographer/mapping/internal/constraints/constraint_builder_2d.h"
-#include "cartographer/mapping/2d/probability_grid.h"
 
 #include <functional>
 
 #include "cartographer/common/internal/testing/thread_pool_for_testing.h"
+#include "cartographer/mapping/2d/probability_grid.h"
 #include "cartographer/mapping/2d/submap_2d.h"
 #include "cartographer/mapping/internal/constraints/constraint_builder.h"
 #include "cartographer/mapping/internal/testing/test_helpers.h"

--- a/cartographer/mapping/map_builder.h
+++ b/cartographer/mapping/map_builder.h
@@ -17,11 +17,10 @@
 #ifndef CARTOGRAPHER_MAPPING_MAP_BUILDER_H_
 #define CARTOGRAPHER_MAPPING_MAP_BUILDER_H_
 
-#include "cartographer/mapping/map_builder_interface.h"
-
 #include <memory>
 
 #include "cartographer/common/thread_pool.h"
+#include "cartographer/mapping/map_builder_interface.h"
 #include "cartographer/mapping/pose_graph.h"
 #include "cartographer/mapping/proto/map_builder_options.pb.h"
 #include "cartographer/sensor/collator_interface.h"

--- a/cartographer/mapping/range_data_inserter_interface.cc
+++ b/cartographer/mapping/range_data_inserter_interface.cc
@@ -15,6 +15,7 @@
  */
 
 #include "cartographer/mapping/range_data_inserter_interface.h"
+
 #include "cartographer/mapping/2d/probability_grid_range_data_inserter_2d.h"
 #include "cartographer/mapping/2d/tsdf_range_data_inserter_2d.h"
 

--- a/cartographer/sensor/point_cloud_test.cc
+++ b/cartographer/sensor/point_cloud_test.cc
@@ -15,10 +15,10 @@
  */
 
 #include "cartographer/sensor/point_cloud.h"
-#include "cartographer/transform/transform.h"
 
 #include <cmath>
 
+#include "cartographer/transform/transform.h"
 #include "gtest/gtest.h"
 
 namespace cartographer {


### PR DESCRIPTION
Apparently the format bot uses a bleeding edge clang-format that uses
the new Google style and reformats a bunch of files in every PR. This is
an empty commit to trigger this in a separate commit.

See https://github.com/llvm-mirror/clang/commit/62e3198c4f5490a1c60ba51d81fe2e1f0dc99135