### PR TITLE
Use Manifold instead of LocalParameterization.

### DIFF
--- a/cartographer/mapping/internal/3d/rotation_parameterization_test.cc
+++ b/cartographer/mapping/internal/3d/rotation_parameterization_test.cc
@@ -1,0 +1,48 @@
+#include "cartographer/mapping/internal/3d/rotation_parameterization.h"
+
+#include "ceres/manifold_test_utils.h"
+#include "gtest/gtest.h"
+
+namespace cartographer::mapping {
+
+template <typename T>
+class RotationParameterizationTests : public ::testing::Test {};
+
+using TestTypes =
+    ::testing::Types<YawOnlyQuaternionManifold, ConstantYawQuaternionManifold>;
+TYPED_TEST_SUITE(RotationParameterizationTests, TestTypes);
+
+TYPED_TEST(RotationParameterizationTests, ManifoldInvariantsHold) {
+  const TypeParam manifold;
+
+  constexpr static int kNumTrials = 10;
+  constexpr static double kTolerance = 1.e-5;
+  const std::vector<double> delta_magnitutes = {0.0, 1.e-9, 1.e-3, 0.5};
+  for (int trial = 0; trial < kNumTrials; ++trial) {
+    const Eigen::VectorXd x =
+        Eigen::VectorXd::Random(manifold.AmbientSize()).normalized();
+
+    for (const double delta_magnitude : delta_magnitutes) {
+      const Eigen::VectorXd delta =
+          Eigen::VectorXd::Random(manifold.TangentSize()) * delta_magnitude;
+      EXPECT_THAT(manifold, ceres::XPlusZeroIsXAt(x, kTolerance));
+      EXPECT_THAT(manifold, ceres::XMinusXIsZeroAt(x, kTolerance));
+      EXPECT_THAT(manifold, ceres::MinusPlusIsIdentityAt(x, delta, kTolerance));
+      const Eigen::VectorXd zero_tangent =
+          Eigen::VectorXd::Zero(manifold.TangentSize());
+      EXPECT_THAT(manifold,
+                  ceres::MinusPlusIsIdentityAt(x, zero_tangent, kTolerance));
+
+      Eigen::VectorXd y(manifold.AmbientSize());
+      ASSERT_TRUE(manifold.Plus(x.data(), delta.data(), y.data()));
+      EXPECT_THAT(manifold, ceres::PlusMinusIsIdentityAt(x, x, kTolerance));
+      EXPECT_THAT(manifold, ceres::PlusMinusIsIdentityAt(x, y, kTolerance));
+      EXPECT_THAT(manifold, ceres::HasCorrectPlusJacobianAt(x, kTolerance));
+      EXPECT_THAT(manifold, ceres::HasCorrectMinusJacobianAt(x, kTolerance));
+      EXPECT_THAT(manifold,
+                  ceres::MinusPlusJacobianIsIdentityAt(x, kTolerance));
+    }
+  }
+}
+
+}  // namespace cartographer::mapping

--- a/cartographer/mapping/internal/3d/scan_matching/ceres_scan_matcher_3d.cc
+++ b/cartographer/mapping/internal/3d/scan_matching/ceres_scan_matcher_3d.cc
@@ -31,6 +31,7 @@
 #include "cartographer/transform/rigid_transform.h"
 #include "cartographer/transform/transform.h"
 #include "ceres/ceres.h"
+#include "ceres/manifold.h"
 #include "glog/logging.h"
 
 namespace cartographer {
@@ -98,11 +99,10 @@ void CeresScanMatcher3D::Match(
   optimization::CeresPose ceres_pose(
       initial_pose_estimate, nullptr /* translation_parameterization */,
       options_.only_optimize_yaw()
-          ? std::unique_ptr<ceres::LocalParameterization>(
-                absl::make_unique<ceres::AutoDiffLocalParameterization<
-                    YawOnlyQuaternionPlus, 4, 1>>())
-          : std::unique_ptr<ceres::LocalParameterization>(
-                absl::make_unique<ceres::QuaternionParameterization>()),
+          ? std::unique_ptr<ceres::Manifold>(
+                absl::make_unique<YawOnlyQuaternionManifold>())
+          : std::unique_ptr<ceres::Manifold>(
+                absl::make_unique<ceres::QuaternionManifold>()),
       &problem);
 
   CHECK_EQ(options_.occupied_space_weight_size(),

--- a/cartographer/mapping/internal/optimization/ceres_pose.cc
+++ b/cartographer/mapping/internal/optimization/ceres_pose.cc
@@ -29,14 +29,14 @@ CeresPose::Data FromPose(const transform::Rigid3d& pose) {
 
 CeresPose::CeresPose(
     const transform::Rigid3d& pose,
-    std::unique_ptr<ceres::LocalParameterization> translation_parametrization,
-    std::unique_ptr<ceres::LocalParameterization> rotation_parametrization,
+    std::unique_ptr<ceres::Manifold> translation_manifold,
+    std::unique_ptr<ceres::Manifold> rotation_manifold,
     ceres::Problem* problem)
     : data_(std::make_shared<CeresPose::Data>(FromPose(pose))) {
   problem->AddParameterBlock(data_->translation.data(), 3,
-                             translation_parametrization.release());
+                             translation_manifold.release());
   problem->AddParameterBlock(data_->rotation.data(), 4,
-                             rotation_parametrization.release());
+                             rotation_manifold.release());
 }
 
 const transform::Rigid3d CeresPose::ToRigid() const {

--- a/cartographer/mapping/internal/optimization/ceres_pose.h
+++ b/cartographer/mapping/internal/optimization/ceres_pose.h
@@ -23,6 +23,7 @@
 #include "Eigen/Core"
 #include "cartographer/transform/rigid_transform.h"
 #include "ceres/ceres.h"
+#include "ceres/manifold.h"
 
 namespace cartographer {
 namespace mapping {
@@ -31,9 +32,9 @@ namespace optimization {
 class CeresPose {
  public:
   CeresPose(
-      const transform::Rigid3d& rigid,
-      std::unique_ptr<ceres::LocalParameterization> translation_parametrization,
-      std::unique_ptr<ceres::LocalParameterization> rotation_parametrization,
+      const transform::Rigid3d& pose,
+      std::unique_ptr<ceres::Manifold> translation_manifold,
+      std::unique_ptr<ceres::Manifold> rotation_manifold,
       ceres::Problem* problem);
 
   const transform::Rigid3d ToRigid() const;

--- a/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
@@ -144,8 +144,8 @@ void AddLandmarkCostFunctions(
                                          *prev_node_pose, *next_node_pose);
         C_landmarks->emplace(
             landmark_id,
-            CeresPose(starting_point, nullptr /* translation_parametrization */,
-                      absl::make_unique<ceres::QuaternionParameterization>(),
+            CeresPose(starting_point, nullptr /* translation_manifold */,
+                      absl::make_unique<ceres::QuaternionManifold>(),
                       problem));
         // Set landmark constant if it is frozen.
         if (landmark_node.second.frozen) {


### PR DESCRIPTION
We need to migrate the Cartographer code to use Manifolds instead of LocalParameterization to allow Ceres code to remove the LocalParameterization code.

The PR converts internal use of LocalParameterization to Manifold.  Removes headers that reference local_parameterization or implementation classes.

Note that internal variable and method names with type Manifold were renamed Manifold/manifold, but the outer abstraction class, proto name and so on were left as Parameterization/parameterization.

Signed-off-by: Jie Zheng <zhengj@google.com>