### PR TITLE
Instead of crashing when timestamps out of order, log and continue.

### DIFF
--- a/cartographer/sensor/map_by_time.h
+++ b/cartographer/sensor/map_by_time.h
@@ -40,7 +40,13 @@ class MapByTime {
     CHECK_GE(trajectory_id, 0);
     auto& trajectory = data_[trajectory_id];
     if (!trajectory.empty()) {
-      CHECK_GT(data.time, std::prev(trajectory.end())->first);
+      auto prev_time = std::prev(trajectory.end())->first;
+      if (data.time <= prev_time) {
+        LOG(WARNING) << "Ignoring data with non-increasing timestamp. "
+                     << "last timestamp = " << prev_time
+                     << "; current timestamp = " << data.time;
+        return;
+      }
     }
     trajectory.emplace(data.time, data);
   }


### PR DESCRIPTION
When using some ROS2 QoS settings, data can arrive out of order or multiple times. Instead of treating this as a fatal error, log it as a warning and ignore the delayed data.