### PR TITLE
Add libabsl-dev to the package.xml dependencies.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -43,6 +43,7 @@
 
   <depend>libboost-iostreams-dev</depend>
   <depend>eigen</depend>
+  <depend>libabsl-dev</depend>
   <depend>libcairo2-dev</depend>
   <depend>libceres-dev</depend>
   <depend>libgflags-dev</depend>


### PR DESCRIPTION
This will allow the ROS buildfarm to properly install dependencies
when attempting to build this package.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>